### PR TITLE
Restrict memory usage with MAVEN_OPTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     working_directory: ~/qpp-conversion-tool
     docker:
       - image: circleci/openjdk:8-jdk-browsers
+    environment:
+      MAVEN_OPTS: "-Xms1G -Xmx1G"
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
### Information
- JIRA story QPPCT-536.

### Changes proposed in this PR:
- Lowers memory dedicated to the build through MAVEN_OPTS on circleci

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
