### PR TITLE
Propagate signals to java in Docker container

### DIFF
--- a/docker-artifacts/qppConverter.sh
+++ b/docker-artifacts/qppConverter.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 sed -i -e "s/NEWRELIC_API_KEY/$NEWRELIC_API_KEY/g" ./newrelic/newrelic.yml
-java -javaagent:./newrelic/newrelic.jar -jar ./rest-api.jar
+exec java -javaagent:./newrelic/newrelic.jar -jar ./rest-api.jar


### PR DESCRIPTION
For our application to be a "good Docker citizen", it should respond to signals that may be passed to it.  The problem is that a Bash script is executed as our application (which in turn executes our Java application) and Bash doesn't propagate signals to child processes.  By calling `java` via `exec`, Java replaces the Bash process and therefore receives the signals.  Yay!