### PR TITLE
QPPCT-599, add debug to the maven compile config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 						<forceJavacCompilerUse>true</forceJavacCompilerUse>
 						<source>${java.version}</source>
 						<target>${java.version}</target>
+						<debug>true</debug>
 					</configuration>
 					<dependencies>
 						<dependency>


### PR DESCRIPTION
### Information
- Fixes QPPCT-599

### Changes proposed in this PR:
- Adds <debug>true</debug> to the maven compiler configuration to add debug info to the compiled java classes
-
-

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [n/a] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
