### PR TITLE
Fixed ValidationError Hamcrest matcher

### DIFF
--- a/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/model/error/ValidationErrorMatcher.java
+++ b/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/model/error/ValidationErrorMatcher.java
@@ -2,12 +2,10 @@ package gov.cms.qpp.conversion.model.error;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsCollectionContaining;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.stream.Collectors;
 
 /**
  * A Hamcrest matcher for {@link ValidationError}.
@@ -16,7 +14,7 @@ import java.util.stream.Collectors;
  * <ul>
  *     <li>{@link #validationErrorTextMatches}</li>
  *     <li>{@link #validationErrorTextAndPathMatches}</li>
- *     <li>{@link #containsValidationErrorInAnyOrderIgnoringPath}</li>
+ *     <li>{@link #hasValidationErrorsIgnoringPath}</li>
  * </ul>
  */
 public class ValidationErrorMatcher extends TypeSafeMatcher<ValidationError> {
@@ -56,11 +54,11 @@ public class ValidationErrorMatcher extends TypeSafeMatcher<ValidationError> {
 	 * @param errorTexts The {@code errorText}s that the matcher should search for.
 	 * @return A matcher that matches all the {@code errorTexts} provided in many {@code ValidationError}s.
 	 */
-	public static Matcher<Iterable<? extends ValidationError>> containsValidationErrorInAnyOrderIgnoringPath(String... errorTexts) {
-		Collection<Matcher<? super ValidationError>> validationErrorMatchers = Arrays.stream(errorTexts)
-			.map(ValidationErrorMatcher::validationErrorTextMatches).collect(Collectors.toList());
+	public static Matcher<Iterable<ValidationError>> hasValidationErrorsIgnoringPath(String... errorTexts) {
+		Matcher<ValidationError>[] validationErrorMatchers = Arrays.stream(errorTexts)
+			.map(ValidationErrorMatcher::validationErrorTextMatches).toArray(ValidationErrorMatcher[]::new);
 
-		return Matchers.containsInAnyOrder(validationErrorMatchers);
+		return IsCollectionContaining.hasItems(validationErrorMatchers);
 	}
 
 	private String errorText = null;

--- a/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/validate/CheckerTest.java
+++ b/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/validate/CheckerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.containsValidationErrorInAnyOrderIgnoringPath;
+import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.hasValidationErrorsIgnoringPath;
 import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.validationErrorTextMatches;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -317,7 +317,7 @@ public class CheckerTest {
 
 		assertThat("There are errors", validationErrors, hasSize(2));
 		assertThat("int validation error", validationErrors,
-				containsValidationErrorInAnyOrderIgnoringPath("int failure" ,"maximum failure"));
+				hasValidationErrorsIgnoringPath("int failure" ,"maximum failure"));
 	}
 
 	@Test

--- a/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidatorTest.java
+++ b/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidatorTest.java
@@ -16,7 +16,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.containsValidationErrorInAnyOrderIgnoringPath;
+import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.hasValidationErrorsIgnoringPath;
 import static gov.cms.qpp.conversion.util.JsonHelper.readJson;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -88,7 +88,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be one error", errors, iterableWithSize(1));
 		assertThat("error should be about missing Clinical Document node", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(EXPECTED_TEXT));
+			hasValidationErrorsIgnoringPath(EXPECTED_TEXT));
 	}
 
 	@Test
@@ -101,7 +101,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be one error", errors, iterableWithSize(1));
 		assertThat("error should be about too many Clinical Document nodes", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(EXPECTED_ONE_ALLOWED));
+			hasValidationErrorsIgnoringPath(EXPECTED_ONE_ALLOWED));
 	}
 
 	@Test
@@ -114,7 +114,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be one error", errors, iterableWithSize(1));
 		assertThat("error should be about missing section node", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(EXPECTED_NO_SECTION));
+			hasValidationErrorsIgnoringPath(EXPECTED_NO_SECTION));
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be one error", errors, hasSize(1));
 		assertThat("error should be about missing section node", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(EXPECTED_NO_SECTION));
+			hasValidationErrorsIgnoringPath(EXPECTED_NO_SECTION));
 	}
 
 	@Test
