### PR TITLE
QPPCT-395: aftermath

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Error.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Error.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.model.error;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -19,6 +20,7 @@ public class Error implements Serializable {
 	private String sourceIdentifier;
 	private String type;
 	private String message;
+	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
 	@JsonProperty("details")
 	private List<Detail> details = new ArrayList<>();
 

--- a/rest-api/src/test/resources/submissionDuplicateEntryErrorFixture.json
+++ b/rest-api/src/test/resources/submissionDuplicateEntryErrorFixture.json
@@ -1,0 +1,9 @@
+{
+	"error": {
+		"type": "DuplicateEntryError",
+		"message": "Category/SubmissionMethod/SubmitterId/SubmitterType ia/electronicHealthRecord/1234567/organization,quality/electronicHealthRecord/1234567/organization,aci/electronicHealthRecord/1234567/organization already exists for this taxpayerIdentificationNumber/nationalProviderIdentifier/performanceYear",
+		"details": {
+			"submissionId": "29eae3a3-17eb-45e4-888b-e15e428b276a"
+		}
+	}
+}


### PR DESCRIPTION
### Information
- QPPCT-395 kind of

### Changes proposed in this PR:
- adjust for possibility of error details object rather than single entry array

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
