### PR TITLE
Finish junit 5 conversion (part 1 of 2)

### DIFF
--- a/converter/src/test/java/gov/cms/qpp/acceptance/SubmissionIntegrationTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/SubmissionIntegrationTest.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,8 +27,6 @@ import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assume.assumeTrue;
-
 
 class SubmissionIntegrationTest {
 
@@ -43,7 +42,7 @@ class SubmissionIntegrationTest {
 		request.setHeader("qpp-taxpayer-identification-number", "000777777");
 		request.setHeader("Content-Type", "application/json");
 		HttpResponse response = client.execute(request);
-		assumeTrue("Submissions api is down", endpointIsUp(response));
+		Assumptions.assumeTrue(endpointIsUp(response), "Submissions api is down");
 
 		try {
 			List<Map<?, ?>> subs = JsonHelper.readJsonAtJsonPath(response.getEntity().getContent(),
@@ -69,7 +68,7 @@ class SubmissionIntegrationTest {
 	@Test
 	void testSubmissionApiPostSuccess() throws IOException {
 		HttpResponse httpResponse = servicePost(qpp);
-		assumeTrue("Submissions api is down", endpointIsUp(httpResponse));
+		Assumptions.assumeTrue(endpointIsUp(httpResponse), "Submissions api is down");
 		cleanUp(httpResponse);
 
 		assertThat(getStatus(httpResponse)).isEqualTo(200);
@@ -81,7 +80,7 @@ class SubmissionIntegrationTest {
 		Map<String, Object> obj = (Map<String, Object>) qpp.getObject();
 		obj.remove("performanceYear");
 		HttpResponse httpResponse = servicePost(qpp);
-		assumeTrue("Submissions api is down", endpointIsUp(httpResponse));
+		Assumptions.assumeTrue(endpointIsUp(httpResponse), "Submissions api is down");
 
 		assertWithMessage("QPP submission should be unprocessable")
 				.that(getStatus(httpResponse))

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdMultiEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdMultiEncoderTest.java
@@ -1,21 +1,22 @@
 package gov.cms.qpp.conversion.encode;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-
-import static com.google.common.truth.Truth.assertWithMessage;
-
-public class QualityMeasureIdMultiEncoderTest {
+class QualityMeasureIdMultiEncoderTest {
 
 	private static final String REQUIRE_POPULATION_TOTAL = "Must have a required eligiblePopulation";
 	private static final String REQUIRE_PERFORMANCE_MET = "Must have a required performanceMet";
@@ -46,18 +47,18 @@ public class QualityMeasureIdMultiEncoderTest {
 	private JsonWrapper wrapper;
 	private QualityMeasureIdEncoder encoder;
 
-	@BeforeClass
-	public static  void setUpCustomMeasureData() {
+	@BeforeAll
+	static  void setUpCustomMeasureData() {
 		MeasureConfigs.setMeasureDataFile("test-multi-prop-measure-data.json");
 	}
 
-	@AfterClass
-	public static void resetMeasuresData() {
+	@AfterAll
+	static void resetMeasuresData() {
 		MeasureConfigs.setMeasureDataFile(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
 	}
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		qualityMeasureId = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2);
 		qualityMeasureId.putValue(MEASURE_ID, "test1");
 
@@ -120,7 +121,7 @@ public class QualityMeasureIdMultiEncoderTest {
 	}
 
 	@Test
-	public void testInternalEncode() {
+	void testInternalEncode() {
 		qualityMeasureId.addChildNodes(
 				eligiblePopulationNode, eligiblePopulationExceptionNode,
 				eligiblePopulationExclusionNode, numeratorNode, denominatorNode,
@@ -138,7 +139,7 @@ public class QualityMeasureIdMultiEncoderTest {
 	}
 
 	@Test
-	public void testNullSubPopulations() {
+	void testNullSubPopulations() {
 		qualityMeasureId.putValue(MEASURE_ID, "test2");
 		qualityMeasureId.addChildNodes(eligiblePopulationNode, eligiblePopulationExceptionNode,
 				numeratorNode, denominatorNode, eligiblePopulationNodeTwo,

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/AciMeasurePerformedRnRValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/AciMeasurePerformedRnRValidatorTest.java
@@ -1,24 +1,25 @@
 package gov.cms.qpp.conversion.validate;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
-import org.junit.Before;
-import org.junit.Test;
 
-import java.util.Set;
-
-import static com.google.common.truth.Truth.assertWithMessage;
-
-public class AciMeasurePerformedRnRValidatorTest {
+class AciMeasurePerformedRnRValidatorTest {
 
 	private AciMeasurePerformedRnRValidator validator;
 	private Node aciMeasurePerformedRnRNode;
 
-	@Before
-	public void init() {
+	@BeforeEach
+	void init() {
 		validator = new AciMeasurePerformedRnRValidator();
 
 		aciMeasurePerformedRnRNode = new Node(TemplateId.ACI_MEASURE_PERFORMED_REFERENCE_AND_RESULTS);
@@ -29,14 +30,14 @@ public class AciMeasurePerformedRnRValidatorTest {
 	}
 
 	@Test
-	public void testValidateGoodData() throws Exception {
+	void testValidateGoodData() throws Exception {
 		Set<Detail> errors = run();
 		assertWithMessage("no errors should be present")
 				.that(errors).isEmpty();
 	}
 
 	@Test
-	public void testWithNoMeasureId() throws Exception {
+	void testWithNoMeasureId() throws Exception {
 		aciMeasurePerformedRnRNode.removeValue("measureId");
 		Set<Detail> errors = run();
 		assertWithMessage("Should result in a MEASURE_ID_IS_REQUIRED error")
@@ -45,7 +46,7 @@ public class AciMeasurePerformedRnRValidatorTest {
 	}
 
 	@Test
-	public void testWithNoChildren() throws Exception {
+	void testWithNoChildren() throws Exception {
 		aciMeasurePerformedRnRNode.getChildNodes().clear();
 		Set<Detail> errors = run();
 		assertWithMessage("Validation error size should be 1")

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/AciSectionValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/AciSectionValidatorTest.java
@@ -1,31 +1,28 @@
 package gov.cms.qpp.conversion.validate;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.util.Set;
+class AciSectionValidatorTest {
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
-public class AciSectionValidatorTest {
 	private static final String VALID_ACI_MEASURE = "ACI_EP_1";
 	private Node reportingParamNode;
 	private Node aciNumeratorDenominatorNode;
 	private Node measureNode;
 	private Node aciSectionNode;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
-	@Before
-	public void setUpAciSectionNode() {
+	@BeforeEach
+	void setUpAciSectionNode() {
 		reportingParamNode = new Node(TemplateId.REPORTING_PARAMETERS_ACT);
 		aciNumeratorDenominatorNode = new Node(TemplateId.ACI_NUMERATOR_DENOMINATOR);
 		measureNode = new Node(TemplateId.MEASURE_PERFORMED);
@@ -36,7 +33,7 @@ public class AciSectionValidatorTest {
 	}
 
 	@Test
-	public void testNoReportingParamPresent() {
+	void testNoReportingParamPresent() {
 		aciSectionNode.addChildNodes(aciNumeratorDenominatorNode, measureNode);
 
 		AciSectionValidator aciSectionValidator = new AciSectionValidator();
@@ -49,7 +46,7 @@ public class AciSectionValidatorTest {
 	}
 
 	@Test
-	public void testTooManyReportingParams() {
+	void testTooManyReportingParams() {
 		Node invalidReportingParamNode = new Node(TemplateId.REPORTING_PARAMETERS_ACT);
 		aciSectionNode.addChildNodes(reportingParamNode, invalidReportingParamNode, aciNumeratorDenominatorNode, measureNode);
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidatorTest.java
@@ -1,20 +1,22 @@
 package gov.cms.qpp.conversion.validate;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
-import org.junit.Before;
-import org.junit.Test;
 
-import static com.google.common.truth.Truth.assertWithMessage;
+class CpcQualityMeasureIdValidatorTest {
 
-public class CpcQualityMeasureIdValidatorTest {
 	private CpcQualityMeasureIdValidator validator;
 	private Node testNode;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		validator = new CpcQualityMeasureIdValidator();
 
 		testNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2);
@@ -22,7 +24,7 @@ public class CpcQualityMeasureIdValidatorTest {
 	}
 
 	@Test
-	public void testPerformanceCountWithNoErrors() {
+	void testPerformanceCountWithNoErrors() {
 		addAnyNumberOfChildren(2);
 		validator.internalValidateSingleNode(testNode);
 
@@ -32,7 +34,7 @@ public class CpcQualityMeasureIdValidatorTest {
 	}
 
 	@Test
-	public void testPerformanceCountWithIncreasedSizeError() {
+	void testPerformanceCountWithIncreasedSizeError() {
 		addAnyNumberOfChildren(3);
 		validator.internalValidateSingleNode(testNode);
 
@@ -42,7 +44,7 @@ public class CpcQualityMeasureIdValidatorTest {
 	}
 
 	@Test
-	public void testPerformanceCountWithDecreasedSizeError() {
+	void testPerformanceCountWithDecreasedSizeError() {
 		addAnyNumberOfChildren(1);
 		validator.internalValidateSingleNode(testNode);
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/PerformanceRateValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/PerformanceRateValidatorTest.java
@@ -2,8 +2,8 @@ package gov.cms.qpp.conversion.validate;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder;
 import gov.cms.qpp.conversion.model.Node;
@@ -11,26 +11,27 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 
-public class PerformanceRateValidatorTest {
+class PerformanceRateValidatorTest {
+
 	private PerformanceRateValidator performanceRateValidator;
 	private Node node;
 
-	@Before
-	public  void setup() {
+	@BeforeEach
+	void setup() {
 		performanceRateValidator = new PerformanceRateValidator();
 		node = new Node(TemplateId.PERFORMANCE_RATE_PROPORTION_MEASURE);
 		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "0");
 	}
 
 	@Test
-	public void testZeroValue() {
+	void testZeroValue() {
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
 				.that(performanceRateValidator.getDetails()).isEmpty();
 	}
 
 	@Test
-	public void testOneValue() {
+	void testOneValue() {
 		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "1");
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
@@ -38,7 +39,7 @@ public class PerformanceRateValidatorTest {
 	}
 
 	@Test
-	public void testNAValue() {
+	void testNAValue() {
 		node.putValue(PerformanceRateProportionMeasureDecoder.NULL_PERFORMANCE_RATE, "NA");
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
@@ -46,7 +47,7 @@ public class PerformanceRateValidatorTest {
 	}
 
 	@Test
-	public void testNegativeValue() {
+	void testNegativeValue() {
 		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "-1");
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
@@ -55,7 +56,7 @@ public class PerformanceRateValidatorTest {
 	}
 
 	@Test
-	public void testInvalidValue() {
+	void testInvalidValue() {
 		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "2");
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
@@ -64,7 +65,7 @@ public class PerformanceRateValidatorTest {
 	}
 
 	@Test
-	public void testInvalidStringValue() {
+	void testInvalidStringValue() {
 		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "Inval");
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureSectionValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureSectionValidatorTest.java
@@ -4,8 +4,8 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
@@ -13,18 +13,19 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 
-public class QualityMeasureSectionValidatorTest {
+class QualityMeasureSectionValidatorTest {
+
 	private Node reportingParameterNode;
 	private Node qualityMeasureSectionNode;
 
-	@Before
-	public void setUpQualityMeasureSection() {
+	@BeforeEach
+	void setUpQualityMeasureSection() {
 		reportingParameterNode = new Node(TemplateId.REPORTING_PARAMETERS_ACT);
 		qualityMeasureSectionNode = new Node(TemplateId.MEASURE_SECTION_V2);
 	}
 
 	@Test
-	public void validQualityMeasureSectionValidation() {
+	void validQualityMeasureSectionValidation() {
 		qualityMeasureSectionNode.addChildNode(reportingParameterNode);
 
 		Set<Detail> errors = validateQualityMeasureSection();
@@ -34,7 +35,7 @@ public class QualityMeasureSectionValidatorTest {
 	}
 
 	@Test
-	public void testMissingReportingParams() {
+	void testMissingReportingParams() {
 		Set<Detail> errors = validateQualityMeasureSection();
 
 		assertWithMessage("Must contain correct error")
@@ -44,7 +45,7 @@ public class QualityMeasureSectionValidatorTest {
 	}
 
 	@Test
-	public void testTooManyReportingParams() {
+	void testTooManyReportingParams() {
 		Node secondReportingParameterNode = new Node(TemplateId.REPORTING_PARAMETERS_ACT);
 		qualityMeasureSectionNode.addChildNodes(reportingParameterNode, secondReportingParameterNode);
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/ExceptionHandlerControllerV1Test.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/ExceptionHandlerControllerV1Test.java
@@ -1,35 +1,37 @@
 package gov.cms.qpp.conversion.api.controllers.v1;
 
-import gov.cms.qpp.conversion.Converter;
-import gov.cms.qpp.conversion.api.exceptions.NoFileInDatabaseException;
-import gov.cms.qpp.conversion.PathSource;
-import gov.cms.qpp.conversion.api.services.AuditService;
-import gov.cms.qpp.conversion.api.services.CpcFileServiceImpl;
-import gov.cms.qpp.conversion.model.error.AllErrors;
-import gov.cms.qpp.conversion.model.error.QppValidationException;
-import gov.cms.qpp.conversion.model.error.TransformException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.CompletableFuture;
-
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ExceptionHandlerControllerV1Test {
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import gov.cms.qpp.conversion.Converter;
+import gov.cms.qpp.conversion.PathSource;
+import gov.cms.qpp.conversion.api.exceptions.NoFileInDatabaseException;
+import gov.cms.qpp.conversion.api.services.AuditService;
+import gov.cms.qpp.conversion.api.services.CpcFileServiceImpl;
+import gov.cms.qpp.conversion.model.error.AllErrors;
+import gov.cms.qpp.conversion.model.error.QppValidationException;
+import gov.cms.qpp.conversion.model.error.TransformException;
+import gov.cms.qpp.test.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExceptionHandlerControllerV1Test {
+
 	private static Converter.ConversionReport report;
 	private static AllErrors allErrors = new AllErrors();
 
@@ -39,21 +41,21 @@ public class ExceptionHandlerControllerV1Test {
 	@Mock
 	private AuditService auditService;
 
-	@BeforeClass
-	public static void setup() {
+	@BeforeAll
+	static void setup() {
 		Path path = Paths.get("../qrda-files/valid-QRDA-III-latest.xml");
 		report = new Converter(new PathSource(path)).getReport();
 		report.setReportDetails(allErrors);
 	}
 
-	@Before
-	public void before() {
+	@BeforeEach
+	void before() {
 		when(auditService.failConversion(any(Converter.ConversionReport.class)))
 				.thenReturn(CompletableFuture.completedFuture(null));
 	}
 
 	@Test
-	public void testTransformExceptionStatusCode() {
+	void testTransformExceptionStatusCode() {
 		TransformException exception =
 				new TransformException("test transform exception", new NullPointerException(), report);
 
@@ -65,7 +67,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testTransformExceptionHeaderContentType() {
+	void testTransformExceptionHeaderContentType() {
 		TransformException exception =
 				new TransformException("test transform exception", new NullPointerException(), report);
 
@@ -76,7 +78,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testTransformExceptionBody() {
+	void testTransformExceptionBody() {
 		TransformException exception =
 				new TransformException("test transform exception", new NullPointerException(), report);
 
@@ -85,7 +87,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testQppValidationExceptionStatusCode() {
+	void testQppValidationExceptionStatusCode() {
 		QppValidationException exception =
 				new QppValidationException("test transform exception", new NullPointerException(), report);
 
@@ -97,7 +99,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testQppValidationExceptionHeaderContentType() {
+	void testQppValidationExceptionHeaderContentType() {
 		QppValidationException exception =
 				new QppValidationException("test transform exception", new NullPointerException(), report);
 
@@ -108,7 +110,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testQppValidationExceptionBody() {
+	void testQppValidationExceptionBody() {
 		QppValidationException exception =
 				new QppValidationException("test transform exception", new NullPointerException(), report);
 
@@ -117,7 +119,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testFileNotFoundExceptionStatusCode() {
+	void testFileNotFoundExceptionStatusCode() {
 		NoFileInDatabaseException exception =
 				new NoFileInDatabaseException(CpcFileServiceImpl.FILE_NOT_FOUND);
 
@@ -129,7 +131,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testFileNotFoundExceptionHeaderContentType() {
+	void testFileNotFoundExceptionHeaderContentType() {
 		NoFileInDatabaseException exception =
 				new NoFileInDatabaseException(CpcFileServiceImpl.FILE_NOT_FOUND);
 
@@ -140,7 +142,7 @@ public class ExceptionHandlerControllerV1Test {
 	}
 
 	@Test
-	public void testFileNotFoundExceptionBody() {
+	void testFileNotFoundExceptionBody() {
 		NoFileInDatabaseException exception =
 				new NoFileInDatabaseException(CpcFileServiceImpl.FILE_NOT_FOUND);
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/integration/QrdaRestIntegration.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/integration/QrdaRestIntegration.java
@@ -1,32 +1,33 @@
 package gov.cms.qpp.conversion.api.integration;
 
-import gov.cms.qpp.conversion.api.model.Constants;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import gov.cms.qpp.conversion.api.model.Constants;
 
 @SpringBootTest
 @WebAppConfiguration
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @TestPropertySource(locations = "classpath:test.properties")
 public class QrdaRestIntegration {
 
@@ -35,19 +36,19 @@ public class QrdaRestIntegration {
 
 	private MockMvc mockMvc;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 	}
 
 	@Test
-	public void shouldBeHealthy() throws Exception {
+	void shouldBeHealthy() throws Exception {
 		mockMvc.perform(MockMvcRequestBuilders.request(HttpMethod.GET, "/health"))
 				.andExpect(status().is(200));
 	}
 
 	@Test
-	public void testDefaultValidQpp() throws Exception {
+	void testDefaultValidQpp() throws Exception {
 		MockMultipartFile qrda3File = new MockMultipartFile("file", Files.newInputStream(Paths.get("../qrda-files/valid-QRDA-III-latest.xml")));
 		mockMvc.perform(MockMvcRequestBuilders
 			.fileUpload("/").file(qrda3File))
@@ -57,7 +58,7 @@ public class QrdaRestIntegration {
 	}
 
 	@Test
-	public void testValidQpp() throws Exception {
+	void testValidQpp() throws Exception {
 		MockMultipartFile qrda3File = new MockMultipartFile("file", Files.newInputStream(Paths.get("../qrda-files/valid-QRDA-III-latest.xml")));
 		mockMvc.perform(MockMvcRequestBuilders
 				.fileUpload("/").file(qrda3File).accept(Constants.V1_API_ACCEPT))
@@ -68,7 +69,7 @@ public class QrdaRestIntegration {
 
 
 	@Test
-	public void testInvalidQpp() throws Exception {
+	void testInvalidQpp() throws Exception {
 		MockMultipartFile qrda3File = new MockMultipartFile("file", Files.newInputStream(Paths.get("../qrda-files/not-a-QDRA-III-file.xml")));
 		mockMvc.perform(MockMvcRequestBuilders
 			.fileUpload("/").file(qrda3File))
@@ -78,7 +79,7 @@ public class QrdaRestIntegration {
 	}
 
 	@Test
-	public void testInvalidAcceptHeader() throws Exception {
+	void testInvalidAcceptHeader() throws Exception {
 		MockMultipartFile qrda3File = new MockMultipartFile("file", Files.newInputStream(Paths.get("../qrda-files/not-a-QDRA-III-file.xml")));
 		mockMvc.perform(MockMvcRequestBuilders
 				.fileUpload("/").file(qrda3File)
@@ -87,7 +88,7 @@ public class QrdaRestIntegration {
 	}
 
 	@Test
-	public void shouldFailForSubmissionApiValidation() throws Exception {
+	void shouldFailForSubmissionApiValidation() throws Exception {
 		String file = "../converter/src/test/resources/cpc_plus/CPCPlus_CMSPrgrm_LowerCase_SampleQRDA-III-success.xml";
 		MockMultipartFile qrda3File = new MockMultipartFile("file", Files.newInputStream(Paths.get(file)));
 		mockMvc.perform(MockMvcRequestBuilders

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/AnyOrderAsyncActionServiceTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/AnyOrderAsyncActionServiceTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -53,7 +52,7 @@ class AnyOrderAsyncActionServiceTest {
 	void testAsynchronousActionIsCalled() {
 		runSimpleScenario(0);
 
-		assertTrue("The asynchronousAction was not called.", objectUnderTest.asynchronousActionCalled.get());
+		assertThat(objectUnderTest.asynchronousActionCalled.get()).isTrue();
 	}
 
 	@Test

--- a/rest-logging/src/test/java/gov/cms/qpp/conversion/logging/AttachmentHashPartConverterTest.java
+++ b/rest-logging/src/test/java/gov/cms/qpp/conversion/logging/AttachmentHashPartConverterTest.java
@@ -1,32 +1,33 @@
 package gov.cms.qpp.conversion.logging;
 
-import ch.qos.logback.classic.spi.LoggingEvent;
-import gov.cms.qpp.conversion.logging.AttachmentHashPartConverter;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.Part;
-import java.io.IOException;
-
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-public class AttachmentHashPartConverterTest {
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Part;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+class AttachmentHashPartConverterTest {
+
 	private AttachmentHashPartConverter converter;
 	private LoggingEvent event = new LoggingEvent();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		converter = spy(new AttachmentHashPartConverter());
 	}
 
 	@Test
-	public void convertPartlessTest() throws IOException, ServletException {
+	void convertPartlessTest() throws IOException, ServletException {
 		doReturn(null).when(converter).getPart();
 		String result = converter.convert(event);
 
@@ -35,7 +36,7 @@ public class AttachmentHashPartConverterTest {
 	}
 
 	@Test
-	public void convertPartfulTest() throws IOException, ServletException {
+	void convertPartfulTest() throws IOException, ServletException {
 		Part part = mock(Part.class);
 		doReturn(part).when(converter).getPart();
 		String result = converter.convert(event);
@@ -45,7 +46,7 @@ public class AttachmentHashPartConverterTest {
 	}
 
 	@Test
-	public void convertIOExceptionOnPartRetrieval() throws IOException, ServletException {
+	void convertIOExceptionOnPartRetrieval() throws IOException, ServletException {
 		doThrow(new IOException()).when(converter).getPart();
 		String result = converter.convert(event);
 
@@ -54,7 +55,7 @@ public class AttachmentHashPartConverterTest {
 	}
 
 	@Test
-	public void convertServletExceptionOnPartRetrieval() throws IOException, ServletException {
+	void convertServletExceptionOnPartRetrieval() throws IOException, ServletException {
 		doThrow(new ServletException()).when(converter).getPart();
 		String result = converter.convert(event);
 


### PR DESCRIPTION
### Information
- JIRA story QPPCT-283.

### Changes proposed in this PR:
- Finishes the junit 5 conversion for all classes which do not need new code written. Still need to finish power mockito extension.

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
