### PR TITLE
QPPCT-531: SPIKE - Investigate System.out/System.err printing in tests

### DIFF
--- a/commandline/src/test/java/gov/cms/qpp/conversion/ConverterWithAbridgedTest.java
+++ b/commandline/src/test/java/gov/cms/qpp/conversion/ConverterWithAbridgedTest.java
@@ -30,12 +30,8 @@ class ConverterWithAbridgedTest implements JimfsContract {
 		setup(fileSystem);
 
 		String fileName = "valid-QRDA-III-abridged.qpp.json";
-		long start = System.currentTimeMillis();
-
 		ConversionEntry.main("--" + ConversionEntry.SKIP_VALIDATION,
 				"src/test/resources/valid-QRDA-III-abridged.xml");
-
-		long finish = System.currentTimeMillis();
 
 		Path aJson = fileSystem.getPath(fileName);
 
@@ -52,13 +48,10 @@ class ConverterWithAbridgedTest implements JimfsContract {
 
 		String aConversion = "a.qpp.json";
 		String dConversion = "d.qpp.json";
-		long start = System.currentTimeMillis();
 
 		ConversionEntry.main("--" + ConversionEntry.SKIP_VALIDATION,
 				"src/test/resources/pathTest/a.xml",
 				"src/test/resources/pathTest/subdir/*.xml");
-
-		long finish = System.currentTimeMillis();
 
 		Path aJson = fileSystem.getPath(aConversion);
 		Path dJson = fileSystem.getPath(dConversion);

--- a/commandline/src/test/java/gov/cms/qpp/conversion/ConverterWithAbridgedTest.java
+++ b/commandline/src/test/java/gov/cms/qpp/conversion/ConverterWithAbridgedTest.java
@@ -1,6 +1,9 @@
 package gov.cms.qpp.conversion;
 
-import static com.google.common.truth.Truth.assertWithMessage;
+import org.junit.jupiter.api.AfterEach;
+
+import gov.cms.qpp.test.jimfs.JimfsContract;
+import gov.cms.qpp.test.jimfs.JimfsTest;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -8,10 +11,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.AfterEach;
-
-import gov.cms.qpp.test.jimfs.JimfsTest;
-import gov.cms.qpp.test.jimfs.JimfsContract;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 class ConverterWithAbridgedTest implements JimfsContract {
 
@@ -44,8 +44,6 @@ class ConverterWithAbridgedTest implements JimfsContract {
 				.isTrue();
 
 		Files.delete(aJson);
-
-		System.out.println("Time to run transform " + (finish - start));
 	}
 
 	@JimfsTest
@@ -74,8 +72,6 @@ class ConverterWithAbridgedTest implements JimfsContract {
 
 		Files.delete(aJson);
 		Files.delete(dJson);
-
-		System.out.println("Time to run two thread transform " + (finish - start));
 	}
 
 	private void setup(FileSystem fileSystem) throws Exception {

--- a/converter/src/test/java/gov/cms/qpp/MarkupManipulationHandler.java
+++ b/converter/src/test/java/gov/cms/qpp/MarkupManipulationHandler.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp;
 
+import org.xml.sax.SAXException;
+
 import gov.cms.qpp.acceptance.helper.MarkupManipulator;
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.InputStreamSupplierSource;
@@ -8,7 +10,6 @@ import gov.cms.qpp.conversion.model.error.AllErrors;
 import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.Error;
 import gov.cms.qpp.conversion.model.error.TransformException;
-import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
@@ -16,6 +17,8 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.google.common.truth.Truth.assertWithMessage;
 
 public class MarkupManipulationHandler {
 	private static final String NAMESPACE_URI = "urn:hl7-org:v3";
@@ -48,9 +51,7 @@ public class MarkupManipulationHandler {
 
 	public String getPath(String templateId, String attribute) {
 		String path = PathCorrelator.getXpath(templateId, attribute, NAMESPACE_URI);
-		if (path == null) {
-			System.out.println("Bad combo templateId: " + templateId + " attribute: " + attribute);
-		}
+		assertWithMessage("Bad combo templateId: %s attribute: %s", templateId, attribute).that(path).isNotNull();
 		return "//" + path;
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/acceptance/helper/JsonPathToXpathHelper.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/helper/JsonPathToXpathHelper.java
@@ -1,12 +1,6 @@
 package gov.cms.qpp.acceptance.helper;
 
-import gov.cms.qpp.conversion.Converter;
-import gov.cms.qpp.conversion.PathSource;
-import gov.cms.qpp.conversion.correlation.PathCorrelator;
-import gov.cms.qpp.conversion.encode.JsonWrapper;
-import gov.cms.qpp.conversion.encode.QppOutputEncoder;
-import gov.cms.qpp.conversion.xml.XmlException;
-import gov.cms.qpp.conversion.xml.XmlUtils;
+import com.google.common.collect.Sets;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.jdom2.filter.Filter;
@@ -14,23 +8,38 @@ import org.jdom2.filter.Filters;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 
+import gov.cms.qpp.conversion.Converter;
+import gov.cms.qpp.conversion.PathSource;
+import gov.cms.qpp.conversion.correlation.PathCorrelator;
+import gov.cms.qpp.conversion.encode.JsonWrapper;
+import gov.cms.qpp.conversion.encode.QppOutputEncoder;
+import gov.cms.qpp.conversion.xml.XmlException;
+import gov.cms.qpp.conversion.xml.XmlUtils;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static junit.framework.TestCase.fail;
 
 public class JsonPathToXpathHelper {
 
+	private static final Set<String> CHECK_FOR_NULL_SET = Sets
+		.newHashSet("entityType", "performanceYear", "performanceNotMet", "performanceStart", "performanceEnd", "programName", "measureId", "stratum", "value")
+		.stream().map(ignored -> ".*" + ignored + "$").collect(Collectors.toCollection(HashSet::new));
 	private static XPathFactory xpf = XPathFactory.instance();
 	private Path path;
 	private JsonWrapper wrapper;
 
-	public JsonPathToXpathHelper(Path inPath, JsonWrapper inWrapper) throws IOException {
+	public JsonPathToXpathHelper(Path inPath, JsonWrapper inWrapper) {
 		this(inPath, inWrapper, true);
 	}
 
-	public JsonPathToXpathHelper(Path inPath, JsonWrapper inWrapper, boolean doDefaults) throws IOException {
+	public JsonPathToXpathHelper(Path inPath, JsonWrapper inWrapper, boolean doDefaults) {
 		path = inPath;
 		wrapper = inWrapper;
 		Converter converter = new Converter(new PathSource(inPath));
@@ -58,18 +67,12 @@ public class JsonPathToXpathHelper {
 			fail(e.getMessage());
 		}
 
-		if (attribute == null) {
-			System.out.println("no attribute for path: " + jsonPath
-					+ "\n xpath: " + xPath);
+		if (CHECK_FOR_NULL_SET.stream().anyMatch(jsonPath::matches)) {
+			assertThat(attribute.getValue()).isNotNull();
+		} else {
+			assertWithMessage("( %s ) value ( %s ) does not equal ( %s ) at \n( %s ). \nPlease investigate.", jsonPath, expectedValue, attribute.getValue(), xPath)
+				.that(attribute.getValue()).isEqualTo(expectedValue);
 		}
-
-		if (!expectedValue.equals(attribute.getValue())) {
-			System.err.println("( " + jsonPath + " ) value ( " + expectedValue +
-					" ) does not equal ( " + attribute.getValue() +
-					" ) at \n( " + xPath + " ). \nPlease investigate.");
-		}
-
-		assertThat(attribute.getValue()).isNotNull();
 	}
 
 	public void executeAttributeTest(String jsonPath, String xmlAttributeName, String expectedValue)

--- a/converter/src/test/java/gov/cms/qpp/acceptance/helper/MarkupManipulator.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/helper/MarkupManipulator.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
 public class MarkupManipulator {
 	private static TransformerFactory tf = TransformerFactory.newInstance();
 	private static XPathFactory xpf = XPathFactory.newInstance();
@@ -49,25 +51,23 @@ public class MarkupManipulator {
 			XPathExpression expression = xpath.compile(xPath);
 
 			NodeList searchedNodes = (NodeList) expression.evaluate(document, XPathConstants.NODESET);
-			if (searchedNodes == null) {
-				System.out.println("bad path: " + xPath);
-			} else {
-				for (int i = 0; i < searchedNodes.getLength(); i++) {
-					Node searched = searchedNodes.item(i);
+			assertWithMessage("bad path: %s", xPath).that(searchedNodes).isNotNull();
 
-					Node owningElement = (searched instanceof ElementImpl)
-							? searched
-							: ((AttrImpl) searched).getOwnerElement();
+			for (int i = 0; i < searchedNodes.getLength(); i++) {
+				Node searched = searchedNodes.item(i);
 
-					Node containingParent = owningElement.getParentNode();
+				Node owningElement = (searched instanceof ElementImpl)
+						? searched
+						: ((AttrImpl) searched).getOwnerElement();
 
-					if (remove) {
-						containingParent.removeChild(owningElement);
-					} else {
-						containingParent.appendChild(owningElement.cloneNode(true));
-					}
+				Node containingParent = owningElement.getParentNode();
 
+				if (remove) {
+					containingParent.removeChild(owningElement);
+				} else {
+					containingParent.appendChild(owningElement.cloneNode(true));
 				}
+
 			}
 
 			Transformer t = tf.newTransformer();

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/RegistryTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/RegistryTest.java
@@ -1,7 +1,6 @@
 package gov.cms.qpp.conversion.model;
 
 import org.jdom2.Element;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,6 @@ import gov.cms.qpp.conversion.decode.DecodeResult;
 import gov.cms.qpp.conversion.decode.QrdaDecoder;
 import gov.cms.qpp.conversion.encode.AggregateCountEncoder;
 
-import java.io.PrintStream;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -23,18 +21,11 @@ class RegistryTest {
 
 	private Context context;
 	private Registry<QrdaDecoder> registry;
-	private PrintStream err;
 
 	@BeforeEach
 	void before() {
 		context = new Context();
 		registry = context.getRegistry(Decoder.class);
-		err = System.err;
-	}
-
-	@AfterEach
-	void tearDown() {
-		System.setErr(err);
 	}
 
 	@Test

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/InOrderAsyncActionServiceTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/InOrderAsyncActionServiceTest.java
@@ -1,6 +1,5 @@
 package gov.cms.qpp.conversion.api.services;
 
-import gov.cms.qpp.test.MockitoExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +9,8 @@ import org.mockito.Mock;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
+
+import gov.cms.qpp.test.MockitoExtension;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,7 +66,6 @@ class InOrderAsyncActionServiceTest {
 		protected Object asynchronousAction(final Object objectToActOn) {
 
 			while (pauseAsynchronousAction.get()) {
-				System.out.println("While pauseAsynchronousAction");
 				try {
 					Thread.sleep(1000);
 				}


### PR DESCRIPTION
### Information
- JIRA story QPPCT-531.

### Changes proposed in this PR:
- Removed extraneous uses of `System.out` and `System.err`.
- Changed a few instances where we printed something to an actual assert (`assertWithMessage`).
- In `JsonPathToXpathHelper`, we used to only check that all JSON paths, when mapped back to XPaths, didn't result in a `null` value in the original XML.  For certain attributes, we now check that the values are equal between the QPP and XML.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.