### PR TITLE
QPPCT-414: Reduced string creation rate

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/QppXmlDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/QppXmlDecoder.java
@@ -8,16 +8,17 @@ import gov.cms.qpp.conversion.model.Registry;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.SupplementalData.SupplementalType;
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Consumer;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.jdom2.filter.Filters;
 import org.jdom2.xpath.XPathHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import static gov.cms.qpp.conversion.decode.SupplementalDataEthnicityDecoder.SUPPLEMENTAL_DATA_CODE;
 import static gov.cms.qpp.conversion.decode.SupplementalDataEthnicityDecoder.SUPPLEMENTAL_DATA_KEY;
@@ -97,7 +98,6 @@ public class QppXmlDecoder extends XmlInputDecoder {
 				Node childNode = new Node(templateId, parentNode);
 
 				childNode.setDefaultNsUri(defaultNs.getURI());
-				childNode.setPath(XPathHelper.getAbsolutePath(element));
 				
 				setNamespace(childElement, childDecoder);
 				
@@ -106,6 +106,8 @@ public class QppXmlDecoder extends XmlInputDecoder {
 				if (result == DecodeResult.TREE_ESCAPED) {
 					return DecodeResult.TREE_FINISHED;
 				}
+
+				childNode.setPath(XPathHelper.getAbsolutePath(element));
 
 				parentNode.addChildNode(childNode);
 				currentNode = childNode;

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QppOutputEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QppOutputEncoder.java
@@ -4,7 +4,6 @@ import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Encoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.Registry;
-import gov.cms.qpp.conversion.model.TemplateId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,18 +18,15 @@ public class QppOutputEncoder extends JsonOutputEncoder {
 	protected final Registry<JsonOutputEncoder> encoders;
 
 	protected final Context context;
-	private final TemplateId template;
 
 	public QppOutputEncoder(Context context) {
 		this.context = context;
 		this.encoders = context.getRegistry(Encoder.class);
-		Encoder enc = this.getClass().getAnnotation(Encoder.class);
-		template = (enc != null) ? enc.value() : TemplateId.DEFAULT;
 	}
 
 	@Override
 	public final void encode(JsonWrapper wrapper, Node node) {
-		DEV_LOG.debug("Using " + template + " encoder to encode " + node);
+		DEV_LOG.debug("Using {} to encode {}", this.getClass().getName(), node);
 		super.encode(wrapper, node);
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/NodeValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/NodeValidator.java
@@ -1,8 +1,6 @@
 package gov.cms.qpp.conversion.validate;
 
 import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.Validator;
 import gov.cms.qpp.conversion.model.error.Detail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,13 +14,7 @@ import java.util.Set;
 public abstract class NodeValidator {
 
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(NodeValidator.class);
-	private final TemplateId template;
 	private Set<Detail> details = new LinkedHashSet<>();
-
-	public NodeValidator() {
-		Validator val = this.getClass().getAnnotation(Validator.class);
-		template = (val != null) ? val.value() : TemplateId.DEFAULT;
-	}
 
 	/**
 	 * Validates a single {@link gov.cms.qpp.conversion.model.Node} and returns the list
@@ -33,7 +25,7 @@ public abstract class NodeValidator {
 	 * @see #internalValidateSingleNode(Node)
 	 */
 	public Set<Detail> validateSingleNode(final Node node) {
-		DEV_LOG.debug("Using " + template + " validator (class: " + this.getClass().getName() + ") to validate " + node);
+		DEV_LOG.debug("Using {} to validate {}", this.getClass().getName(), node);
 		internalValidateSingleNode(node);
 		return getDetails();
 	}
@@ -53,7 +45,6 @@ public abstract class NodeValidator {
 	 * @param newError The error to add to the list.
 	 */
 	protected void addValidationError(final Detail newError) {
-		logValidationError(newError);
 		getDetails().add(newError);
 	}
 
@@ -70,20 +61,6 @@ public abstract class NodeValidator {
 	 * @param node The node to validate.
 	 */
 	protected abstract void internalValidateSingleNode(final Node node);
-
-	private void logValidationError(final Detail newError) {
-		DEV_LOG.debug("Error '{}' added for templateId {}", newError, getTemplateId());
-	}
-
-	/**
-	 * Get the node validator's corresponding template id.
-	 *
-	 * @return templateId
-	 */
-	protected TemplateId getTemplateId() {
-		final Validator validator = this.getClass().getAnnotation(Validator.class);
-		return (null != validator) ? validator.value() : null;
-	}
 
 	protected Checker check(Node node) {
 		return Checker.check(node, this.getDetails());

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/AggregateCountValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/AggregateCountValidatorTest.java
@@ -1,17 +1,17 @@
 package gov.cms.qpp.conversion.validate;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
-import java.util.Set;
-
-import org.junit.jupiter.api.Test;
-
 import gov.cms.qpp.conversion.decode.AggregateCountDecoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.Validator;
 import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertWithMessage;
 
 
 class AggregateCountValidatorTest {
@@ -23,7 +23,7 @@ class AggregateCountValidatorTest {
         AggregateCountValidator validator = new AggregateCountValidator();
 
         assertWithMessage("validator and node are compatible")
-                .that(validator.getTemplateId()).isEqualTo(aggregateCountNode.getType());
+                .that(validator.getClass().getAnnotation(Validator.class).value()).isEqualTo(aggregateCountNode.getType());
     }
 
     @Test


### PR DESCRIPTION
### Information
- JIRA story QPPCT-414.

### Changes proposed in this PR:
- While triaging calls to `new Reflections(...)` as per the QPPCT-414 description, I noticed that a lot of strings being creating at certain logger debug calls in high traffic methods.
- Due to the string concatenation in the logger debug statements, strings were being created even though debug logging was disabled.  Strings are now created only when debug logging is enabled.
- Deleted unused code from the debug logging refactor.
- Moved the memory expensive `XPathHelper#getAbsolutePath` call to below the `DecodeResult.TREE_ESCAPED` check.  This results in the call occurring only if the child node that was just decoded will stick around.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.