### PR TITLE
QPPCT-511: use large instances to run build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     working_directory: ~/qpp-conversion-tool
     docker:
       - image: circleci/openjdk:8-jdk-browsers
+    resource_class: large
     steps:
       - checkout
       - run: cd converter; mvn dependency:resolve
@@ -39,6 +40,7 @@ jobs:
     working_directory: ~/qpp-conversion-tool
     docker:
       - image: circleci/node:7.10.0-browsers
+    resource_class: large
     steps:
       - checkout
       - run: curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
@@ -56,6 +58,7 @@ jobs:
     working_directory: ~/qpp-conversion-tool
     docker:
       - image: circleci/node:7.10.0-browsers
+    resource_class: large
     steps:
       - checkout
       - run: cd frontend; rm -f yarn.lock && yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
     working_directory: ~/qpp-conversion-tool
     docker:
       - image: circleci/node:7.10.0-browsers
-    resource_class: large
     steps:
       - checkout
       - run: curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
@@ -58,7 +57,6 @@ jobs:
     working_directory: ~/qpp-conversion-tool
     docker:
       - image: circleci/node:7.10.0-browsers
-    resource_class: large
     steps:
       - checkout
       - run: cd frontend; rm -f yarn.lock && yarn


### PR DESCRIPTION
### Information
- JIRA QPPCT-511

### Changes proposed in this PR:
- Specified the use of a larger instance or resource class on which our build jobs should be executed.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
