### PR TITLE
QPPCT-629: problem with only child assumption

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionDenominatorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionDenominatorEncoder.java
@@ -1,11 +1,9 @@
 package gov.cms.qpp.conversion.encode;
 
-import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Encoder;
 import gov.cms.qpp.conversion.model.Node;
-
-import java.util.List;
+import gov.cms.qpp.conversion.model.TemplateId;
 
 /**
  * Encoder to serialize Advancing Care Information Numerator Denominator Type

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionDenominatorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionDenominatorEncoder.java
@@ -27,9 +27,8 @@ public class AciProportionDenominatorEncoder extends QppOutputEncoder {
 
 		// the ACI Proportion Denominator Node should have a single child
 		// node that holds the value
-		List<Node> children = node.getChildNodes();
-		if (!children.isEmpty()) {
-			Node denominatorValueNode = children.get(0);
+		Node denominatorValueNode = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
+		if (denominatorValueNode != null) {
 			JsonOutputEncoder denominatorValueEncoder = encoders.get(denominatorValueNode.getType());
 
 			JsonWrapper value = new JsonWrapper();

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionNumeratorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionNumeratorEncoder.java
@@ -29,10 +29,10 @@ public class AciProportionNumeratorEncoder extends QppOutputEncoder {
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
 
-		List<Node> children = node.getChildNodes();
+		Node aciNumeratorNode = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
 
-		if (!children.isEmpty()) {
-			JsonWrapper numerator = encodeChild(children.get(0));
+		if (aciNumeratorNode != null) {
+			JsonWrapper numerator = encodeChild(aciNumeratorNode);
 
 			if (null != numerator.getInteger(VALUE)) {
 				wrapper.putObject(ENCODE_LABEL, numerator.getInteger(VALUE));

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionNumeratorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/AciProportionNumeratorEncoder.java
@@ -5,8 +5,6 @@ import gov.cms.qpp.conversion.model.Encoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 
-import java.util.List;
-
 /**
  * Encoder to serialize numerator data from a Numerator/Denominator Type Measure.
  */

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
@@ -42,7 +42,7 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 
 		JsonWrapper measurementSets =
 			encodeMeasurementSets(childMapByTemplateId);
