### PR TITLE
Demo replacement with Truth

### DIFF
--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AciMeasurePerformedRnRDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AciMeasurePerformedRnRDecoderTest.java
@@ -12,10 +12,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 public class AciMeasurePerformedRnRDecoderTest {
 	private static final String MEASURE_ID = "ACI_INFBLO_1";
@@ -49,10 +47,11 @@ public class AciMeasurePerformedRnRDecoderTest {
 		DecodeResult decodeResult = objectUnderTest.internalDecode(element, aciMeasurePerformedNode);
 
 		//assert
-		assertThat("The decode result is incorrect.", decodeResult, is(DecodeResult.TREE_CONTINUE));
+		assertWithMessage("The decode result is incorrect").that(decodeResult).isEqualTo(DecodeResult.TREE_CONTINUE);
+
 		String actualMeasureId = aciMeasurePerformedNode.getValue("measureId");
-		assertThat("measureId must not be null.", actualMeasureId, is(not(nullValue())));
-		assertThat("measureId is incorrect.", actualMeasureId, is(MEASURE_ID));
+		assertThat(actualMeasureId).isNotNull();
+		assertWithMessage("measureId is incorrect.").that(actualMeasureId).isEqualTo(MEASURE_ID);
 	}
 
 	@Test
@@ -64,10 +63,10 @@ public class AciMeasurePerformedRnRDecoderTest {
 
 		String actualMeasureId = aciMeasurePerformedNode.getValue("measureId");
 
-		assertThat("The measureId must not be null.", actualMeasureId, is(not(nullValue())));
-		assertThat("The measureId is incorrect.", actualMeasureId, is(MEASURE_ID));
+		assertThat(actualMeasureId).isNotNull();
+		assertWithMessage("The measureId is incorrect.").that(actualMeasureId).isEqualTo(MEASURE_ID);
 		long measurePerformedCount = aciMeasurePerformedNode.getChildNodes(
 			node -> node.getType() == TemplateId.MEASURE_PERFORMED).count();
-		assertThat("There must be one Measure Performed child node.", measurePerformedCount, is(1L));
+		assertWithMessage("There must be one Measure Performed child node.").that(measurePerformedCount).isEqualTo(1);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,13 @@
 			<version>1.7.1</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.truth</groupId>
+			<artifactId>truth</artifactId>
+			<version>0.36</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
### Information
- JIRA story QPPCT-289.

### Changes proposed in this PR:
- None (do not merge this)

This PR is not meant to be merged, rather to host discussion on Truth vs JUnit + Hamcrest. I refactored one class to use Truth. There are 138 other imports of org.junit.Assert, and 77 imports of org.hamcrest.CoreMatchers. I estimate this task would take about four hours of work.

My vote is "worth it", because it makes the code much more readable. Bring on the disagreement!
