### PR TITLE
QPPCT-655: Filter out duplicate templateId elements

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/QrdaDecoderEngine.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/QrdaDecoderEngine.java
@@ -178,12 +178,12 @@ public class QrdaDecoderEngine extends XmlDecoderEngine {
 
 		return childElements.stream()
 			.filter(filterElement -> {
-				boolean isTemplateIdId = TEMPLATE_ID.equals(filterElement.getName());
+				boolean isTemplateId = TEMPLATE_ID.equals(filterElement.getName());
 				TemplateId filterTemplateId = getTemplateId(filterElement);
 
 				boolean elementWillStay = true;
 
-				if (isTemplateIdId) {
+				if (isTemplateId) {
 					if (getDecoder(filterTemplateId) == null) {
 						elementWillStay = false;
 					} else if (uniqueTemplates.contains(filterTemplateId)) {

--- a/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentRoundTripTest.java
@@ -1,16 +1,20 @@
 package gov.cms.qpp.acceptance;
 
-import gov.cms.qpp.TestHelper;
-import gov.cms.qpp.conversion.Context;
-import gov.cms.qpp.conversion.decode.XmlDecoderEngine;
-import gov.cms.qpp.conversion.decode.placeholder.DefaultDecoder;
-import gov.cms.qpp.conversion.encode.QppOutputEncoder;
-import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.xml.XmlUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.reflections.util.ClasspathHelper;
+
+import gov.cms.qpp.TestHelper;
+import gov.cms.qpp.conversion.Context;
+import gov.cms.qpp.conversion.decode.QrdaDecoderEngine;
+import gov.cms.qpp.conversion.decode.XmlDecoderEngine;
+import gov.cms.qpp.conversion.decode.placeholder.DefaultDecoder;
+import gov.cms.qpp.conversion.encode.QppOutputEncoder;
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.xml.XmlException;
+import gov.cms.qpp.conversion.xml.XmlUtils;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -51,4 +55,19 @@ class ClinicalDocumentRoundTripTest {
 		assertThat(sw.toString()).isEqualTo(expected);
 	}
 
+	@Test
+	void checkCorrectClinicalDocumentTemplateIdWins() throws XmlException {
+		String similarClinicalDocumentBlob = "<ClinicalDocument xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+			+ "\t\t\t\t  xsi:schemaLocation=\"urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd\"\n"
+			+ "\t\t\t\t  xmlns=\"urn:hl7-org:v3\" xmlns:voc=\"urn:hl7-org:v3/voc\">\n"
+			+ "\t<realmCode code=\"US\"/>\n"
+			+ "\t<typeId root=\"2.16.840.1.113883.1.3\" extension=\"POCD_HD000040\"/>\n"
+			+ "\t<templateId root=\"2.16.840.1.113883.10.20.27.1.2\"/>\n"
+			+ "\t<templateId root=\"2.16.840.1.113883.10.20.27.1.2\" extension=\"2017-07-01\"/>\n"
+			+ "</ClinicalDocument>";
+
+		Node root = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(similarClinicalDocumentBlob));
+
+		assertThat(root.getType()).isEqualTo(TemplateId.CLINICAL_DOCUMENT);
+	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QrdaDecoderEngineTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QrdaDecoderEngineTest.java
@@ -251,6 +251,28 @@ class QrdaDecoderEngineTest {
 		assertThat(objectUnderTest.accepts(rootElement)).isTrue();
 	}
 
+	@Test
+	void testGetUniqueTemplateIdElements() {
+		Element rootElement = createRootElement();
+		Element middleElement = createGenericElement();
+		Element initialTemplateIdElement = createContinueElement();
+		Element duplicateTemplateIdElement = createContinueElement();
+		Element fourthLevelElement = createGenericElement();
+		Element fifthLevelElement = createFinishElement();
+
+		addChildToParent(rootElement, middleElement);
+		addChildToParent(middleElement, initialTemplateIdElement);
+		addChildToParent(middleElement, duplicateTemplateIdElement);
+		addChildToParent(middleElement, fourthLevelElement);
+		addChildToParent(fourthLevelElement, fifthLevelElement);
+
+
+		QrdaDecoderEngine objectUnderTest = new QrdaDecoderEngine(context);
+		Node decodedNodes = objectUnderTest.decode(rootElement);
+
+		assertNodeCount(decodedNodes, 1, 1, 0);
+	}
+
 	private Element createContinueElement() {
 		Element element = new Element(TEMPLATE_ID);
 		element.setAttribute(ROOT, TemplateId.ACI_SECTION.getRoot());


### PR DESCRIPTION
### Information
- JIRA story QPPCT-655.

### Changes proposed in this PR:
- Thanks to @clydet for the inspiration for this change!
- Filter out duplicate template IDs when decoding.
  - This reduces the number of extraneous decoded `Node`s when a user accidentally includes extra `templateId` elements.
- A test.
- In the QRDA3 file attached to the original issue, it drops the number of issues from "holy cow, just start over on that file" to 2!

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