-			wrapper.putObject(MEASUREMENT_SETS, measurementSets);
+		wrapper.putObject(MEASUREMENT_SETS, measurementSets);
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
@@ -5,8 +5,6 @@ import gov.cms.qpp.conversion.model.Encoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 
-import java.util.List;
-
 /**
  * Encoder to serialize Improvement Activity Performed Measure Reference and Results
  */

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
@@ -28,10 +28,9 @@ public class IaMeasureEncoder extends QppOutputEncoder {
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
 		wrapper.putObject("measureId", node.getValue("measureId"));
 
-		List<Node> children = node.getChildNodes();
+		Node measurePerformedNode = node.findFirstNode(TemplateId.MEASURE_PERFORMED);
 
-		if (!children.isEmpty()) {
-			Node measurePerformedNode = children.get(0);
+		if (measurePerformedNode != null) {
 			JsonOutputEncoder measurePerformedEncoder = encoders.get(measurePerformedNode.getType());
 
 			JsonWrapper value = new JsonWrapper();

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -394,7 +394,8 @@ public class JsonWrapper {
 	}
 
 	/**
-	 * Validates that the given value conforms to expected date formatting (i.e. yyyyMMdd).
+	 * Validates that the given value conforms to an ISO date with or without separators.
+	 * It can include a time but is unnecessary.
 	 *
 	 * @param value to validate
 	 * @return valid date String

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -201,7 +201,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		Node numeratorNode = parentNode.findChildNode(n -> SubPopulations.NUMER.equals(n.getValue(TYPE)));
 		Optional.ofNullable(numeratorNode).ifPresent(
 			node -> {
-				Node aggCount = node.getChildNodes().get(0);
+				Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
 				maintainContinuity(wrapper, aggCount, "performanceMet");
 				wrapper.putInteger("performanceMet", aggCount.getValue(AGGREGATE_COUNT));
 			});
@@ -258,7 +258,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 
 		Optional.ofNullable(denomExclusionNode).ifPresent(
 				node -> {
-					Node aggCount = node.getChildNodes().get(0);
+					Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
 					maintainContinuity(wrapper, aggCount, "eligiblePopulationExclusion");
 					String value = aggCount.getValue(AGGREGATE_COUNT);
 					wrapper.putInteger("eligiblePopulationExclusion", value);
@@ -266,7 +266,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 
 		Optional.ofNullable(denomExceptionNode).ifPresent(
 				node -> {
-					Node aggCount = node.getChildNodes().get(0);
+					Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
 					maintainContinuity(wrapper, aggCount, "eligiblePopulationException");
 					String value = aggCount.getValue(AGGREGATE_COUNT);
 					wrapper.putInteger("eligiblePopulationException", value);
@@ -276,7 +276,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 				node -> {
 					String performanceNotMet = calculatePerformanceNotMet(numeratorNode, denominatorNode,
 							denomExclusionNode, denomExceptionNode);
-					Node aggCount = node.getChildNodes().get(0);
+					Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
 					//for eCQMs, will be equal to
 					// denominator - numerator - denominator exclusion - denominator exception
 					maintainContinuity(wrapper, aggCount, "performanceNotMet");
@@ -295,13 +295,13 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 											Node denomExclusionNode, Node denomExceptionNode) {
 
 		String denominatorValue = denominatorNode == null ? "0" :
-				denominatorNode.getChildNodes().get(0).getValue(AGGREGATE_COUNT);
+				denominatorNode.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT).getValue(AGGREGATE_COUNT);
 		String denomExclusionValue = denomExclusionNode == null ? "0" :
-				denomExclusionNode.getChildNodes().get(0).getValue(AGGREGATE_COUNT);
+				denomExclusionNode.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT).getValue(AGGREGATE_COUNT);
 		String numeratorValue = numeratorNode == null ? "0" :
-				numeratorNode.getChildNodes().get(0).getValue(AGGREGATE_COUNT);
+				numeratorNode.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT).getValue(AGGREGATE_COUNT);
 		String denomExceptionValue = denomExceptionNode == null ? "0" :
-				denomExceptionNode.getChildNodes().get(0).getValue(AGGREGATE_COUNT);
+				denomExceptionNode.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT).getValue(AGGREGATE_COUNT);
 
 		// for eCQMs, will be equal to denominator - numerator - denominator exclusion - denominator exception
 		return Integer.toString(Integer.parseInt(denominatorValue)

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -1,19 +1,13 @@
 package gov.cms.qpp.conversion.model;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a node of data that should be converted. Consists of a key/value
@@ -315,16 +309,23 @@ public class Node {
 	 */
 	private List<Node> findNode(TemplateId templateId, Predicate<List<Node>> bail) {
 		List<Node> foundNodes = new ArrayList<>();
-		if (this.type == templateId) {
-			foundNodes.add(this);
-		}
-		for (Node childNode : childNodes) {
+		List<Node> toSearch = Lists.newArrayList(childNodes);
+		Consumer<Node> templateCheck = (node) -> {
+			if (node.getType() == templateId) {
+				foundNodes.add(node);
+			}
+		};
+		templateCheck.accept(this);
+
+		for (int i = 0; i < toSearch.size(); i++) {
 			if (bail != null && bail.test(foundNodes)) {
 				break;
 			}
-			List<Node> matches = childNode.findNode(templateId, bail);
-			foundNodes.addAll(matches);
+			Node childNode = toSearch.get(i);
+			templateCheck.accept(childNode);
+			toSearch.addAll(childNode.getChildNodes());
 		}
+
 		return foundNodes;
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -319,7 +319,7 @@ public class Node {
 	private List<Node> findNode(TemplateId templateId, Predicate<List<Node>> bail) {
 		List<Node> foundNodes = new ArrayList<>();
 		List<Node> toSearch = Lists.newArrayList(childNodes);
-		Consumer<Node> templateCheck = (node) -> {
+		Consumer<Node> templateCheck = node -> {
 			if (node.getType() == templateId) {
 				foundNodes.add(node);
 			}

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -3,10 +3,19 @@ package gov.cms.qpp.conversion.model;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/AciProportionDenominatorEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/AciProportionDenominatorEncoderTest.java
@@ -21,10 +21,13 @@ class AciProportionDenominatorEncoderTest {
 
 	@BeforeEach
 	void createNode() {
+		Node ensureOrderIsNotOfConcern = new Node(TemplateId.DEFAULT);
+
 		numeratorDenominatorValueNode = new Node(TemplateId.ACI_AGGREGATE_COUNT);
 		numeratorDenominatorValueNode.putValue("aggregateCount", "600");
 
 		aciProportionDenominatorNode = new Node(TemplateId.ACI_DENOMINATOR);
+		aciProportionDenominatorNode.addChildNode(ensureOrderIsNotOfConcern);
 		aciProportionDenominatorNode.addChildNode(numeratorDenominatorValueNode);
 
 		nodes = new ArrayList<>();

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/AciProportionNumeratorEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/AciProportionNumeratorEncoderTest.java
@@ -16,19 +16,18 @@ class AciProportionNumeratorEncoderTest {
 
 	private Node aciProportionNumeratorNode;
 	private Node numeratorDenominatorValueNode;
-	private List<Node> nodes;
 	private JsonWrapper jsonWrapper;
 
 	@BeforeEach
 	void createNode() {
+		Node ensureChildOrderIsNotProblematic = new Node(TemplateId.CLINICAL_DOCUMENT);
+
 		numeratorDenominatorValueNode = new Node(TemplateId.ACI_AGGREGATE_COUNT);
 		numeratorDenominatorValueNode.putValue("aggregateCount", "600");
 
 		aciProportionNumeratorNode = new Node(TemplateId.ACI_NUMERATOR);
+		aciProportionNumeratorNode.addChildNode(ensureChildOrderIsNotProblematic);
 		aciProportionNumeratorNode.addChildNode(numeratorDenominatorValueNode);
-
-		nodes = new ArrayList<>();
-		nodes.add(aciProportionNumeratorNode);
 
 		jsonWrapper = new JsonWrapper();
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -191,8 +192,29 @@ class JsonWrapperTest {
 	}
 
 	@Test
+	void testValidDateWithSeconds1() throws Exception {
+		objectObjWrapper.putDate("20170101000000");
+		assertWithMessage("should be an object container")
+				.that(((List<?>) objectObjWrapper.getObject()))
+				.isNotEmpty();
+	}
+
+	@Test
+	void testValidDateWithSeconds2() throws Exception {
+		objectObjWrapper.putDate("20171231235959");
+		assertWithMessage("should be an object container")
+				.that(((List<?>) objectObjWrapper.getObject()))
+				.isNotEmpty();
+	}
+
+	@Test
 	void testValidDateYyMmDdIsInvalid() throws Exception {
 		Assertions.assertThrows(EncodeException.class, () -> objectObjWrapper.putDate("690720"));
+	}
+
+	@Test
+	void testValidDateRandomStringIsInvalid() throws Exception {
+		Assertions.assertThrows(EncodeException.class, () -> objectObjWrapper.putDate(UUID.randomUUID().toString()));
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -145,63 +146,56 @@ class JsonWrapperTest {
 
 	@Test
 	void testValidDateYyyyMmDd() throws Exception {
-		objectObjWrapper.putDate("19690720");
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid("19690720");
 	}
 
 	@Test
 	void testValidDateYyyySlashMmSlashDd() throws Exception {
-		objectObjWrapper.putDate("1969/07/20");
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid("1969/07/20");
 	}
 
 	@Test
 	void testValidDateYyyyDashMmDashDd() throws Exception {
-		objectObjWrapper.putDate("1969-07-20");
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid("1969-07-20");
+	}
+
+	@Test
+	void testValidDateYyyyDashMmDashDdThhColonMmColonSsZ() {
+		ensureDateIsValid("2018-01-26T15:35:30.685Z");
 	}
 
 	@Test
 	void testValidDateFromInstant() throws Exception {
-		objectObjWrapper.putDate(Instant.now().toString());
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid(Instant.now().toString());
 	}
 
 	@Test
 	void testValidDateFromLocalDate() throws Exception {
-		objectObjWrapper.putDate(LocalDate.now().toString());
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid(LocalDate.now().toString());
 	}
 
 	@Test
 	void testValidDateFromLocalDateTime() throws Exception {
-		objectObjWrapper.putDate(LocalDateTime.now().toString());
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid(LocalDateTime.now().toString());
 	}
 
 	@Test
 	void testValidDateWithSeconds1() throws Exception {
-		objectObjWrapper.putDate("20170101000000");
-		assertWithMessage("should be an object container")
-				.that(((List<?>) objectObjWrapper.getObject()))
-				.isNotEmpty();
+		ensureDateIsValid("20170101000000");
 	}
 
 	@Test
 	void testValidDateWithSeconds2() throws Exception {
-		objectObjWrapper.putDate("20171231235959");
+		ensureDateIsValid("20171231235959");
+	}
+
+	@Test
+	void testValidDateFullyQualified() {
+		ensureDateIsValid("2018-01-22T20:09:39.949Z");
+	}
+
+	private void ensureDateIsValid(String date) {
+		objectObjWrapper.putDate(date);
 		assertWithMessage("should be an object container")
 				.that(((List<?>) objectObjWrapper.getObject()))
 				.isNotEmpty();

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -21,6 +21,7 @@ class QualityMeasureIdEncoderTest {
 	private Node numeratorNode;
 	private Node denominatorNode;
 	private Node aggregateCountNode;
+	private Node paymentNode;
 	private JsonWrapper wrapper;
 	private QualityMeasureIdEncoder encoder;
 	private String type = "type";
@@ -34,6 +35,9 @@ class QualityMeasureIdEncoderTest {
 		aggregateCountNode = new Node(TemplateId.ACI_AGGREGATE_COUNT);
 		aggregateCountNode.putValue("aggregateCount", "600");
 
+		paymentNode = new Node(TemplateId.PAYER_SUPPLEMENTAL_DATA_ELEMENT_CMS_V2);
+		paymentNode.putValue("place", "holder");
+
 		populationNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
 		populationNode.putValue(type, SubPopulations.IPOP);
 		populationNode.addChildNode(aggregateCountNode);
@@ -45,9 +49,11 @@ class QualityMeasureIdEncoderTest {
 		numeratorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
 		numeratorNode.putValue(type, SubPopulations.NUMER);
 		numeratorNode.addChildNode(aggregateCountNode);
+		numeratorNode.addChildNode(paymentNode);
 
 		denominatorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
 		denominatorNode.putValue(type, SubPopulations.DENOM);
+		denominatorNode.addChildNode(paymentNode);
 		denominatorNode.addChildNode(aggregateCountNode);
 
 		encoder = new QualityMeasureIdEncoder(new Context());

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/NodeTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/NodeTest.java
@@ -3,6 +3,7 @@ package gov.cms.qpp.conversion.model;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,37 @@ class NodeTest {
 
 		assertWithMessage("should find first child that has the searched id")
 				.that(results).hasSize(1);
+	}
+
+	@Test
+	void testFindNodeLoveThySelf() {
+		Node parent = new Node(TemplateId.PLACEHOLDER);
+		Node onlyChild = new Node(TemplateId.PLACEHOLDER);
+		parent.addChildNodes(onlyChild);
+
+		List<Node> results = parent.findNode(TemplateId.PLACEHOLDER);
+
+		assertWithMessage("should find first node that has the searched id")
+			.that(results).hasSize(2);
+		assertWithMessage("should search self first")
+			.that(results.get(0)).isSameAs(parent);
+	}
+
+	@Test
+	void testFindNodeOrder() {
+		Node carter = new Node(TemplateId.PLACEHOLDER);
+		Node lois = new Node(TemplateId.PLACEHOLDER);
+		Node chris = new Node(TemplateId.PLACEHOLDER);
+		Node meg = new Node(TemplateId.PLACEHOLDER);
+		Node stewie = new Node(TemplateId.PLACEHOLDER);
+		carter.addChildNodes(lois);
+		lois.addChildNodes(chris, meg, stewie);
+		List<Node> order = Arrays.asList(carter, lois, chris, meg, stewie);
+
+		List<Node> results = carter.findNode(TemplateId.PLACEHOLDER);
+
+		assertWithMessage("should prioritize by generation and birth / add order")
+			.that(results).containsExactlyElementsIn(order).inOrder();
 	}
 
 	@Test

--- a/sample-files/MIPS_GROUP_QRDA_III_ACI_IA_Sample2.xml
+++ b/sample-files/MIPS_GROUP_QRDA_III_ACI_IA_Sample2.xml
@@ -2252,24 +2252,6 @@ CDA Header
 										code="IPOP"
 										codeSystem="2.16.840.1.113883.5.4"
 										codeSystemName="ActCode"/>
-									<!--IPOP Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<!-- Aggregate Count -->
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<!-- Aggregate Count - CMS -->
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												codeSystemName="ActCode"
-												displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT"
-												codeSystem="2.16.840.1.113883.5.84"
-												codeSystemName="ObservationMethod"
-												displayName="Count"/>
-										</observation>
-									</entryRelationship>
 									<!-- Sex Supplemental Data Element - Male-->
 									<entryRelationship typeCode="COMP">
 										<observation classCode="OBS" moodCode="EVN">
@@ -2732,6 +2714,24 @@ CDA Header
 												displayName="Count"/>
 												</observation>
 											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Aggregate Count -->
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<!-- Aggregate Count - CMS -->
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
 										</observation>
 									</entryRelationship>
 									<!--IPOP Population ID from eMeasure-->


### PR DESCRIPTION
### Information
- QPPCT-629

### Changes proposed in this PR:
- The assumption that some nodes have single entry child node lists resulted in the attempted encoding of incompatible nodes.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
