### PR TITLE
Maven runs in 6 GB on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     <<: *container_config
     environment:
-      MAVEN_OPTS: "-Xms7G -Xmx7G"
+      MAVEN_OPTS: "-Xms6G -Xmx6G"
     resource_class: large
     steps:
       - attach_workspace:


### PR DESCRIPTION
### Information
Fix-up task.

### Changes proposed in this PR:
- Decreased Maven's memory footprint by another gigabyte because we are still getting Maven failures.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
