### PR TITLE
Limit DynamoDb retrieve file list

### DIFF
--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -91,6 +91,7 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 	 * @return Metadata found
 	 */
 	public Metadata getMetadataById(String uuid) {
+		API_LOG.info("Read item {} from DynamoDB", uuid);
 		return mapper.load(Metadata.class, uuid);
 	}
 

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -71,6 +71,7 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 			Map<String, AttributeValue> valueMap = new HashMap<>();
 			valueMap.put(":cpcValue", new AttributeValue().withS(Constants.CPC_DYNAMO_PARTITION_START + partition));
 			valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false"));
+			int limit = 3;
 
 			DynamoDBQueryExpression<Metadata> metadataQuery = new DynamoDBQueryExpression<Metadata>()
 				.withIndexName("Cpc-CpcProcessed_CreateDate-index")
@@ -78,7 +79,7 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 					Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE + ", :cpcProcessedValue)")
 				.withExpressionAttributeValues(valueMap)
 				.withConsistentRead(false)
-				.withLimit(3);
+				.withLimit(limit);
 
 			return mapper.queryPage(Metadata.class, metadataQuery).getResults().stream();
 		}).flatMap(Function.identity()).collect(Collectors.toList());

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -75,9 +75,10 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 				.withKeyConditionExpression(Constants.DYNAMO_CPC_ATTRIBUTE + " = :cpcValue and begins_with(" +
 					Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE + ", :cpcProcessedValue)")
 				.withExpressionAttributeValues(valueMap)
-				.withConsistentRead(false);
+				.withConsistentRead(false)
+				.withLimit(3);
 
-			return mapper.query(Metadata.class, metadataQuery).stream();
+			return mapper.queryPage(Metadata.class, metadataQuery).getResults().stream();
 		}).flatMap(Function.identity()).collect(Collectors.toList());
 	}
 

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -27,6 +27,7 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 		implements DbService {
 
 	private static final Logger API_LOG = LoggerFactory.getLogger(Constants.API_LOG);
+	private static final int LIMIT = 3;
 
 	@Autowired
 	private DynamoDBMapper mapper;
@@ -71,7 +72,6 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 			Map<String, AttributeValue> valueMap = new HashMap<>();
 			valueMap.put(":cpcValue", new AttributeValue().withS(Constants.CPC_DYNAMO_PARTITION_START + partition));
 			valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false"));
-			int limit = 3;
 
 			DynamoDBQueryExpression<Metadata> metadataQuery = new DynamoDBQueryExpression<Metadata>()
 				.withIndexName("Cpc-CpcProcessed_CreateDate-index")
@@ -79,7 +79,7 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 					Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE + ", :cpcProcessedValue)")
 				.withExpressionAttributeValues(valueMap)
 				.withConsistentRead(false)
-				.withLimit(limit);
+				.withLimit(LIMIT);
 
 			return mapper.queryPage(Metadata.class, metadataQuery).getResults().stream();
 		}).flatMap(Function.identity()).collect(Collectors.toList());

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -59,7 +59,9 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 	}
 
 	/**
-	 * Scans the DynamoDB table for unprocessed {@link Metadata}
+	 * Queries the DynamoDB GSI for unprocessed {@link Metadata} with a maximum of 96 items.
+	 *
+	 * Iterates over all of the different partitions, returning a maximum of three items from each.
 	 *
 	 * @return {@link List} of unprocessed {@link Metadata}
 	 */

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/DbServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/DbServiceImplTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -92,13 +94,13 @@ class DbServiceImplTest {
 
 	@Test
 	void testGetUnprocessedCpcPlusMetaData() {
-		PaginatedQueryList<Metadata> mockMetadataList = mock(PaginatedQueryList.class);
-		when(mockMetadataList.stream()).thenAnswer(invocationOnMock -> Stream.of(new Metadata(), new Metadata()));
-		when(dbMapper.query(eq(Metadata.class), any(DynamoDBQueryExpression.class))).thenReturn(mockMetadataList);
+		QueryResultPage<Metadata> mockMetadataPage = mock(QueryResultPage.class);
+		when(mockMetadataPage.getResults()).thenReturn(Lists.newArrayList(new Metadata(), new Metadata()));
+		when(dbMapper.queryPage(eq(Metadata.class), any(DynamoDBQueryExpression.class))).thenReturn(mockMetadataPage);
 
 		List<Metadata> metaDataList = underTest.getUnprocessedCpcPlusMetaData();
 
-		verify(dbMapper, times(Constants.CPC_DYNAMO_PARTITIONS)).query(any(Class.class), any(DynamoDBQueryExpression.class));
+		verify(dbMapper, times(Constants.CPC_DYNAMO_PARTITIONS)).queryPage(any(Class.class), any(DynamoDBQueryExpression.class));
 		assertThat(metaDataList).hasSize(2 * Constants.CPC_DYNAMO_PARTITIONS);
 	}
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/DbServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/DbServiceImplTest.java
@@ -1,5 +1,24 @@
 package gov.cms.qpp.conversion.api.services;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
+import gov.cms.qpp.conversion.api.model.Constants;
+import gov.cms.qpp.conversion.api.model.Metadata;
+import gov.cms.qpp.test.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.core.env.Environment;
+import org.springframework.core.task.TaskExecutor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,28 +30,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
-import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
-import com.google.common.collect.Lists;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.springframework.core.env.Environment;
-import org.springframework.core.task.TaskExecutor;
-
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
-import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
-
-import gov.cms.qpp.conversion.api.model.Constants;
-import gov.cms.qpp.conversion.api.model.Metadata;
-import gov.cms.qpp.test.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DbServiceImplTest {
@@ -94,14 +91,16 @@ class DbServiceImplTest {
 
 	@Test
 	void testGetUnprocessedCpcPlusMetaData() {
+		int itemsPerPartition = 2;
+
 		QueryResultPage<Metadata> mockMetadataPage = mock(QueryResultPage.class);
-		when(mockMetadataPage.getResults()).thenReturn(Lists.newArrayList(new Metadata(), new Metadata()));
+		when(mockMetadataPage.getResults()).thenReturn(Stream.generate(Metadata::new).limit(itemsPerPartition).collect(Collectors.toList()));
 		when(dbMapper.queryPage(eq(Metadata.class), any(DynamoDBQueryExpression.class))).thenReturn(mockMetadataPage);
 
 		List<Metadata> metaDataList = underTest.getUnprocessedCpcPlusMetaData();
 
 		verify(dbMapper, times(Constants.CPC_DYNAMO_PARTITIONS)).queryPage(any(Class.class), any(DynamoDBQueryExpression.class));
-		assertThat(metaDataList).hasSize(2 * Constants.CPC_DYNAMO_PARTITIONS);
+		assertThat(metaDataList).hasSize(itemsPerPartition * Constants.CPC_DYNAMO_PARTITIONS);
 	}
 
 	@Test


### PR DESCRIPTION
### Information
- QPPCT-598

### Changes proposed in this PR:
- Change CPC+ endpoint 1 to have a max limit of up to 96 files that can be retrieved.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