@@ -150,7 +150,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be two errors", errors, hasSize(2));
 		assertThat("error should be about missing missing program name", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(
+			hasValidationErrorsIgnoringPath(
 				ClinicalDocumentValidator.CONTAINS_PROGRAM_NAME,
 				ClinicalDocumentValidator.INCORRECT_PROGRAM_NAME));
 	}
@@ -171,7 +171,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be one error", errors, hasSize(1));
 		assertThat("error should be about missing section node", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(ClinicalDocumentValidator.CONTAINS_TAX_ID_NUMBER));
+			hasValidationErrorsIgnoringPath(ClinicalDocumentValidator.CONTAINS_TAX_ID_NUMBER));
 	}
 
 	@Test
@@ -205,7 +205,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("there should be one error", errors, hasSize(2));
 		assertThat("error should be about missing reporting node", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(
+			hasValidationErrorsIgnoringPath(
 					ClinicalDocumentValidator.REPORTING_PARAMETER_REQUIRED,
 					ClinicalDocumentValidator.CONTAINS_PERFORMANCE_YEAR));
 	}
@@ -226,7 +226,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("Should contain one error", errors, hasSize(1));
 		assertThat("Should contain one error", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(ClinicalDocumentValidator.CONTAINS_DUPLICATE_ACI_SECTIONS));
+			hasValidationErrorsIgnoringPath(ClinicalDocumentValidator.CONTAINS_DUPLICATE_ACI_SECTIONS));
 	}
 
 	@Test
@@ -245,7 +245,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("Should contain one error", errors, hasSize(1));
 		assertThat("Should contain one error", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(ClinicalDocumentValidator.CONTAINS_DUPLICATE_IA_SECTIONS));
+			hasValidationErrorsIgnoringPath(ClinicalDocumentValidator.CONTAINS_DUPLICATE_IA_SECTIONS));
 	}
 
 	@Test
@@ -264,7 +264,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("Should contain one error", errors, hasSize(1));
 		assertThat("Should contain one error", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(ClinicalDocumentValidator.CONTAINS_DUPLICATE_ECQM_SECTIONS));
+			hasValidationErrorsIgnoringPath(ClinicalDocumentValidator.CONTAINS_DUPLICATE_ECQM_SECTIONS));
 	}
 
 	@Test
