### PR TITLE
Make ErrorTest use junit 5

### DIFF
--- a/converter/src/test/java/gov/cms/qpp/conversion/model/error/ErrorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/error/ErrorTest.java
@@ -1,23 +1,24 @@
 package gov.cms.qpp.conversion.model.error;
 
-import com.google.common.truth.StringSubject;
-import org.junit.Test;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.util.Collections;
 
-import static com.google.common.truth.Truth.assertWithMessage;
+import org.junit.jupiter.api.Test;
 
-public class ErrorTest {
+import com.google.common.truth.StringSubject;
+
+class ErrorTest {
 
 	@Test
-	public void validationErrorInit() {
+	void testValidationErrorInit() {
 		Error objectUnderTest = new Error();
 		assertWithMessage("The validation errors should have been empty at first")
 				.that(objectUnderTest.getDetails()).isEmpty();
 	}
 
 	@Test
-	public void addValidationError() {
+	void testAddValidationError() {
 		Error objectUnderTest = new Error();
 		objectUnderTest.addValidationError(new Detail("description", "path"));
 		objectUnderTest.addValidationError(new Detail("description", "path"));
@@ -27,7 +28,7 @@ public class ErrorTest {
 	}
 
 	@Test
-	public void initializesDetailsWhenNull() {
+	void testInitializesDetailsWhenNull() {
 		Error objectUnderTest = new Error();
 		objectUnderTest.setDetails(null);
 		objectUnderTest.addValidationError(new Detail());
@@ -37,7 +38,7 @@ public class ErrorTest {
 	}
 
 	@Test
-	public void mutability() {
+	void testMutability() {
 		Error objectUnderTest = new Error();
 
 		objectUnderTest.setSourceIdentifier("meep");
@@ -50,7 +51,7 @@ public class ErrorTest {
 	}
 
 	@Test
-	public void testToString() {
+	void testToString() {
 		Error objectUnderTest = new Error();
 		objectUnderTest.setSourceIdentifier("sourceID");
 		objectUnderTest.setDetails(Collections.singletonList(new Detail("description", "path")));


### PR DESCRIPTION
### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
