### PR TITLE
QPPCT-482: Encrypt S3 uploads with KMS key

### DIFF
--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/StorageServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/StorageServiceImplTest.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.services.s3.transfer.model.UploadResult;
-import gov.cms.qpp.test.MockitoExtension;
 import gov.cms.qpp.conversion.api.model.Constants;
+import gov.cms.qpp.test.MockitoExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,6 +50,7 @@ class StorageServiceImplTest {
 	private Environment environment;
 
 	private String bucketName = "test-bucket";
+	private String ksmKey = "test-key";
 	private UploadResult result;
 
 	@BeforeEach
@@ -69,6 +70,7 @@ class StorageServiceImplTest {
 	void testPut() throws TimeoutException, InterruptedException {
 		when(upload.waitForUploadResult()).thenReturn(result);
 		Mockito.when(environment.getProperty(eq(Constants.BUCKET_NAME_ENV_VARIABLE))).thenReturn(bucketName);
+		Mockito.when(environment.getProperty(eq(Constants.KMS_KEY_ENV_VARIABLE))).thenReturn(ksmKey);
 
 		assertThat(storeFile()).isNotNull();
 		verify(transferManager, times(1)).upload(any(PutObjectRequest.class));
@@ -78,6 +80,7 @@ class StorageServiceImplTest {
 	void testPutFail() throws TimeoutException, InterruptedException {
 		when(upload.waitForUploadResult()).thenThrow(InterruptedException.class);
 		Mockito.when(environment.getProperty(eq(Constants.BUCKET_NAME_ENV_VARIABLE))).thenReturn(bucketName);
+		Mockito.when(environment.getProperty(eq(Constants.KMS_KEY_ENV_VARIABLE))).thenReturn(ksmKey);
 
 		assertThrows(CompletionException.class, this::storeFile);
 	}
@@ -86,6 +89,7 @@ class StorageServiceImplTest {
 	void testPutRecoverableFailure() throws TimeoutException, InterruptedException {
 		when(upload.waitForUploadResult()).thenThrow(Exception.class).thenReturn(result);
 		Mockito.when(environment.getProperty(eq(Constants.BUCKET_NAME_ENV_VARIABLE))).thenReturn(bucketName);
+		Mockito.when(environment.getProperty(eq(Constants.KMS_KEY_ENV_VARIABLE))).thenReturn(ksmKey);
 
 		assertThat(storeFile()).isNotNull();
 		verify(transferManager, times(2)).upload(any(PutObjectRequest.class));
@@ -102,6 +106,15 @@ class StorageServiceImplTest {
 	@Test
 	void testPutNoBucketSpecified() throws TimeoutException, InterruptedException {
 		assertThat(storeFile()).isEmpty();
+		verify(transferManager, times(0)).upload(any(PutObjectRequest.class));
+	}
+
+	@Test
+	void testNotSpecifyKmsKey() {
+		Mockito.when(environment.getProperty(eq(Constants.BUCKET_NAME_ENV_VARIABLE))).thenReturn(bucketName);
+
+		String s3ObjectId = storeFile();
+		assertThat(s3ObjectId).isEqualTo("");
 		verify(transferManager, times(0)).upload(any(PutObjectRequest.class));
 	}
 


### PR DESCRIPTION
### Information
- JIRA story QPPCT-482.

### Changes proposed in this PR:
- We now SSE encrypt S3 uploads with the specified KMS key.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