@@ -299,7 +299,7 @@ public class ClinicalDocumentValidatorTest {
 		assertThat("Must have 4 errors", errors, hasSize(4));
 
 		assertThat("Must contain the error", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(
+			hasValidationErrorsIgnoringPath(
 				ClinicalDocumentValidator.CONTAINS_PROGRAM_NAME,
 				ClinicalDocumentValidator.INCORRECT_PROGRAM_NAME,
 				ClinicalDocumentValidator.CONTAINS_TAX_ID_NUMBER,
@@ -318,7 +318,7 @@ public class ClinicalDocumentValidatorTest {
 
 		assertThat("Should have 1 validation errors", errors, hasSize(1));
 		assertThat("Must contain the error", errors,
-			containsValidationErrorInAnyOrderIgnoringPath(ClinicalDocumentValidator.INCORRECT_PROGRAM_NAME));
+			hasValidationErrorsIgnoringPath(ClinicalDocumentValidator.INCORRECT_PROGRAM_NAME));
 	}
 
 

--- a/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/java-conversion-tool/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_POPULATION;
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
-import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.containsValidationErrorInAnyOrderIgnoringPath;
+import static gov.cms.qpp.conversion.model.error.ValidationErrorMatcher.hasValidationErrorsIgnoringPath;
 import static gov.cms.qpp.conversion.validate.QualityMeasureIdValidator.MEASURE_ID;
 import static gov.cms.qpp.conversion.validate.QualityMeasureIdValidator.REQUIRED_CHILD_MEASURE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -86,7 +86,7 @@ public class QualityMeasureIdValidatorTest {
 
 		assertThat("There must be only one validation error.", validationErrors, hasSize(1));
 		assertThat("Incorrect validation error.", validationErrors,
-			containsValidationErrorInAnyOrderIgnoringPath(QualityMeasureIdValidator.MEASURE_GUID_MISSING));
+			hasValidationErrorsIgnoringPath(QualityMeasureIdValidator.MEASURE_GUID_MISSING));
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class QualityMeasureIdValidatorTest {
 
 		assertThat("There must be only one validation error.", validationErrors, hasSize(1));
 		assertThat("Incorrect validation error.", validationErrors,
-			containsValidationErrorInAnyOrderIgnoringPath(QualityMeasureIdValidator.NO_CHILD_MEASURE));
+			hasValidationErrorsIgnoringPath(QualityMeasureIdValidator.NO_CHILD_MEASURE));
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class QualityMeasureIdValidatorTest {
 
 		assertThat("There must be only two validation errors.", validationErrors, hasSize(2));
 		assertThat("Incorrect validation error.", validationErrors,
-			containsValidationErrorInAnyOrderIgnoringPath(QualityMeasureIdValidator.MEASURE_GUID_MISSING,
+			hasValidationErrorsIgnoringPath(QualityMeasureIdValidator.MEASURE_GUID_MISSING,
 				QualityMeasureIdValidator.NO_CHILD_MEASURE));
 	}
 
@@ -139,7 +139,7 @@ public class QualityMeasureIdValidatorTest {
 		List<ValidationError> validationErrors = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
 		assertThat("There must be a validation error.", validationErrors, hasSize(1));
 		assertThat("Incorrect validation error.", validationErrors,
-			containsValidationErrorInAnyOrderIgnoringPath(
+			hasValidationErrorsIgnoringPath(
 				String.format(QualityMeasureIdValidator.REQUIRED_CHILD_MEASURE,
 				QualityMeasureIdValidator.DENEX)));
 	}
@@ -191,7 +191,7 @@ public class QualityMeasureIdValidatorTest {
 			.build();
 
 		List<ValidationError> validationErrors = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
-		assertThat("Incorrect validation error.", validationErrors, containsValidationErrorInAnyOrderIgnoringPath(message));
+		assertThat("Incorrect validation error.", validationErrors, hasValidationErrorsIgnoringPath(message));
 	}
 
 	@Test
@@ -238,7 +238,7 @@ public class QualityMeasureIdValidatorTest {
 			.build();
 
 		List<ValidationError> validationErrors = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
-		assertThat("Incorrect validation error.", validationErrors, containsValidationErrorInAnyOrderIgnoringPath(message));
+		assertThat("Incorrect validation error.", validationErrors, hasValidationErrorsIgnoringPath(message));
 
 	}
 
@@ -262,7 +262,7 @@ public class QualityMeasureIdValidatorTest {
 			.build();
 
 		List<ValidationError> validationErrors = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
-		assertThat("Incorrect validation error.", validationErrors, containsValidationErrorInAnyOrderIgnoringPath(message));
+		assertThat("Incorrect validation error.", validationErrors, hasValidationErrorsIgnoringPath(message));
 
 
 	}


### PR DESCRIPTION
The `ValidationErrorMatcher#containsValidationErrorInAnyOrderIgnoringPath(String... errorTexts)` was requiring every element in a collection of `ValidationError`s to match every element in the argument `errorTexts`.

That is not the intention of that method.

The correct intention is to require every element in the argument `errorTexts` to match an element in the collection of `ValidationError`s, but not ever element in the collection of `ValidationError`s needs to be matched.
I also renamed the method to `hasValidationErrorsIgnoringPath`.

Here is the usecase of the original, incorrect, matcher.
```java
List<ValidationError> errors = {"Moof", "DogCow", "PageSetup"};  //short hand
assertThat("blah", errors, containsValidationErrorInAnyOrderIgnoringPath("DogCow"));  //fails because "Moof" and "PageSetup" from the collection are not matched
assertThat("blah", errors, containsValidationErrorInAnyOrderIgnoringPath("DogCow", "Moof", "PageSetup"));  //passes because all elements of the collection matches
```

Here is the usecase of the new, correct, matcher.
```java
List<ValidationError> errors = {"Moof", "DogCow", "PageSetup"};  //short hand
assertThat("blah", errors, hasValidationErrorsIgnoringPath("DogCow"));  //passes because "DogCow" matches at least one element in the collection
assertThat("blah", errors, hasValidationErrorsIgnoringPath("DogCow", "PageSetup"));  //passes because all elements of the passed in argument "errorTexts" each match one element in the collection
assertThat("blah", errors, hasValidationErrorsIgnoringPath("DogCow", "something"));  //fails because "something" was not a ValidationError in the List.
```