### PR TITLE
Make AllErrorsTest use junit 5

### DIFF
--- a/converter/src/test/java/gov/cms/qpp/conversion/model/error/AllErrorsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/error/AllErrorsTest.java
@@ -1,18 +1,18 @@
 package gov.cms.qpp.conversion.model.error;
 
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
-public class AllErrorsTest {
+class AllErrorsTest {
 
 	@Test
-	public void errorSourceInit() {
+	void testErrorSourceInit() {
 		AllErrors objectUnderTest = new AllErrors();
 		assertWithMessage("The error sources should have been null at first")
 				.that(objectUnderTest.getErrors())
@@ -20,7 +20,7 @@ public class AllErrorsTest {
 	}
 
 	@Test
-	public void addErrorSource() {
+	void testAddErrorSource() {
 		AllErrors objectUnderTest = new AllErrors();
 		objectUnderTest.addError(new Error());
 
@@ -29,7 +29,7 @@ public class AllErrorsTest {
 	}
 
 	@Test
-	public void addErrorSources() {
+	void testAddErrorSources() {
 		AllErrors objectUnderTest = new AllErrors();
 		objectUnderTest.addError(new Error());
 		objectUnderTest.addError(new Error());
@@ -39,7 +39,7 @@ public class AllErrorsTest {
 	}
 
 	@Test
-	public void setErrorSources() {
+	void testSetErrorSources() {
 		AllErrors objectUnderTest = new AllErrors();
 		objectUnderTest.setErrors(Collections.singletonList(new Error()));
 
@@ -48,7 +48,7 @@ public class AllErrorsTest {
 	}
 
 	@Test
-	public void testToString() {
+	void testToString() {
 		AllErrors objectUnderTest = new AllErrors();
 		Error error = new Error();
 		objectUnderTest.addError(error);
@@ -58,7 +58,7 @@ public class AllErrorsTest {
 	}
 
 	@Test
-	public void testArgConstructor() {
+	void testArgConstructor() {
 		List<Error> errors = new ArrayList<>();
 		errors.add(new Error());
 		new AllErrors(errors);


### PR DESCRIPTION
### Information
- JIRA story QPPCT-283.

### Changes proposed in this PR:
- Updates a single class to use junit 5

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
