### PR TITLE
Remove extraneous {} from conversion error

### DIFF
--- a/commandline/src/main/java/gov/cms/qpp/conversion/ConversionFileWriterWrapper.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/ConversionFileWriterWrapper.java
@@ -1,20 +1,19 @@
 package gov.cms.qpp.conversion;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import gov.cms.qpp.conversion.encode.JsonWrapper;
+import gov.cms.qpp.conversion.model.error.AllErrors;
+import gov.cms.qpp.conversion.model.error.TransformException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-
-import gov.cms.qpp.conversion.encode.JsonWrapper;
-import gov.cms.qpp.conversion.model.error.AllErrors;
-import gov.cms.qpp.conversion.model.error.TransformException;
 
 /**
  * Calls the {@link Converter} and writes the results to a file.
@@ -67,7 +66,7 @@ public class ConversionFileWriterWrapper {
 		} catch (TransformException exception) {
 			AllErrors allErrors = exception.getDetails();
 			Path outFile = getOutputFile(source.getName(), false);
-			DEV_LOG.warn("There were errors during conversion.  Writing out errors to {} " + outFile.toString(),
+			DEV_LOG.warn("There were errors during conversion.  Writing out errors to " + outFile.toString(),
 					exception);
 			writeOutErrors(allErrors, outFile);
 		}


### PR DESCRIPTION
### Information
An enhancement.

### Changes proposed in this PR:
- Removed extraneous `{}` since it wasn't being used.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
