### PR TITLE
Remove extraneous test run from build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,8 +25,7 @@ test:
     - cd frontend; npm install -g protractor
     - cp ./sonar-scanner.properties sonar-scanner-3.0.1.733/conf/sonar-scanner.properties
   override:
-    - mvn clean package -Djacoco.skip.instrument=false
-    - mvn integration-test
+    - mvn clean verify -Djacoco.skip.instrument=false
     - mvn jacoco:report
     - ./sonarqube.sh
     - cd frontend; yarn run lint


### PR DESCRIPTION
- Sped up the build by ~1:30.
- Code coverage remains the same.
- Removed `mvn integration-test`
- Changed the main goal of the build to `verify` instead of `package`.  `verify` already comprised of the goal `integration-test`.