### PR TITLE
Update helper script to check commandline.jar

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-if [ ! -f converter/target/converter.jar ]; then
+if [ ! -f commandline/target/commandline.jar ]; then
     echo "Jar not found. Building..."
     mvn package -Dmaven.test.skip=true
-    if [ ! -f converter/target/converter.jar ]; then
+    if [ ! -f commandline/target/commandline.jar ]; then
         echo "Build failed. Aborting."
         exit 1
     fi


### PR DESCRIPTION
### Information
- Just a quick clean-up.

### Changes proposed in this PR:
- The `convert.sh` script now checks the existence of the correct `.jar` file.