### PR TITLE
QPPCT-651: Active checkstyle on benchmark and ignore JMH generated sources

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -157,6 +157,13 @@
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<configuration>
+					<excludes>**/generated/*</excludes>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
### Information
- JIRA story QPPCT-651.

### Changes proposed in this PR:
- The only issues with the benchmark sub-project were generated sources by JMH, not our own code.
- Told checkstyle to ignore the generated sources.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
