### PR TITLE
Junit5 decoders

### DIFF
--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AciMeasurePerformedRnRDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AciMeasurePerformedRnRDecoderTest.java
@@ -9,7 +9,7 @@ import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.IOException;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -17,7 +17,7 @@ public class AciMeasurePerformedRnRDecoderTest {
 	private static final String MEASURE_ID = "ACI_INFBLO_1";
 
 	@Test
-	public void internalDecodeReturnsTreeContinue() {
+	void internalDecodeReturnsTreeContinue() {
 		//set-up
 		AciMeasurePerformedRnRDecoder objectUnderTest = new AciMeasurePerformedRnRDecoder(new Context());
 		
@@ -55,7 +55,7 @@ public class AciMeasurePerformedRnRDecoderTest {
 	}
 
 	@Test
-	public void testUpperLevel() throws XmlException, IOException {
+	void testUpperLevel() throws XmlException, IOException {
 		String needsFormattingXml = TestHelper.getFixture("AciMeasurePerformedIsolated.xml");
 		String xml = String.format(needsFormattingXml, MEASURE_ID);
 		Node wrapperNode = new QppXmlDecoder(new Context()).decode(XmlUtils.stringToDom(xml));

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AciNumeratorDenominatorDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AciNumeratorDenominatorDecoderTest.java
@@ -8,7 +8,7 @@ import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.util.List;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -17,7 +17,7 @@ public class AciNumeratorDenominatorDecoderTest {
 	private static final String MEASURE_ID = "ACI-PEA-1";
 
 	@Test
-	public void decodeAggregateCountAsNode() throws Exception {
+	void decodeAggregateCountAsNode() throws Exception {
 		String xmlFragment = XmlUtils.buildString(
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">",
 				"  <observation classCode=\"OBS\" moodCode=\"EVN\">",
@@ -36,7 +36,7 @@ public class AciNumeratorDenominatorDecoderTest {
 	}
 
 	@Test
-	public void decodeAciNumeratorDenominatorNullValueAsNode() throws Exception {
+	void decodeAciNumeratorDenominatorNullValueAsNode() throws Exception {
 		String xmlFragment = XmlUtils.buildString(
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\" >",
 				"  <observation classCode=\"OBS\" moodCode=\"EVN\">",
@@ -52,7 +52,7 @@ public class AciNumeratorDenominatorDecoderTest {
 	}
 
 	@Test
-	public void decodeAciNumeratorDenominatorNullElementAsNode() throws Exception {
+	void decodeAciNumeratorDenominatorNullElementAsNode() throws Exception {
 		String xmlFragment = XmlUtils.buildString(
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">",
 				"  <observation classCode=\"OBS\" moodCode=\"EVN\">",
@@ -67,7 +67,7 @@ public class AciNumeratorDenominatorDecoderTest {
 	}
 
 	@Test
-	public void decodeValidAciNumeratorDenominatorTest() throws XmlException {
+	void decodeValidAciNumeratorDenominatorTest() throws XmlException {
 		Node aciMeasureNode = new QppXmlDecoder(new Context()).decode(XmlUtils.stringToDom(getValidXmlFragment()));
 		Node numeratorDenominatorNode = aciMeasureNode.getChildNodes().get(0);
 		int numberNodes = countNodes(aciMeasureNode);
@@ -109,7 +109,7 @@ public class AciNumeratorDenominatorDecoderTest {
 	}
 
 	@Test
-	public void decodeAciNumeratorDenominatorExtraneousXMLTest() throws XmlException {
+	void decodeAciNumeratorDenominatorExtraneousXMLTest() throws XmlException {
 		String xmlFragment = getValidXmlFragment();
 		xmlFragment = xmlFragment.replaceAll("<statusCode ",
 				"\n<Stuff arbitrary=\"123\"><newnode>Some extra stuff</newnode></Stuff>Unexpected stuff appears here\n\n<statusCode ");
@@ -142,7 +142,7 @@ public class AciNumeratorDenominatorDecoderTest {
 	}
 
 	@Test
-	public void testInternalDecode() throws Exception {
+	void testInternalDecode() throws Exception {
 		//set-up
 		Namespace rootns = Namespace.getNamespace("urn:hl7-org:v3");
 		Namespace ns = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AciProportionDenominatorDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AciProportionDenominatorDecoderTest.java
@@ -3,7 +3,7 @@ package gov.cms.qpp.conversion.decode;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.xml.XmlUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -22,7 +22,7 @@ public class AciProportionDenominatorDecoderTest {
 	 * @throws Exception
 	 */
 	@Test
-	public void decodeACIProportionDenominatorAsNode() throws Exception {
+	void decodeACIProportionDenominatorAsNode() throws Exception {
 		String xmlFragment = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 				+ "<component xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">\n"
 				+ " <observation classCode=\"OBS\" moodCode=\"EVN\">\n"
@@ -58,7 +58,7 @@ public class AciProportionDenominatorDecoderTest {
 	}
 
 	@Test
-	public void decodeInvalidACIProportionDenominatorAsNode() throws Exception {
+	void decodeInvalidACIProportionDenominatorAsNode() throws Exception {
 		String xmlFragment = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 			+ "<component xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">\n"
 			+ " <observation classCode=\"OBS\" moodCode=\"EVN\">\n"

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AciProportionNumeratorDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AciProportionNumeratorDecoderTest.java
@@ -3,7 +3,7 @@ package gov.cms.qpp.conversion.decode;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import org.jdom2.Element;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -12,7 +12,7 @@ public class AciProportionNumeratorDecoderTest {
 	private static final String NUMERATOR_NODE_NAME = "aciProportionNumerator";
 
 	@Test
-	public void testInternalDecode() {
+	void testInternalDecode() {
 		Element element = new Element("testElement");
 		Node node = new Node();
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AciSectionDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AciSectionDecoderTest.java
@@ -1,11 +1,9 @@
 package gov.cms.qpp.conversion.decode;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.jdom2.Element;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
@@ -13,7 +11,7 @@ import gov.cms.qpp.conversion.model.Node;
 public class AciSectionDecoderTest {
 
 	@Test
-	public void testInternalDecode() {
+	void testInternalDecode() {
 		Element element = new Element("testElement");
 		Node node = new Node();
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/AggregateCountDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/AggregateCountDecoderTest.java
@@ -10,7 +10,7 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -59,7 +59,7 @@ public class AggregateCountDecoderTest {
             + "</observation>";
 
     @Test
-    public void testInternalDecode() throws Exception {
+    void testInternalDecode() throws Exception {
         Namespace rootNs = Namespace.getNamespace("urn:hl7-org:v3");
         Namespace ns = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
 
@@ -82,7 +82,7 @@ public class AggregateCountDecoderTest {
     }
 
     @Test
-    public void testAggregateCountDecoderIgnoresInvalidElements() throws Exception {
+    void testAggregateCountDecoderIgnoresInvalidElements() throws Exception {
 
         Node root = new QppXmlDecoder(new Context()).decode(XmlUtils.stringToDom(XML_FRAGMENT));
         Node node = root.getChildNodes().get(0);
@@ -100,7 +100,7 @@ public class AggregateCountDecoderTest {
     }
 
     @Test
-    public void testAggregateCountDecoderIgnoresInvalidElementsPartTwo() throws Exception {
+    void testAggregateCountDecoderIgnoresInvalidElementsPartTwo() throws Exception {
 
         Node root = new QppXmlDecoder(new Context()).decode(XmlUtils.stringToDom(ANOTHER_XML_FRAGMENT));
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoderTest.java
@@ -12,9 +12,9 @@ import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.reflections.util.ClasspathHelper;
 
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -25,15 +25,15 @@ public class ClinicalDocumentDecoderTest {
 	private static String xmlFragment;
 	private Node clinicalDocument;
 
-	@BeforeClass
-	public static void init() throws IOException {
+	@BeforeAll
+	static void init() throws IOException {
 		InputStream stream =
 				ClasspathHelper.contextClassLoader().getResourceAsStream("valid-QRDA-III-abridged.xml");
 		xmlFragment = IOUtils.toString(stream, Charset.defaultCharset());
 	}
 
-	@Before
-	public void setupTest() throws XmlException {
+	@BeforeEach
+	void setupTest() throws XmlException {
 		Node root = new QppXmlDecoder(new Context()).decode(XmlUtils.stringToDom(xmlFragment));
 		clinicalDocument = root.findFirstNode(TemplateId.CLINICAL_DOCUMENT);
 		// remove default nodes (will fail if defaults change)
@@ -41,35 +41,35 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testRootId() {
+	void testRootId() {
 		assertWithMessage("Must have be the correct TemplateId")
 				.that(clinicalDocument.getType())
 				.isEquivalentAccordingToCompareTo(TemplateId.CLINICAL_DOCUMENT);
 	}
 
 	@Test
-	public void testRootProgramName() {
+	void testRootProgramName() {
 		assertWithMessage("Must be the correct Program Name")
 				.that(clinicalDocument.getValue(ClinicalDocumentDecoder.PROGRAM_NAME))
 				.isEqualTo(ClinicalDocumentDecoder.MIPS_PROGRAM_NAME);
 	}
 
 	@Test
-	public void testRootNationalProviderIdentifier() {
+	void testRootNationalProviderIdentifier() {
 		assertWithMessage("Must have the correct NPI")
 				.that(clinicalDocument.getValue(MultipleTinsDecoder.NATIONAL_PROVIDER_IDENTIFIER))
 				.isEqualTo("2567891421");
 	}
 
 	@Test
-	public void testRootTaxpayerIdentificationNumber() {
+	void testRootTaxpayerIdentificationNumber() {
 		assertWithMessage("Must have the correct TIN")
 				.that(clinicalDocument.getValue(MultipleTinsDecoder.TAX_PAYER_IDENTIFICATION_NUMBER))
 				.isEqualTo("123456789");
 	}
 
 	@Test
-	public void testAciCategory() {
+	void testAciCategory() {
 		Node aciSectionNode = clinicalDocument.getChildNodes().get(0);
 		assertWithMessage("returned category should be aci")
 				.that(aciSectionNode.getValue("category"))
@@ -77,7 +77,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testAciPea1MeasureId() {
+	void testAciPea1MeasureId() {
 		Node aciSectionNode = clinicalDocument.getChildNodes().get(0);
 		assertWithMessage("returned measureId ACI-PEA-1")
 				.that(aciSectionNode.getChildNodes().get(0).getValue("measureId"))
@@ -85,7 +85,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testAciEp1MeasureId() {
+	void testAciEp1MeasureId() {
 		Node aciSectionNode = clinicalDocument.getChildNodes().get(0);
 		assertWithMessage("returned measureId ACI_EP_1")
 				.that(aciSectionNode.getChildNodes().get(1).getValue("measureId"))
@@ -93,7 +93,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testAciCctpe3MeasureId() {
+	void testAciCctpe3MeasureId() {
 		Node aciSectionNode = clinicalDocument.getChildNodes().get(0);
 		assertWithMessage("returned measureId ACI_CCTPE_3")
 				.that(aciSectionNode.getChildNodes().get(2).getValue("measureId"))
@@ -101,7 +101,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testIaCategory() {
+	void testIaCategory() {
 		Node iaSectionNode = clinicalDocument.getChildNodes().get(1);
 		assertWithMessage("returned category")
 				.that(iaSectionNode.getValue("category"))
@@ -109,7 +109,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testIaMeasureId() {
+	void testIaMeasureId() {
 		Node iaSectionNode = clinicalDocument.getChildNodes().get(1);
 		Node iaMeasureNode = iaSectionNode.getChildNodes().get(0);
 		assertWithMessage("returned should have measureId")
@@ -118,7 +118,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testClinicalDocumentIgnoresGarbage() throws IOException, XmlException {
+	void testClinicalDocumentIgnoresGarbage() throws IOException, XmlException {
 		InputStream stream =
 				ClasspathHelper.contextClassLoader().getResourceAsStream("QRDA-III-with-extra-elements.xml");
 		String xmlWithGarbage = IOUtils.toString(stream, Charset.defaultCharset());
@@ -136,7 +136,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void testIaMeasurePerformed() {
+	void testIaMeasurePerformed() {
 		Node iaSectionNode = clinicalDocument.getChildNodes().get(1);
 		Node iaMeasureNode = iaSectionNode.getChildNodes().get(0);
 		Node iaMeasurePerformedNode = iaMeasureNode.getChildNodes().get(0);
@@ -146,7 +146,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeClinicalDocumentInternalDecode() throws Exception {
+	void decodeClinicalDocumentInternalDecode() throws Exception {
 		Element clinicalDocument = makeClinicalDocument("MIPS");
 		Node testParentNode = new Node();
 		ClinicalDocumentDecoder objectUnderTest = new ClinicalDocumentDecoder(new Context());
@@ -175,7 +175,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeClinicalDocumentInternalDecodeMIPSIndividual() throws Exception {
+	void decodeClinicalDocumentInternalDecodeMIPSIndividual() throws Exception {
 		Element clinicalDocument = makeClinicalDocument("MIPS_INDIV");
 		Node testParentNode = new Node();
 		ClinicalDocumentDecoder objectUnderTest = new ClinicalDocumentDecoder(new Context());
@@ -204,7 +204,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeClinicalDocumentInternalDecodeMIPSGroup() throws Exception {
+	void decodeClinicalDocumentInternalDecodeMIPSGroup() throws Exception {
 		Element clinicalDocument = makeClinicalDocument("MIPS_GROUP");
 		Node testParentNode = new Node();
 		ClinicalDocumentDecoder objectUnderTest = new ClinicalDocumentDecoder(new Context());
@@ -233,7 +233,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeClinicalDocumentInternalDecodeCPCPlus() throws Exception {
+	void decodeClinicalDocumentInternalDecodeCPCPlus() throws Exception {
 		Element clinicalDocument = makeClinicalDocument(ClinicalDocumentDecoder.CPCPLUS);
 		Node testParentNode = new Node();
 		ClinicalDocumentDecoder objectUnderTest = new ClinicalDocumentDecoder(new Context());
@@ -262,7 +262,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeClinicalDocumentInternalDecodeUnknown() throws Exception {
+	void decodeClinicalDocumentInternalDecodeUnknown() throws Exception {
 		Element clinicalDocument = makeClinicalDocument("Unknown");
 		Node testParentNode = new Node();
 		ClinicalDocumentDecoder objectUnderTest = new ClinicalDocumentDecoder(new Context());
@@ -291,7 +291,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeCpcPlusEntityIdTest() throws Exception {
+	void decodeCpcPlusEntityIdTest() throws Exception {
 		Element clinicalDocument = makeClinicalDocument(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME);
 		clinicalDocument.addContent( prepareParticipant( clinicalDocument.getNamespace()) );
 		Node testParentNode = new Node();
@@ -304,7 +304,7 @@ public class ClinicalDocumentDecoderTest {
 	}
 
 	@Test
-	public void decodeCpcPracticeSiteAddressTest() throws Exception {
+	void decodeCpcPracticeSiteAddressTest() throws Exception {
 		Element clinicalDocument = makeClinicalDocument(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME);
 		clinicalDocument.addContent( prepareParticipant( clinicalDocument.getNamespace()) );
 		Node testParentNode = new Node();

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/DecodeResultTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/DecodeResultTest.java
@@ -1,6 +1,6 @@
 package gov.cms.qpp.conversion.decode;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -10,7 +10,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 public class DecodeResultTest {
 
 	@Test
-	public void decodeResultTest() {
+	void decodeResultTest() {
 		DecodeResult result = DecodeResult.valueOf("TREE_FINISHED");
 		assertWithMessage("Expect Decode Result to be TREE_FINISHED")
 				.that(result)
@@ -18,7 +18,7 @@ public class DecodeResultTest {
 	}
 
 	@Test
-	public void decodeResultValuesTest() {
+	void decodeResultValuesTest() {
 		DecodeResult[] results = DecodeResult.values();
 		assertWithMessage("Expect Decode Result to be array size 5")
 				.that(results)

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/DecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/DecoderTest.java
@@ -6,7 +6,7 @@ import gov.cms.qpp.conversion.model.Registry;
 import gov.cms.qpp.conversion.model.TemplateId;
 import java.util.EnumSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -35,7 +35,7 @@ public class DecoderTest {
 			TemplateId.IA_MEASURE);
 
 	@Test
-	public void decodeTemplateIds() throws Exception {
+	void decodeTemplateIds() throws Exception {
 		Registry<InputDecoder> registry = new Registry<>(new Context(), Decoder.class);
 
 		for (TemplateId templateId : templateIds) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/IaMeasureDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/IaMeasureDecoderTest.java
@@ -6,8 +6,8 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -17,13 +17,13 @@ import static com.google.common.truth.Truth.assertWithMessage;
 public class IaMeasureDecoderTest {
 	String xmlFragment;
 
-	@Before
-	public void setUp() throws IOException {
+	@BeforeEach
+	void setUp() throws IOException {
 		xmlFragment = TestHelper.getFixture("IaSection.xml");
 	}
 
 	@Test
-	public void internalDecode() throws Exception {
+	void internalDecode() throws Exception {
 		IaMeasureDecoder decoder = new IaMeasureDecoder(new Context());
 		Node root = decoder.decode(XmlUtils.stringToDom(xmlFragment));
 
@@ -43,7 +43,7 @@ public class IaMeasureDecoderTest {
 	}
 
 	@Test
-	public void missingChildTest() throws Exception {
+	void missingChildTest() throws Exception {
 		xmlFragment = removeChildFragment(xmlFragment);
 		IaMeasureDecoder decoder = new IaMeasureDecoder(new Context());
 
@@ -59,7 +59,7 @@ public class IaMeasureDecoderTest {
 	}
 
 	@Test
-	public void internalDecodeWithExtraXmlPasses() throws Exception {
+	void internalDecodeWithExtraXmlPasses() throws Exception {
 		IaMeasureDecoder decoder = new IaMeasureDecoder(new Context());
 		xmlFragment = addExtraXml(xmlFragment);
 		Node root = decoder.decode(XmlUtils.stringToDom(xmlFragment));

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/IaSectionDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/IaSectionDecoderTest.java
@@ -8,21 +8,21 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
 public class IaSectionDecoderTest {
 	private String xmlFragment;
 
-	@Before
-	public void setUp() throws IOException {
+	@BeforeEach
+	void setUp() throws IOException {
 		xmlFragment = TestHelper.getFixture("IaSection.xml");
 	}
 
 	@Test
-	public void decodeAciSectionAsNode() throws XmlException {
+	void decodeAciSectionAsNode() throws XmlException {
 		Node root = executeDecoderWithoutDefaults();
 
 		Node iaSectionNode = root.findFirstNode(TemplateId.IA_SECTION);
@@ -33,7 +33,7 @@ public class IaSectionDecoderTest {
 	}
 
 	@Test
-	public void testDecodeIaSectionIgnoresGarbage() throws XmlException {
+	void testDecodeIaSectionIgnoresGarbage() throws XmlException {
 		xmlFragment = xmlFragment.replaceAll("<statusCode ",
 				"\n<Stuff arbitrary=\"123\"><newnode>Some extra stuff</newnode></Stuff>" +
 						"Unexpected stuff appears here\n\n<statusCode ");

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasureDataDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasureDataDecoderTest.java
@@ -8,9 +8,9 @@ import gov.cms.qpp.conversion.model.validation.SubPopulations;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
@@ -22,35 +22,35 @@ public class MeasureDataDecoderTest {
 	private Context context;
 	private Node placeholder;
 
-	@BeforeClass
-	public static void setup() throws IOException {
+	@BeforeAll
+	static void setup() throws IOException {
 		happy = TestHelper.getFixture("measureDataHappy.xml");
 	}
 
-	@Before
-	public void before() throws XmlException {
+	@BeforeEach
+	void before() throws XmlException {
 		context = new Context();
 		MeasureDataDecoder measureDataDecoder = new MeasureDataDecoder(context);
 		placeholder = measureDataDecoder.decode(XmlUtils.stringToDom(happy));
 	}
 
 	@Test
-	public void testDecodeOfDenomMeasureData() {
+	void testDecodeOfDenomMeasureData() {
 		sharedTest(SubPopulations.DENOM);
 	}
 
 	@Test
-	public void testDecodeOfNumerMeasureData() {
+	void testDecodeOfNumerMeasureData() {
 		sharedTest(SubPopulations.NUMER);
 	}
 
 	@Test
-	public void testDecodeOfDenexMeasureData() {
+	void testDecodeOfDenexMeasureData() {
 		sharedTest(SubPopulations.DENEX);
 	}
 
 	@Test
-	public void testDecodeOfDenexcepMeasureData() {
+	void testDecodeOfDenexcepMeasureData() {
 		sharedTest(SubPopulations.DENEXCEP);
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasurePerformedDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasurePerformedDecoderTest.java
@@ -7,8 +7,8 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -17,14 +17,14 @@ public class MeasurePerformedDecoderTest {
 	private Context context;
 	private String xmlFragment;
 
-	@Before
-	public void setUp() throws IOException {
+	@BeforeEach
+	void setUp() throws IOException {
 		context = new Context();
 		xmlFragment = TestHelper.getFixture("MeasurePerformed.xml");
 	}
 
 	@Test
-	public void testMeasurePerformed() throws XmlException {
+	void testMeasurePerformed() throws XmlException {
 		Node measurePerformedNode = executeMeasurePerformedDecoder(xmlFragment)
 				.findFirstNode(TemplateId.MEASURE_PERFORMED);
 
@@ -32,7 +32,7 @@ public class MeasurePerformedDecoderTest {
 	}
 
 	@Test
-	public void testGarbageXmlIsIgnore() throws XmlException {
+	void testGarbageXmlIsIgnore() throws XmlException {
 		xmlFragment = xmlFragment.replaceAll("<statusCode ",
 				"\n<Stuff arbitrary=\"123\">abc<newnode>Some extra stuff</newnode></Stuff>Unexpected text appears here\n\n<statusCode ");
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/MultipleTinsDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/MultipleTinsDecoderTest.java
@@ -8,11 +8,11 @@ import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import org.jdom2.Element;
 import org.jdom2.xpath.XPathHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -31,13 +31,13 @@ public class MultipleTinsDecoderTest {
 
 	private Context context;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		context = new Context();
 	}
 
 	@Test
-	public void internalDecode() throws Exception {
+	void internalDecode() throws Exception {
 		Element multipleTinsElement = makeTestElement();
 		List<Node> children = getTestChildren(multipleTinsElement);
 		assertThat(children).hasSize(4);
@@ -67,7 +67,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testNullNPI() throws Exception {
+	void testNullNPI() throws Exception {
 
 		Element multipleTinsElement = makeTestElementMissingNPI();
 		List<Node> children = getTestChildren(multipleTinsElement);
@@ -81,7 +81,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testNullTIN() throws Exception {
+	void testNullTIN() throws Exception {
 		Element multipleTinsElement = makeTestElementMissingTIN();
 		List<Node> children = getTestChildren(multipleTinsElement);
 		assertWithMessage("Expect that there are three children")
@@ -94,7 +94,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testNullTINID() throws Exception {
+	void testNullTINID() throws Exception {
 		Element multipleTinsElement = makeTestElementMissingTINID();
 		List<Node> children = getTestChildren(multipleTinsElement);
 		assertWithMessage("Expect that there are four children")
@@ -103,7 +103,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testNullNPIID() throws Exception {
+	void testNullNPIID() throws Exception {
 		Element multipleTinsElement = makeTestElementMissingNPIID();
 		List<Node> children = getTestChildren(multipleTinsElement);
 		assertWithMessage("Expect that there are four children")
@@ -112,7 +112,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testNullTINIDAndNPIID() throws Exception {
+	void testNullTINIDAndNPIID() throws Exception {
 		Element multipleTinsElement = makeTestElementMissingTINIDAndNPIID();
 		List<Node> children = getTestChildren(multipleTinsElement);
 		assertWithMessage("Expect that there are three children")
@@ -121,7 +121,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testNullTaxEl() throws Exception {
+	void testNullTaxEl() throws Exception {
 		Element multipleTinsElement = makeTestElementMissingTaxEl();
 		List<Node> children = getTestChildren(multipleTinsElement);
 		assertWithMessage("Expect that there are three children")
@@ -130,7 +130,7 @@ public class MultipleTinsDecoderTest {
 	}
 
 	@Test
-	public void testPathIsSet() throws Exception {
+	void testPathIsSet() throws Exception {
 		Element multipleTinsElement = makeTestElementMissingTaxEl();
 		Node child = getTestChildren(multipleTinsElement)
 				.stream()

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/NullReturnDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/NullReturnDecoderTest.java
@@ -4,14 +4,14 @@ import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.xml.XmlUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
 public class NullReturnDecoderTest {
 
 	@Test
-	public void decodeReturnNullNode() throws Exception {
+	void decodeReturnNullNode() throws Exception {
 		String xmlFragment = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 				+ "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">\n"
 				+ "	<null resultName=\"result\" resultValue=\"mytestvalue\">\n"

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/PerformanceRateProportionMeasureDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/PerformanceRateProportionMeasureDecoderTest.java
@@ -7,9 +7,9 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -21,27 +21,27 @@ public class PerformanceRateProportionMeasureDecoderTest {
 	private Node placeholder;
 	private Node performanceRateNode;
 
-	@BeforeClass
-	public static void setup() throws IOException {
+	@BeforeAll
+	static void setup() throws IOException {
 		happy = TestHelper.getFixture("measureDataWithPerformanceRate.xml");
 		nullHappy = TestHelper.getFixture("measureDataWithNullPerformanceRate.xml");
 	}
 
-	@Before
-	public void before() throws XmlException {
+	@BeforeEach
+	void before() throws XmlException {
 		decodeNodeFromFile(happy);
 		performanceRateNode = getNode();
 	}
 
 	@Test
-	public void testPerformanceRateValueSuccess() {
+	void testPerformanceRateValueSuccess() {
 		assertWithMessage("Must contain the correct value")
 				.that(performanceRateNode.getValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE))
 				.isEqualTo("0.947368");
 	}
 
 	@Test
-	public void testPerformanceRateUuidSuccess() {
+	void testPerformanceRateUuidSuccess() {
 		final String performanceRateId = "6D01A564-58CC-4CF5-929F-B83583701BFE";
 		assertWithMessage("Must contain the correct UUID")
 				.that(performanceRateNode.getValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID))
@@ -49,7 +49,7 @@ public class PerformanceRateProportionMeasureDecoderTest {
 	}
 
 	@Test
-	public void testSuccessfulNullPerformanceRate() throws XmlException {
+	void testSuccessfulNullPerformanceRate() throws XmlException {
 		decodeNodeFromFile(nullHappy);
 		performanceRateNode = getNode();
 		assertWithMessage("Must contain the correct value")

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QedDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QedDecoderTest.java
@@ -3,14 +3,14 @@ package gov.cms.qpp.conversion.decode;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.xml.XmlUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
 public class QedDecoderTest {
 
 	@Test
-	public void decodeQEDAsNode() throws Exception {
+	void decodeQEDAsNode() throws Exception {
 		String xmlFragment = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 				+ "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">\n"
 				+ "	<qed resultName=\"result\" resultValue=\"mytestvalue\">\n"

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QppXmlDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QppXmlDecoderTest.java
@@ -8,7 +8,7 @@ import gov.cms.qpp.conversion.model.Program;
 import gov.cms.qpp.conversion.model.TemplateId;
 import java.lang.reflect.Method;
 import org.jdom2.Element;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -17,14 +17,14 @@ public class QppXmlDecoderTest {
 	private static boolean errorDecode = false;
 
 	@Test
-	public void decodeResultNoAction() throws Exception {
+	void decodeResultNoAction() throws Exception {
 		assertWithMessage("DecodeResult is incorrect")
 				.that(new QppXmlDecoder(new Context()).internalDecode(null, null))
 				.isEquivalentAccordingToCompareTo(DecodeResult.NO_ACTION);
 	}
 
 	@Test
-	public void nullElementDecodeReturnsError() {
+	void nullElementDecodeReturnsError() {
 		// Element nullElement = null;
 		assertWithMessage("DecodeResult is incorrect")
 				.that(new QppXmlDecoder(new Context()).decode((Element) null, null))
@@ -32,7 +32,7 @@ public class QppXmlDecoderTest {
 	}
 
 	@Test
-	public void decodeInvalidChildReturnsError() {
+	void decodeInvalidChildReturnsError() {
 		Context context = new Context();
 		TestHelper.mockDecoder(context, TestChildDecodeError.class, new ComponentKey(TemplateId.CONTINUOUS_VARIABLE_MEASURE_VALUE_CMS, Program.ALL));
 		TestHelper.mockDecoder(context, TestChildNoAction.class, new ComponentKey(TemplateId.PLACEHOLDER, Program.ALL));
@@ -53,7 +53,7 @@ public class QppXmlDecoderTest {
 	}
 
 	@Test
-	public void testChildDecodeErrorResultTest() throws Exception {
+	void testChildDecodeErrorResultTest() throws Exception {
 		DecodeResult result = DecodeResult.ERROR;
 		DecodeResult returnValue = runTestChildDecodeResult(result);
 		assertWithMessage("Should get an invalid Decode Result")
@@ -63,7 +63,7 @@ public class QppXmlDecoderTest {
 	}
 
 	@Test
-	public void testChildDecodeInvalidResultTest() throws Exception {
+	void testChildDecodeInvalidResultTest() throws Exception {
 		DecodeResult result = DecodeResult.NO_ACTION;
 		DecodeResult returnValue = runTestChildDecodeResult(result);
 		assertWithMessage("Should get an invalid Decode Result")

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QualityMeasureIdDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QualityMeasureIdDecoderTest.java
@@ -5,8 +5,8 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import org.jdom2.Element;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -16,7 +16,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 public class QualityMeasureIdDecoderTest {
 	private QualityMeasureIdDecoder objectUnderTest;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		objectUnderTest = new QualityMeasureIdDecoder(new Context());
 	}
@@ -27,7 +27,7 @@ public class QualityMeasureIdDecoderTest {
 	 * @throws XmlException when parsing xml fragment fails.
 	 */
 	@Test
-	public void internalDecodeValid() throws XmlException {
+	void internalDecodeValid() throws XmlException {
 		Node qualityMeasureIdNode = new Node();
 		Element qualityMeasureIdElement = XmlUtils.stringToDom(getXmlFragmentWithMeasureGuid("Measurement Id Value"));
 		objectUnderTest.setNamespace(qualityMeasureIdElement, objectUnderTest);
@@ -45,7 +45,7 @@ public class QualityMeasureIdDecoderTest {
 	 * @throws XmlException when the xml fragment is not well formed
 	 */
 	@Test
-	public void internalDecodeMissingId() throws XmlException {
+	void internalDecodeMissingId() throws XmlException {
 		String xmlFragment = getXmlFragmentWithMeasureGuid("Measurement Id Value").replace("<id ", "<noid ");
 
 		Node qualityMeasureIdNode = new Node();
@@ -62,7 +62,7 @@ public class QualityMeasureIdDecoderTest {
 	}
 
 	@Test
-	public void incorrectRoot() throws XmlException {
+	void incorrectRoot() throws XmlException {
 		//set-up
 		Element qualityMeasureIdElement = XmlUtils.stringToDom(getBadXmlFragmentWithIncorrectRoot());
 		Node qualityMeasureIdNode = new Node();
@@ -81,7 +81,7 @@ public class QualityMeasureIdDecoderTest {
 	}
 
 	@Test
-	public void dontIgnoreStratumMeasure() throws XmlException {
+	void dontIgnoreStratumMeasure() throws XmlException {
 		//set-up
 		String nonIgnorableGuid = "40280381-528a-60ff-0152-8e089ed20376";
 		Element qualityMeasureIdElement = XmlUtils.stringToDom(getXmlFragmentWithMeasureGuid(nonIgnorableGuid));

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QualityMeasureScopedTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QualityMeasureScopedTest.java
@@ -9,57 +9,57 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
 import gov.cms.qpp.conversion.xml.XmlException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QualityMeasureScopedTest {
 	private static String location = "src/test/resources/fixtures/qppct298/cms137v5.xml";
 
 
 	@Test
-	public void internalDecodeValidMeasure137V5Ipop() throws IOException, XmlException {
+	void internalDecodeValidMeasure137V5Ipop() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long ipops = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
 				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.IPOP))
 				.count();
 
-		assertEquals("Valid CMS137v5 measure should have 2 IPOP values", ipops, 2);
+		assertEquals(ipops, 2);
 	}
 
 	@Test
-	public void internalDecodeValidMeasure137V5Denom() throws IOException, XmlException {
+	void internalDecodeValidMeasure137V5Denom() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long denom = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
 				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.DENOM))
 				.count();
 
-		assertEquals("Valid CMS137v5 measure should have 2 DENOM values", denom, 2);
+		assertEquals(denom, 2);
 	}
 
 	@Test
-	public void internalDecodeValidMeasure137V5Denex() throws IOException, XmlException {
+	void internalDecodeValidMeasure137V5Denex() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long denex = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
 				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.DENEX))
 				.count();
 
-		assertEquals("Valid CMS137v5 measure should have 2 DENEX values", denex, 2);
+		assertEquals(denex, 2);
 	}
 
 	@Test
-	public void internalDecodeValidMeasure137V5Numer() throws IOException, XmlException {
+	void internalDecodeValidMeasure137V5Numer() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long numer = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
 				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.NUMER))
 				.count();
 
-		assertEquals("Valid CMS137v5 measure should have 2 NUMER values", numer, 2);
+		assertEquals(numer, 2);
 	}
 
 	private Stream<Node> pluckDescendants(Node parent, TemplateId... path) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QualitySectionDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QualitySectionDecoderTest.java
@@ -5,7 +5,7 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import org.jdom2.Element;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -19,7 +19,7 @@ public class QualitySectionDecoderTest {
 	 * @throws XmlException when parsing invalid xml fragment
 	 */
 	@Test
-	public void testInternalDecodeValidXml() throws XmlException {
+	void testInternalDecodeValidXml() throws XmlException {
 
 		String validXML = getValidXML();
 


### PR DESCRIPTION
### Information
- QPPCT-476

### Changes proposed in this PR:
- Refactor decoders in converter to use Junit 5

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
