### PR TITLE
Disable stacktrace trimming in maven surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.19.1</version>
 					<configuration>
+						<trimStackTrace>false</trimStackTrace>
 						<useFile>false</useFile>
 						<excludes>
 							<exclude>${exclusionFilter}</exclude>


### PR DESCRIPTION
### Information
- JIRA story QPPCT-468.

### Changes proposed in this PR:
- This makes it so when tests fail, the exception stacktraces are not trimmed. Major help when debugging from console.

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
