### PR TITLE
QPPCT-180: deployment hiccups

### DIFF
--- a/ansible/conversion_playbook.yml
+++ b/ansible/conversion_playbook.yml
@@ -46,6 +46,17 @@
       src: ../qpp_conversion_docker_image.tar
       dest: ~/
     become: true
+  - name: Stop and remove QPP Conversion Tools Docker container
+    docker_container:
+      name: qpp_converter
+      state: absent
+    become: true
+  - name: Delete old QPP Conversion Tools Docker image
+    docker_image:
+      name: qpp_conversion
+      state: absent
+      force: yes
+    become: true
   - name: Load QPP Conversion Tools Docker image
     docker_image:
       name: qpp_conversion


### PR DESCRIPTION
The error `Timeout (12s) waiting for privilege escalation prompt` is generated because the EC2 instance had run out of disk space to upload the new image.  It ran out of disk space because all the old images that were replaced on a new deployment were not being deleted.

Therefore, we now...
 - Explicitly stop and remove the previously running container which then allows us to...
 - Explicitly delete the previous image before loading the new image.