### PR TITLE
CircleCI builds use 7 GB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/openjdk:8-jdk-browsers
     environment:
-      MAVEN_OPTS: "-Xms1G -Xmx1G"
+      MAVEN_OPTS: "-Xms7G -Xmx7G"
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
### Information
- Enhancement PR

### Changes proposed in this PR:
- Tells Maven to use 7 GB out of the available 8 GB in our CircleCI runs.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.