### PR TITLE
QPPCT-579: Change logging

### DIFF
--- a/commandline/src/main/resources/logback.xml
+++ b/commandline/src/main/resources/logback.xml
@@ -2,26 +2,10 @@
 <configuration>
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%-2level - %msg%n</pattern>
-		</encoder>
-	</appender>
-	<appender name="DEV" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>dev-log.log</file>
-		<append>true</append>
-		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-			<fileNamePattern>dev-log.%i.log</fileNamePattern>
-			<minIndex>1</minIndex>
-			<maxIndex>3</maxIndex>
-		</rollingPolicy>
-		<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-			<maxFileSize>10MB</maxFileSize>
-		</triggeringPolicy>
-		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
 		</encoder>
 	</appender>
 	<logger name="gov.cms" level="INFO">
 		<appender-ref ref="STDOUT"/>
-		<appender-ref ref="DEV"/>
 	</logger>
 </configuration>

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/DynamoDbConfig.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/DynamoDbConfig.java
@@ -32,7 +32,7 @@ import static gov.cms.qpp.conversion.api.config.DynamoDbConfigFactory.createDyna
 @Configuration
 public class DynamoDbConfig {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(DynamoDbConfig.class);
 	static final String NO_KMS_KEY = "No KMS key specified!";
 
 	@Autowired

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/KmsConfig.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/KmsConfig.java
@@ -4,7 +4,6 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
-import gov.cms.qpp.conversion.api.model.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class KmsConfig {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(KmsConfig.class);
 
 	/**
 	 * Creates the KMS client {@link Bean}.

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/S3Config.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/S3Config.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
-import gov.cms.qpp.conversion.api.model.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(S3Config.class);
 
 	/**
 	 * Creates the S3 client {@link Bean}.

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
@@ -30,7 +30,7 @@ import java.util.List;
 @CrossOrigin
 public class CpcFileControllerV1 {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(CpcFileControllerV1.class);
 
 	@Autowired
 	private CpcFileService cpcFileService;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/ExceptionHandlerControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/ExceptionHandlerControllerV1.java
@@ -2,7 +2,6 @@ package gov.cms.qpp.conversion.api.controllers.v1;
 
 import gov.cms.qpp.conversion.api.exceptions.InvalidFileTypeException;
 import gov.cms.qpp.conversion.api.exceptions.NoFileInDatabaseException;
-import gov.cms.qpp.conversion.api.model.Constants;
 import gov.cms.qpp.conversion.api.services.AuditService;
 import gov.cms.qpp.conversion.model.error.AllErrors;
 import gov.cms.qpp.conversion.model.error.QppValidationException;
@@ -24,7 +23,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  */
 @ControllerAdvice
 public class ExceptionHandlerControllerV1 extends ResponseEntityExceptionHandler {
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(ExceptionHandlerControllerV1.class);
 
 	@Autowired
 	private AuditService auditService;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 @RequestMapping("/")
 @CrossOrigin
 public class QrdaControllerV1 {
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(QrdaControllerV1.class);
 
 	@Autowired
 	private QrdaService qrdaService;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
@@ -4,7 +4,6 @@ package gov.cms.qpp.conversion.api.model;
  * Constants library for use within the ReST API.
  */
 public class Constants {
-	public static final String API_LOG = "API_LOG";
 	public static final String DYNAMO_TABLE_NAME_ENV_VARIABLE = "DYNAMO_TABLE_NAME";
 	public static final String KMS_KEY_ENV_VARIABLE = "KMS_KEY";
 	public static final String NO_AUDIT_ENV_VARIABLE = "NO_AUDIT";

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AnyOrderActionService.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AnyOrderActionService.java
@@ -1,6 +1,5 @@
 package gov.cms.qpp.conversion.api.services;
 
-import gov.cms.qpp.conversion.api.model.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public abstract class AnyOrderActionService<T, S> {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(AnyOrderActionService.class);
 
 	@Autowired
 	protected TaskExecutor taskExecutor;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AuditServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/AuditServiceImpl.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @Service
 public class AuditServiceImpl implements AuditService {
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(AuditServiceImpl.class);
 
 	@Autowired
 	private StorageService storageService;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -26,7 +26,7 @@ import java.util.stream.IntStream;
 public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 		implements DbService {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(DbServiceImpl.class);
 
 	@Autowired
 	private DynamoDBMapper mapper;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/QrdaServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/QrdaServiceImpl.java
@@ -2,7 +2,6 @@ package gov.cms.qpp.conversion.api.services;
 
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.Source;
-import gov.cms.qpp.conversion.api.model.Constants;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +14,7 @@ import javax.annotation.PostConstruct;
  */
 @Service
 public class QrdaServiceImpl implements QrdaService {
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(QrdaServiceImpl.class);
 
 	/**
 	 * Preloads the measure configs data

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageServiceImpl.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 @Service
 public class StorageServiceImpl extends AnyOrderActionService<PutObjectRequest, String>
 		implements StorageService {
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(StorageServiceImpl.class);
 
 	@Autowired
 	private TransferManager s3TransferManager;

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/ValidationServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/ValidationServiceImpl.java
@@ -1,11 +1,14 @@
 package gov.cms.qpp.conversion.api.services;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import javax.annotation.PostConstruct;
-
+import gov.cms.qpp.conversion.Converter;
+import gov.cms.qpp.conversion.api.model.Constants;
+import gov.cms.qpp.conversion.api.model.ErrorMessage;
+import gov.cms.qpp.conversion.correlation.PathCorrelator;
+import gov.cms.qpp.conversion.encode.JsonWrapper;
+import gov.cms.qpp.conversion.model.error.AllErrors;
+import gov.cms.qpp.conversion.model.error.Error;
+import gov.cms.qpp.conversion.model.error.QppValidationException;
+import gov.cms.qpp.conversion.util.JsonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,15 +23,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
-import gov.cms.qpp.conversion.Converter;
-import gov.cms.qpp.conversion.api.model.Constants;
-import gov.cms.qpp.conversion.api.model.ErrorMessage;
-import gov.cms.qpp.conversion.correlation.PathCorrelator;
-import gov.cms.qpp.conversion.encode.JsonWrapper;
-import gov.cms.qpp.conversion.model.error.AllErrors;
-import gov.cms.qpp.conversion.model.error.Error;
-import gov.cms.qpp.conversion.model.error.QppValidationException;
-import gov.cms.qpp.conversion.util.JsonHelper;
+import javax.annotation.PostConstruct;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Implementation for the QPP Validation Service
@@ -36,7 +34,7 @@ import gov.cms.qpp.conversion.util.JsonHelper;
 @Service
 public class ValidationServiceImpl implements ValidationService {
 
-	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final Logger API_LOG = LoggerFactory.getLogger(ValidationServiceImpl.class);
 	static final String CONTENT_TYPE = "application/json";
 
 	@Autowired

--- a/rest-logging/src/main/resources/logback.xml
+++ b/rest-logging/src/main/resources/logback.xml
@@ -17,30 +17,7 @@
 			</providers>
 		</encoder>
 	</appender>
-	<appender name="REST_API" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>rest-api-log.log</file>
-		<append>true</append>
-		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-			<fileNamePattern>rest-api-log.%i.log</fileNamePattern>
-			<minIndex>1</minIndex>
-			<maxIndex>3</maxIndex>
-		</rollingPolicy>
-		<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-			<maxFileSize>10MB</maxFileSize>
-		</triggeringPolicy>
-		<encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-			<providers>
-				<pattern>
-					<pattern>
-						${defaultPattern}
-					</pattern>
-				</pattern>
-				<stackTrace/>
-			</providers>
-		</encoder>
-	</appender>
 	<root name="API_LOG" level="INFO">
 		<appender-ref ref="STDOUT_DETAIL"/>
-		<appender-ref ref="REST_API"/>
 	</root>
 </configuration>

--- a/rest-logging/src/main/resources/logback.xml
+++ b/rest-logging/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 			</providers>
 		</encoder>
 	</appender>
-	<root name="API_LOG" level="INFO">
+	<root name="gov.cms" level="INFO">
 		<appender-ref ref="STDOUT_DETAIL"/>
 	</root>
 </configuration>


### PR DESCRIPTION
### Information
- JIRA story QPPCT-579.

### Changes proposed in this PR:
- Removed the file logging from the command line.
- Made the STDOUT logger spit out more details.  For example...
  ```
  Lithium:code halprin$ ./convert.sh ./qrda-files/valid-QRDA-III-latest.xml 
  16:52:17.414 [main] INFO  gov.cms.qpp.conversion.Converter - Transform invoked
  16:52:18.007 [main] INFO  gov.cms.qpp.conversion.Converter - Decoded template ID CLINICAL_DOCUMENT
  16:52:18.057 [main] INFO  g.c.q.c.validate.QrdaValidator - Validating all nodes in the tree
  16:52:18.233 [main] INFO  gov.cms.qpp.conversion.Converter - Encoding template ID CLINICAL_DOCUMENT
  16:52:18.276 [main] INFO  g.c.q.c.ConversionFileWriterWrapper - Successful conversion.  Writing out QPP to valid-QRDA-III-latest.qpp.json
  ```
- Removed the file logging from the ReST API.
- Made the ReST API loggers associate themselves with the class that they are in.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
