### PR TITLE
QPPCT-495: Specify size for S3 uploads

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/Converter.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/Converter.java
@@ -259,14 +259,29 @@ public class Converter {
 			qppValidationDetails = details;
 		}
 
+		/**
+		 * Get the {@link Source} for the input to the converter.
+		 *
+		 * @return {@link Source} for the input.
+		 */
 		public Source getQrdaSource() {
 			return source;
 		}
 
+		/**
+		 * Get the {@link Source} for the output.
+		 *
+		 * @return {@link Source} for the output.
+		 */
 		public Source getQppSource() {
 			return getEncoded().toSource();
 		}
 
+		/**
+		 * Get the {@link Source} for the conversion validation errors.
+		 *
+		 * @return {@link Source} for the validation errors.
+		 */
 		public Source getValidationErrorsSource() {
 			try {
 				byte[] validationErrorBytes = mapper.writeValueAsBytes(reportDetails);
@@ -276,6 +291,11 @@ public class Converter {
 			}
 		}
 
+		/**
+		 * Get the {@link Source} for the raw QPP validation errors (if any).
+		 *
+		 * @return {@link Source} for the raw QPP validation errors.
+		 */
 		public Source getRawValidationErrorsOrEmptySource() {
 			String raw = (qppValidationDetails != null) ? qppValidationDetails : "";
 			byte[] rawValidationErrorBytes = raw.getBytes(StandardCharsets.UTF_8);

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -11,10 +11,11 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import gov.cms.qpp.conversion.InputStreamSupplierSource;
+import gov.cms.qpp.conversion.Source;
 import gov.cms.qpp.conversion.model.Node;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -529,8 +530,9 @@ public class JsonWrapper {
 	 *
 	 * @return input stream containing serialized json
 	 */
-	public InputStream contentStream() {
-		return new ByteArrayInputStream(toString().getBytes(StandardCharsets.UTF_8));
+	public Source toSource() {
+		byte[] qppBytes = toString().getBytes(StandardCharsets.UTF_8);
+		return new InputStreamSupplierSource("QPP", () -> new ByteArrayInputStream(qppBytes), qppBytes.length);
 	}
 
 	/**

--- a/converter/src/test/java/gov/cms/qpp/conversion/ConversionReportTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/ConversionReportTest.java
@@ -62,14 +62,14 @@ class ConversionReportTest {
 				new PathSource(Paths.get("../qrda-files/valid-QRDA-III-latest.xml")));
 		Converter.ConversionReport aReport = converter.getReport();
 		aReport.setRawValidationDetails("meep");
-		String details = IOUtils.toString(aReport.streamRawValidationDetails(), "UTF-8");
+		String details = IOUtils.toString(aReport.getRawValidationErrorsOrEmptySource().toInputStream(), "UTF-8");
 
 		assertThat(details).isEqualTo("meep");
 	}
 
 	@Test
 	void emptyValidationErrorDetails() throws IOException {
-		String details = IOUtils.toString(errorReport.streamRawValidationDetails(), "UTF-8");
+		String details = IOUtils.toString(errorReport.getRawValidationErrorsOrEmptySource().toInputStream(), "UTF-8");
 
 		assertThat(details).isEmpty();
 	}
@@ -94,16 +94,16 @@ class ConversionReportTest {
 		field.setAccessible(true);
 		field.set(badReport, mockMapper);
 
-		assertThrows(EncodeException.class, badReport::streamDetails);
+		assertThrows(EncodeException.class, badReport::getValidationErrorsSource);
 	}
 
 	@Test
-	void getGoodReportDetails() throws NoSuchFieldException, IllegalAccessException, JsonProcessingException {
-		assertThat(errorReport.streamDetails()).isNotNull();
+	void getGoodReportDetails() {
+		assertThat(errorReport.getValidationErrorsSource().toInputStream()).isNotNull();
 	}
 
 	@Test
-	void getErrorStream() throws IOException {
+	void getErrorStream() {
 		Converter converter = new Converter(
 				new PathSource(Paths.get("../qrda-files/valid-QRDA-III-latest.xml")));
 		Converter.ConversionReport badReport = converter.getReport();
@@ -113,17 +113,7 @@ class ConversionReportTest {
 		errors.addError(error);
 		badReport.setReportDetails(errors);
 
-		AllErrors echo = JsonHelper.readJson(badReport.streamDetails(), AllErrors.class);
+		AllErrors echo = JsonHelper.readJson(badReport.getValidationErrorsSource().toInputStream(), AllErrors.class);
 		assertThat(echo.toString()).isEqualTo(errors.toString());
-	}
-
-	@Test
-	void getFilename() {
-		assertThat(report.getFilename()).isEqualTo("valid-QRDA-III-latest.xml");
-	}
-
-	@Test
-	void getFileInput() {
-		assertThat(report.getFileInput()).isNotNull();
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -595,7 +595,7 @@ class JsonWrapperTest {
 	@SuppressWarnings("unchecked")
 	void testContentStream() {
 		objectObjWrapper.putString("meep", "mawp");
-		InputStream content = objectObjWrapper.contentStream();
+		InputStream content = objectObjWrapper.toSource().toInputStream();
 		Map<String, String> contentMap = JsonHelper.readJson(content, Map.class);
 		assertThat(contentMap.get("meep")).isEqualTo("mawp");
 	}

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AuditServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AuditServiceImpl.java
@@ -109,6 +109,11 @@ public class AuditServiceImpl implements AuditService {
 		return allWrites.whenComplete((nada, thrown) -> persist(metadata, thrown));
 	}
 
+	/**
+	 * Determines whether the no audit environment variable is set.
+	 *
+	 * @return Whether to do auditing or not.
+	 */
 	private boolean noAudit() {
 		String noAudit = environment.getProperty(Constants.NO_AUDIT_ENV_VARIABLE);
 		boolean returnValue = noAudit != null && !noAudit.isEmpty();
@@ -120,17 +125,38 @@ public class AuditServiceImpl implements AuditService {
 		return returnValue;
 	}
 
+	/**
+	 * Creates a baseline {@link Metadata} object.
+	 *
+	 * @param report The report from a conversion.
+	 * @param outcome The high level outcome of a conversion.
+	 * @return A new {@link Metadata}.
+	 */
 	private Metadata initMetadata(Converter.ConversionReport report, MetadataHelper.Outcome outcome) {
 		Metadata metadata = MetadataHelper.generateMetadata(report.getDecoded(), outcome);
 		metadata.setFileName(report.getQrdaSource().getName());
 		return metadata;
 	}
 
+	/**
+	 * Calls the {@link StorageService} to store an {@link InputStream}.
+	 *
+	 * @param content The {@link InputStream} to store.
+	 * @param size The size of the {@link InputStream}.
+	 * @return A {@link CompletableFuture} that represents storing the information.
+	 */
 	private CompletableFuture<String> storeContent(InputStream content, long size) {
 		UUID key = UUID.randomUUID();
 		return storageService.store(key.toString(), content, size);
 	}
 
+	/**
+	 * Calls the {@link DbService} to store the {@link Metadata} in a database.
+	 *
+	 * @param metadata The {@link Metadata} to save.
+	 * @param thrown A {@link Throwable} from a previous step.
+	 * @return A {@link CompletableFuture} that represents saving {@link Metadata} to a database.
+	 */
 	private CompletableFuture<Metadata> persist(Metadata metadata, Throwable thrown) {
 		if (thrown != null) {
 			throw new AuditException(thrown);

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AuditServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AuditServiceImpl.java
@@ -51,8 +51,8 @@ public class AuditServiceImpl implements AuditService {
 		Source qppSource = conversionReport.getQppSource();
 
 		CompletableFuture<Void> allWrites = CompletableFuture.allOf(
-				storeContent(qrdaSource.toInputStream(), qrdaSource.getSize()).thenAccept(metadata::setSubmissionLocator),
-				storeContent(qppSource.toInputStream(), qppSource.getSize()).thenAccept(metadata::setQppLocator));
+				storeContent(qrdaSource).thenAccept(metadata::setSubmissionLocator),
+				storeContent(qppSource).thenAccept(metadata::setQppLocator));
 		return allWrites.whenComplete((nada, thrown) -> persist(metadata, thrown));
 	}
 
@@ -76,8 +76,8 @@ public class AuditServiceImpl implements AuditService {
 		Source validationErrorSource = conversionReport.getValidationErrorsSource();
 
 		CompletableFuture<Void> allWrites = CompletableFuture.allOf(
-				storeContent(validationErrorSource.toInputStream(), validationErrorSource.getSize()).thenAccept(metadata::setConversionErrorLocator),
-				storeContent(qrdaSource.toInputStream(), qrdaSource.getSize()).thenAccept(metadata::setSubmissionLocator));
+				storeContent(validationErrorSource).thenAccept(metadata::setConversionErrorLocator),
+				storeContent(qrdaSource).thenAccept(metadata::setSubmissionLocator));
 		return allWrites.whenComplete((nada, thrown) -> persist(metadata, thrown));
 	}
 
@@ -102,10 +102,10 @@ public class AuditServiceImpl implements AuditService {
 
 		Metadata metadata = initMetadata(conversionReport, Outcome.VALIDATION_ERROR);
 		CompletableFuture<Void> allWrites = CompletableFuture.allOf(
-				storeContent(rawValidationErrorSource.toInputStream(), rawValidationErrorSource.getSize()).thenAccept(metadata::setRawValidationErrorLocator),
-				storeContent(validationErrorSource.toInputStream(), validationErrorSource.getSize()).thenAccept(metadata::setValidationErrorLocator),
-				storeContent(qppSource.toInputStream(), qppSource.getSize()).thenAccept(metadata::setQppLocator),
-				storeContent(qrdaSource.toInputStream(), qrdaSource.getSize()).thenAccept(metadata::setSubmissionLocator));
+				storeContent(rawValidationErrorSource).thenAccept(metadata::setRawValidationErrorLocator),
+				storeContent(validationErrorSource).thenAccept(metadata::setValidationErrorLocator),
+				storeContent(qppSource).thenAccept(metadata::setQppLocator),
+				storeContent(qrdaSource).thenAccept(metadata::setSubmissionLocator));
 		return allWrites.whenComplete((nada, thrown) -> persist(metadata, thrown));
 	}
 
@@ -141,13 +141,12 @@ public class AuditServiceImpl implements AuditService {
 	/**
 	 * Calls the {@link StorageService} to store an {@link InputStream}.
 	 *
-	 * @param content The {@link InputStream} to store.
-	 * @param size The size of the {@link InputStream}.
+	 * @param sourceToStore The {@link Source} to store.
 	 * @return A {@link CompletableFuture} that represents storing the information.
 	 */
-	private CompletableFuture<String> storeContent(InputStream content, long size) {
+	private CompletableFuture<String> storeContent(Source sourceToStore) {
 		UUID key = UUID.randomUUID();
-		return storageService.store(key.toString(), content, size);
+		return storageService.store(key.toString(), sourceToStore.toInputStream(), sourceToStore.getSize());
 	}
 
 	/**

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageService.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageService.java
@@ -3,7 +3,6 @@ package gov.cms.qpp.conversion.api.services;
 
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
-import jdk.internal.util.xml.impl.Input;
 
 /**
  * Interface to store an {@link InputStream} in S3.
@@ -15,6 +14,7 @@ public interface StorageService {
 	 *
 	 * @param keyName The requested key name for the object.
 	 * @param inStream The {@link InputStream} to write out to an object in S3.
+	 * @param size The size of the {@link InputStream}.
 	 * @return A {@link CompletableFuture} that will eventually contain the S3 object key.
 	 */
 	CompletableFuture<String> store(String keyName, InputStream inStream, long size);

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageService.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageService.java
@@ -16,5 +16,5 @@ public interface StorageService {
 	 * @param inStream The {@link InputStream} to write out to an object in S3.
 	 * @return A {@link CompletableFuture} that will eventually contain the S3 object key.
 	 */
-	CompletableFuture<String> store(String keyName, InputStream inStream);
+	CompletableFuture<String> store(String keyName, InputStream inStream, long size);
 }

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageServiceImpl.java
@@ -11,13 +11,14 @@ import com.amazonaws.services.s3.transfer.Upload;
 import com.google.common.base.Strings;
 import gov.cms.qpp.conversion.api.exceptions.UncheckedInterruptedException;
 import gov.cms.qpp.conversion.api.model.Constants;
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Used to store an {@link InputStream} in S3.
@@ -41,6 +42,7 @@ public class StorageServiceImpl extends InOrderActionService<PutObjectRequest, S
 	 *
 	 * @param keyName The requested key name for the object.
 	 * @param inStream The {@link InputStream} to write out to an object in S3.
+	 * @param size The size of the {@link InputStream}.
 	 * @return A {@link CompletableFuture} that will eventually contain the S3 object key.
 	 */
 	@Override

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageServiceImpl.java
@@ -39,7 +39,7 @@ public class StorageServiceImpl extends InOrderActionService<PutObjectRequest, S
 	 * @return A {@link CompletableFuture} that will eventually contain the S3 object key.
 	 */
 	@Override
-	public CompletableFuture<String> store(String keyName, InputStream inStream) {
+	public CompletableFuture<String> store(String keyName, InputStream inStream, long size) {
 		final String bucketName = environment.getProperty(Constants.BUCKET_NAME_ENV_VARIABLE);
 		final String kmsKey = environment.getProperty(Constants.KMS_KEY_ENV_VARIABLE);
 		if (Strings.isNullOrEmpty(bucketName) || Strings.isNullOrEmpty(kmsKey)) {
@@ -47,7 +47,10 @@ public class StorageServiceImpl extends InOrderActionService<PutObjectRequest, S
 			return CompletableFuture.completedFuture("");
 		}
 
-		PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, keyName, inStream, new ObjectMetadata())
+		ObjectMetadata s3ObjectMetadata = new ObjectMetadata();
+		s3ObjectMetadata.setContentLength(size);
+
+		PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, keyName, inStream, s3ObjectMetadata)
 			.withSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(kmsKey));
 
 		API_LOG.info("Writing object {} to S3 bucket {}", keyName, bucketName);

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/StorageServiceImplIntegration.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/StorageServiceImplIntegration.java
@@ -94,7 +94,7 @@ public class StorageServiceImplIntegration {
 		when(environment.getProperty(eq(Constants.BUCKET_NAME_ENV_VARIABLE))).thenReturn(bucketName);
 
 		CompletableFuture<String> result = underTest.store(
-				key, new ByteArrayInputStream(content.getBytes()));
+				key, new ByteArrayInputStream(content.getBytes()), content.getBytes().length);
 
 		result.whenComplete((outcome, ex) -> {
 			waiter.assertEquals(content, getObjectContent(key));

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/StorageServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/StorageServiceImplTest.java
@@ -119,8 +119,9 @@ class StorageServiceImplTest {
 	}
 
 	private String storeFile() {
+		byte[] testBytes = "test file content".getBytes();
 		CompletableFuture<String> storeResult = underTest.store(
-				"submission", new ByteArrayInputStream("test file content".getBytes()));
+				"submission", new ByteArrayInputStream(testBytes), testBytes.length);
 		return storeResult.join();
 	}
 }


### PR DESCRIPTION
### Information
- JIRA story QPPCT-495.

### Changes proposed in this PR:
- Uses the size specified in `Source` to specify the length to the `StorageService`.
- The warnings no longer appear and the log saying the S3 SDK will load the file into memory.
- Validated that the files are still uploaded correctly and not truncated.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.