### PR TITLE
Do a clean when Dockerfiles make the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./ /usr/src/app/
 
 WORKDIR /usr/src/app/
 
-RUN mvn install -Dmaven.test.skip -Djacoco.skip=true > /dev/null
+RUN mvn clean install -Dmaven.test.skip -Djacoco.skip=true > /dev/null
 RUN cp ./rest-api/target/rest-api.jar /usr/src/run/
 RUN cp -r ./tools/docker/docker-artifacts/* /usr/src/run/
 

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -7,7 +7,7 @@ COPY ./ /usr/src/app/
 
 WORKDIR /usr/src/app/
 
-RUN mvn install -Dmaven.test.skip -Djacoco.skip=true > /dev/null
+RUN mvn clean install -Dmaven.test.skip -Djacoco.skip=true > /dev/null
 RUN cp ./rest-api/target/rest-api.jar /usr/src/run/
 RUN cp -r ./tools/docker/docker-test-artifacts/* /usr/src/run/
 


### PR DESCRIPTION
### Information
- Non-story nor issue improvement.

### Changes proposed in this PR:
- Initiate a clean when building our application in Docker.  This will delete any extraneous files when we copy our application into Docker.
- Saves about 100 MB when sending our Docker image to our small Flexion endpoint.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
