### PR TITLE
QPPCT-548: use group instead of individual

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
@@ -152,7 +152,7 @@ public class ClinicalDocumentDecoder extends QppXmlDecoder {
 			pairs[1] = ENTITY_GROUP;
 		} else if (CPCPLUS.equalsIgnoreCase(name)) {
 			pairs[0] = CPCPLUS_PROGRAM_NAME;
-			pairs[1] = ENTITY_INDIVIDUAL;
+			pairs[1] = ENTITY_GROUP;
 		} else {
 			pairs[0] = name.toLowerCase(); //Unknown case
 			pairs[1] = ENTITY_INDIVIDUAL;

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoderTest.java
@@ -246,7 +246,7 @@ class ClinicalDocumentDecoderTest {
 				.isEqualTo(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME);
 		assertWithMessage("Clinical Document doesn't contain entity type")
 				.that(testParentNode.getValue(ClinicalDocumentDecoder.ENTITY_TYPE))
-				.isEqualTo(ClinicalDocumentDecoder.ENTITY_INDIVIDUAL);
+				.isEqualTo(ClinicalDocumentDecoder.ENTITY_GROUP);
 		assertWithMessage("Clinical Document doesn't contain national provider")
 				.that(testParentNode.getValue(MultipleTinsDecoder.NATIONAL_PROVIDER_IDENTIFIER))
 				.isEqualTo("2567891421");


### PR DESCRIPTION
### Information
- JIRA QPPCT-548

### Changes proposed in this PR:
- use "group" as a stop gap entityType

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
