### PR TITLE
Fix for missing supplemental data codes

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -72,4 +72,3 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 67 : CT - Must have one count for Supplemental Data `(Supplemental Data Code)` on Sub-population `(Sub Population)` for eCQM measure `(Measure Id)`
 * 68 : CT - Your CPC+ submission was made after the CPC+ eCQM submission deadline of `(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at `(CPC+ contact email)` for assistance.
 * 69 : CT - `(Performance period start or end date)` is an invalid date format. Please use a standard ISO date format. Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123
-* 70 : CT - The supplemental code is unknown for the following measure id `(electronic measure id)`, subpopulation type `(Subpopulation)`, and supplemental template id type `(Supplemental data type)`

--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -68,7 +68,8 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 61 : CT - A Performance Rate must contain a single Performance Rate UUID
 * 64 : CT - CPC+ Submissions must have at least `(CPC+ measure group minimum)` of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`
 * 65 : CT - CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of the following measures: `(Listing of all CPC+ measure ids)`.
-* 66 : CT - Missing the Supplemental Code `(Supplemental Data Code)` for eCQM measure `(Measure Id)`'s Sub-population `(Sub Population)`
+* 66 : CT - Missing the Supplemental data for code `(Supplemental Data Code)` for eCQM measure `(Measure Id)`'s Sub-population `(Sub Population)`
 * 67 : CT - Must have one count for Supplemental Data `(Supplemental Data Code)` on Sub-population `(Sub Population)` for eCQM measure `(Measure Id)`
 * 68 : CT - Your CPC+ submission was made after the CPC+ eCQM submission deadline of `(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at `(CPC+ contact email)` for assistance.
 * 69 : CT - `(Performance period start or end date)` is an invalid date format. Please use a standard ISO date format. Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123
+* 70 : CT - The supplemental code is unknown for the following measure id `(electronic measure id)`, subpopulation type `(Subpopulation)`, and supplemental template id type `(Supplemental data type)`

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -2,6 +2,7 @@ package gov.cms.qpp.conversion.model.error;
 
 
 import org.apache.commons.text.StrSubstitutor;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -123,7 +124,7 @@ public enum ErrorCode implements LocalizedError {
 			+ "of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`", true),
 	CPC_PLUS_TOO_FEW_QUALITY_MEASURES(65, "CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of "
 		+ "the following measures: `(Listing of all CPC+ measure ids)`.", true),
-	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE(66, "Missing the Supplemental data for code `(Supplemental Data Code)` for eCQM measure "
+	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE(66, "Missing the Supplemental data for code `(Supplemental Data Code)` for eCQM measure "
 		+ "`(Measure Id)`'s Sub-population `(Sub Population)`", true),
 	CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT(67, "Must have one count for Supplemental Data `(Supplemental Data Code)` "
 		+ "on Sub-population `(Sub Population)` for eCQM measure `(Measure Id)`", true),
@@ -132,10 +133,7 @@ public enum ErrorCode implements LocalizedError {
 		+ "`(CPC+ contact email)` for assistance.", true),
 	INVALID_PERFORMANCE_PERIOD_FORMAT(69, "`(Performance period start or end date)` is an invalid date format. "
 		+ "Please use a standard ISO date format. "
-		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true),
-	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_VALUE(70, "The supplemental code is unknown for the following "
-		+ "measure id `(electronic measure id)`, subpopulation type `(Subpopulation)`, and "
-		+ "supplemental template id type `(Supplemental data type)`", true);
+		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true);
 
 
 	private static final Map<Integer, ErrorCode> CODE_TO_VALUE = Arrays.stream(values())

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -123,7 +123,7 @@ public enum ErrorCode implements LocalizedError {
 			+ "of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`", true),
 	CPC_PLUS_TOO_FEW_QUALITY_MEASURES(65, "CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of "
 		+ "the following measures: `(Listing of all CPC+ measure ids)`.", true),
-	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE(66, "Missing the Supplemental Code `(Supplemental Data Code)` for eCQM measure "
+	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE(66, "Missing the Supplemental Code Node `(Supplemental Data Code)` for eCQM measure "
 		+ "`(Measure Id)`'s Sub-population `(Sub Population)`", true),
 	CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT(67, "Must have one count for Supplemental Data `(Supplemental Data Code)` "
 		+ "on Sub-population `(Sub Population)` for eCQM measure `(Measure Id)`", true),
@@ -132,7 +132,10 @@ public enum ErrorCode implements LocalizedError {
 		+ "`(CPC+ contact email)` for assistance.", true),
 	INVALID_PERFORMANCE_PERIOD_FORMAT(69, "`(Performance period start or end date)` is an invalid date format. "
 		+ "Please use a standard ISO date format. "
-		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true);
+		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true),
+	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_VALUE(70, "A supplemental code is unknown for the following "
+		+ "measure id `(electronic measure id)`, subpopulation type `(Subpopulation)`, and "
+		+ "supplemental template id type `(Supplemental data type)`", true);
 
 
 	private static final Map<Integer, ErrorCode> CODE_TO_VALUE = Arrays.stream(values())

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -123,7 +123,7 @@ public enum ErrorCode implements LocalizedError {
 			+ "of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`", true),
 	CPC_PLUS_TOO_FEW_QUALITY_MEASURES(65, "CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of "
 		+ "the following measures: `(Listing of all CPC+ measure ids)`.", true),
-	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE(66, "Missing the Supplemental Code Node `(Supplemental Data Code)` for eCQM measure "
+	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE(66, "Missing the Supplemental data for code `(Supplemental Data Code)` for eCQM measure "
 		+ "`(Measure Id)`'s Sub-population `(Sub Population)`", true),
 	CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT(67, "Must have one count for Supplemental Data `(Supplemental Data Code)` "
 		+ "on Sub-population `(Sub Population)` for eCQM measure `(Measure Id)`", true),
@@ -133,7 +133,7 @@ public enum ErrorCode implements LocalizedError {
 	INVALID_PERFORMANCE_PERIOD_FORMAT(69, "`(Performance period start or end date)` is an invalid date format. "
 		+ "Please use a standard ISO date format. "
 		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true),
-	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_VALUE(70, "A supplemental code is unknown for the following "
+	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_VALUE(70, "The supplemental code is unknown for the following "
 		+ "measure id `(electronic measure id)`, subpopulation type `(Subpopulation)`, and "
 		+ "supplemental template id type `(Supplemental data type)`", true);
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
@@ -66,23 +66,18 @@ public class CpcMeasureDataValidator extends NodeValidator {
 		EnumSet<SupplementalData> codes = EnumSet.copyOf(
 				 SupplementalData.getSupplementalDataSetByType(supplementalDataType));
 
-		MeasureConfig config = MeasureConfigs.getConfigurationMap().get(
-			node.getParent().getValue(QualityMeasureIdValidator.MEASURE_ID));
-		String measureId = config.getElectronicMeasureId();
-		if (config == null) {
-			if(measureId != null) {
-				List<String> suggestions = MeasureConfigs.getMeasureSuggestions(measureId);
-				addValidationError(Detail.forErrorAndNode(ErrorCode.MEASURE_GUID_MISSING.format(measureId, suggestions), node));
-			}
-		} else {
+		String measureId = node.getParent().getValue(QualityMeasureIdValidator.MEASURE_ID);
+		MeasureConfig config = MeasureConfigs.getConfigurationMap().get(measureId);
+		if (config != null) {
+			String electronicMeasureID = config.getElectronicMeasureId();
 			for (SupplementalData supplementalData : codes) {
 				Node validatedSupplementalNode = filterCorrectNode(supplementalDataNodes, supplementalData);
 
 				if (validatedSupplementalNode == null) {
-					addSupplementalValidationError(node, supplementalData, measureId);
+					addSupplementalValidationError(node, supplementalData, electronicMeasureID);
 				}
 			}
-			validateSupplementalDataNodeCounts(node, supplementalDataNodes, measureId);
+			validateSupplementalDataNodeCounts(node, supplementalDataNodes, electronicMeasureID);
 		}
 	}
 
@@ -144,8 +139,9 @@ public class CpcMeasureDataValidator extends NodeValidator {
 	/**
 	 * Creates a localized error for an invalid number of aggregate counts
 	 *
-	 * @param node parent node
-	 * @param supplementalCode current code that's missing
+	 * @param node holder of the measure type
+	 * @param supplementalCode data code that is missing
+	 * @param measureId electronic measure id
 	 * @return
 	 */
 	private LocalizedError makeIncorrectCountSizeLocalizedError(Node node, String supplementalCode, String measureId) {
@@ -157,7 +153,9 @@ public class CpcMeasureDataValidator extends NodeValidator {
 	/**
 	 * Creates a localized error for a missing supplemental code
 	 *
-	 * @param node
+	 * @param node Parent node holding the measure type
+	 * @param supplementalNode holder of the supplemental type
+	 * @param measureId electronic measure id
 	 * @return
 	 */
 	private LocalizedError makeMissingSupplementalCodeValueError(Node node, Node supplementalNode, String measureId) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
@@ -41,7 +41,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -58,7 +58,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ASIAN.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.ASIAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -75,7 +75,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HAWAIIAN_PACIFIC_ISLANDER.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.HAWAIIAN_PACIFIC_ISLANDER.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -92,7 +92,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.WHITE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.WHITE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -109,7 +109,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ALASKAN_NATIVE_AMERICAN_INDIAN.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.ALASKAN_NATIVE_AMERICAN_INDIAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -126,7 +126,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_RACE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.OTHER_RACE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -143,7 +143,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.MALE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -160,7 +160,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.FEMALE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.FEMALE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -177,7 +177,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -194,7 +194,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HISPANIC_LATINO.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.HISPANIC_LATINO.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -211,7 +211,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.MEDICARE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -228,7 +228,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICAID.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.MEDICAID.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -245,7 +245,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.PRIVATE_HEALTH_INSURANCE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.PRIVATE_HEALTH_INSURANCE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -262,7 +262,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_PAYER.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.OTHER_PAYER.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
@@ -44,13 +44,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -61,13 +61,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ASIAN.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ASIAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -78,13 +78,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HAWAIIAN_PACIFIC_ISLANDER.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HAWAIIAN_PACIFIC_ISLANDER.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -95,13 +95,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.WHITE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.WHITE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -112,13 +112,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ALASKAN_NATIVE_AMERICAN_INDIAN.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ALASKAN_NATIVE_AMERICAN_INDIAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -129,13 +129,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_RACE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_RACE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -146,13 +146,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
 			MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(error);
+			.contains(expectedError);
 	}
 
 	@Test
@@ -163,13 +163,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -180,13 +180,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.FEMALE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.FEMALE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -197,13 +197,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
 			MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(error);
+			.contains(expectedError);
 	}
 
 	@Test
@@ -214,13 +214,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -231,13 +231,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HISPANIC_LATINO.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HISPANIC_LATINO.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -248,13 +248,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
 			MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(error);
+			.contains(expectedError);
 	}
 
 	@Test
@@ -265,13 +265,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -282,13 +282,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICAID.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICAID.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -299,13 +299,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.PRIVATE_HEALTH_INSURANCE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.PRIVATE_HEALTH_INSURANCE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -316,13 +316,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_PAYER.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_PAYER.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 
 	@Test
@@ -333,13 +333,13 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
 			MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(error);
+			.contains(expectedError);
 	}
 
 	@Test
@@ -350,12 +350,12 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT.format(
+		LocalizedError expectedError = ErrorCode.CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT.format(
 				 SupplementalData.MALE.getCode(), SubPopulations.IPOP, MEASURE_ID);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(error);
+				.contains(expectedError);
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp.conversion.validate;
 
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.TestHelper;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.decode.QrdaDecoderEngine;
@@ -12,14 +14,15 @@ import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
 import gov.cms.qpp.conversion.model.validation.SupplementalData;
 import gov.cms.qpp.conversion.xml.XmlUtils;
+
 import java.util.Set;
-import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 class CpcMeasureDataValidatorTest {
 
 	private static final String MEASURE_ID = "CMS122v5";
+	private static final String MISSING_SUPPLEMENTAL_CODES_FILE = "missingSupplementalCodeFile.xml";
 
 	@Test
 	void validateSuccessfulSupplementalDataFieldsTest() throws Exception {
@@ -41,7 +44,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -58,7 +61,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.ASIAN.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ASIAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -75,7 +78,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.HAWAIIAN_PACIFIC_ISLANDER.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HAWAIIAN_PACIFIC_ISLANDER.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -92,7 +95,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.WHITE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.WHITE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -109,7 +112,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.ALASKAN_NATIVE_AMERICAN_INDIAN.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.ALASKAN_NATIVE_AMERICAN_INDIAN.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -126,13 +129,30 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.OTHER_RACE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_RACE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.contains(error);
+	}
+
+	@Test
+	void validateFailureSupplementalRaceCodeMissing() throws Exception {
+		String failureSexFile = TestHelper.getFixture(MISSING_SUPPLEMENTAL_CODES_FILE);
+		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(failureSexFile));
+		CpcMeasureDataValidator validator = new CpcMeasureDataValidator();
+		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
+		validator.internalValidateSingleNode(underTest);
+
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.AFRICAN_AMERICAN.getCode(),
+			MEASURE_ID, SubPopulations.IPOP);
+
+		Set<Detail> errors = validator.getDetails();
+
+		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.contains(error);
 	}
 
 	@Test
@@ -143,7 +163,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.MALE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -160,13 +180,30 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.FEMALE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.FEMALE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.contains(error);
+	}
+
+	@Test
+	void validateFailureSupplementalSexCodeMissing() throws Exception {
+		String failureSexFile = TestHelper.getFixture(MISSING_SUPPLEMENTAL_CODES_FILE);
+		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(failureSexFile));
+		CpcMeasureDataValidator validator = new CpcMeasureDataValidator();
+		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
+		validator.internalValidateSingleNode(underTest);
+
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MALE.getCode(),
+			MEASURE_ID, SubPopulations.IPOP);
+
+		Set<Detail> errors = validator.getDetails();
+
+		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.contains(error);
 	}
 
 	@Test
@@ -177,7 +214,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -194,13 +231,30 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.HISPANIC_LATINO.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.HISPANIC_LATINO.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.contains(error);
+	}
+
+	@Test
+	void validateFailureSupplementalEthnicityCodeMissing() throws Exception {
+		String failureSexFile = TestHelper.getFixture(MISSING_SUPPLEMENTAL_CODES_FILE);
+		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(failureSexFile));
+		CpcMeasureDataValidator validator = new CpcMeasureDataValidator();
+		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
+		validator.internalValidateSingleNode(underTest);
+
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.NOT_HISPANIC_LATINO.getCode(),
+			MEASURE_ID, SubPopulations.IPOP);
+
+		Set<Detail> errors = validator.getDetails();
+
+		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.contains(error);
 	}
 
 	@Test
@@ -211,7 +265,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.MEDICARE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -228,7 +282,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.MEDICAID.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICAID.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -245,7 +299,7 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.PRIVATE_HEALTH_INSURANCE.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.PRIVATE_HEALTH_INSURANCE.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
@@ -262,13 +316,30 @@ class CpcMeasureDataValidatorTest {
 		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
 		validator.internalValidateSingleNode(underTest);
 
-		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE_NODE.format(SupplementalData.OTHER_PAYER.getCode(),
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.OTHER_PAYER.getCode(),
 				MEASURE_ID, SubPopulations.IPOP);
 
 		Set<Detail> errors = validator.getDetails();
 
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.contains(error);
+	}
+
+	@Test
+	void validateFailureSupplementalPayerCodeMissing() throws Exception {
+		String failureSexFile = TestHelper.getFixture(MISSING_SUPPLEMENTAL_CODES_FILE);
+		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(failureSexFile));
+		CpcMeasureDataValidator validator = new CpcMeasureDataValidator();
+		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V2);
+		validator.internalValidateSingleNode(underTest);
+
+		LocalizedError error = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE.format(SupplementalData.MEDICARE.getCode(),
+			MEASURE_ID, SubPopulations.IPOP);
+
+		Set<Detail> errors = validator.getDetails();
+
+		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.contains(error);
 	}
 
 	@Test

--- a/converter/src/test/resources/fixtures/missingSupplementalCodeFile.xml
+++ b/converter/src/test/resources/fixtures/missingSupplementalCodeFile.xml
@@ -1,0 +1,669 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+	  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<organizer classCode="CLUSTER" moodCode="EVN">
+		<component>
+			<section>
+				<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+				<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+				<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01"/>
+				<code code="55186-1"
+					  codeSystem="2.16.840.1.113883.6.1"
+					  displayName="measure document"/>
+				<title>Measure Section</title>
+				<!--Performance Period-->
+				<entry>
+					<act classCode="ACT" moodCode="EVN">
+						<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+						<id root="D5E68228-5760-11E7-1256-09173F13E4C5"/>
+						<code code="252116004"
+							  codeSystem="2.16.840.1.113883.6.96"
+							  displayName="Observation Parameters"/>
+						<effectiveTime>
+							<low value="20170101"/>
+							<high value="20171231"/>
+						</effectiveTime>
+					</act>
+				</entry>
+				<!--Measure Entry for NQF 0059 / CMS122-->
+				<entry>
+					<organizer classCode="CLUSTER" moodCode="EVN">
+						<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+						<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+						<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+						<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+						<statusCode code="completed"/>
+						<!--Measure Reference and Results-->
+						<reference typeCode="REFR">
+							<externalDocument classCode="DOC" moodCode="EVN">
+								<id root="2.16.840.1.113883.4.738"
+									extension="40280381-51f0-825b-0152-229afff616ee"/>
+								<code code="57024-2"
+									  codeSystem="2.16.840.1.113883.6.1"
+									  codeSystemName="LOINC"
+									  displayName="Health Quality Measure Document"/>
+								<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+							</externalDocument>
+						</reference>
+						<!--Performance Rate-->
+						<component>
+							<observation classCode="OBS" moodCode="EVN">
+								<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+								<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+								<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+								<code code="72510-1"
+									  codeSystem="2.16.840.1.113883.6.1"
+									  codeSystemName="LOINC"
+									  displayName="Performance Rate"/>
+								<statusCode code="completed"/>
+								<!--Null Flavor Attribute -->
+								<value xsi:type="REAL" nullFlavor="NA"/>
+								<reference typeCode="REFR">
+									<externalObservation classCode="OBS" moodCode="EVN">
+										<id root="6D01A564-58CC-4CF5-929F-B83583701BFE"/>
+										<code code="NUMER"
+											  codeSystem="2.16.840.1.113883.5.4"
+											  codeSystemName="ActCode"
+											  displayName="Numerator"/>
+									</externalObservation>
+								</reference>
+							</observation>
+						</component>
+						<!--IPOP Population-->
+						<component>
+							<observation classCode="OBS" moodCode="EVN">
+								<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+								<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+								<code code="ASSERTION"
+									  codeSystem="2.16.840.1.113883.5.4"
+									  codeSystemName="ActCode"
+									  displayName="Assertion"/>
+								<statusCode code="completed"/>
+								<value xsi:type="CD"
+									   code="IPOP"
+									   codeSystem="2.16.840.1.113883.5.4"
+									   codeSystemName="ActCode"/>
+								<!--IPOP Count-->
+								<entryRelationship typeCode="SUBJ" inversionInd="true">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+										<code code="MSRAGG"
+											  codeSystem="2.16.840.1.113883.5.4"
+											  codeSystemName="ActCode"
+											  displayName="rate aggregation"/>
+										<statusCode code="completed"/>
+										<value xsi:type="INT" value="1000"/>
+										<methodCode code="COUNT"
+													codeSystem="2.16.840.1.113883.5.84"
+													codeSystemName="ObservationMethod"
+													displayName="Count"/>
+									</observation>
+								</entryRelationship>
+								<!--Gender Supplemental Data Element - Male missing code-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+										<id root="D5E68236-5760-11E7-1256-09173F13E4C5"/>
+										<code code="76689-9"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Sex assigned at birth"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   codeSystem="2.16.840.1.113883.5.1"
+											   codeSystemName="AdministrativeGenderCode"
+											   displayName="Male"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="500"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Gender Supplemental Data Element - Female-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+										<id root="D5E68237-5760-11E7-1256-09173F13E4C5"/>
+										<code code="76689-9"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Sex assigned at birth"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="F"
+											   codeSystem="2.16.840.1.113883.5.1"
+											   codeSystemName="AdministrativeGenderCode"
+											   displayName="Female"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="500"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino missing code-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+										<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+										<code code="69490-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Ethnicity"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<!--Missing Code-->
+										<value xsi:type="CD"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="Not Hispanic or Latino"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="500"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+										<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+										<code code="69490-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Ethnicity"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="2135-2"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="Hispanic or Latino"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="500"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Race Supplemental Data Element - Black or African American missing code-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+										<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+										<code code="72826-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Race"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="Black or African American"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Race Supplemental Data Element - White-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+										<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+										<code code="72826-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Race"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="2106-3"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="White"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Race Supplemental Data Element - Asian-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+										<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+										<code code="72826-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Race"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="2028-9"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="Asian"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+										<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+										<code code="72826-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Race"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="1002-5"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="American Indian or Alaska Native"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Race Supplemental Data Element - Hawaiian/Pacific Islander-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+										<id root="Some Root for Hawaiian/Pacific Islander"/>
+										<code code="72826-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Race"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="2076-8"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="American Indian or Alaska Native"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Race Supplemental Data Element - Other-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+										<id root="Some Root for Other"/>
+										<code code="72826-1"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Race"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD"
+											   code="2131-1"
+											   codeSystem="2.16.840.1.113883.6.238"
+											   codeSystemName="Race &amp; Ethnicity - CDC"
+											   displayName="American Indian or Alaska Native"/>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Payer Supplemental Data Element - Medicare missing code -->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+										<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+										<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+										<code code="48768-6"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Payment Source"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD" nullFlavor="OTH">
+											<translation
+														 codeSystem="2.16.840.1.113883.3.249.12"
+														 codeSystemName="CMS Clinical Codes"
+														 displayName="Medicare"/>
+										</value>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Payer Supplemental Data Element - Medicaid-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+										<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+										<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+										<code code="48768-6"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Payment Source"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD" nullFlavor="OTH">
+											<translation code="B"
+														 codeSystem="2.16.840.1.113883.3.249.12"
+														 codeSystemName="CMS Clinical Codes"
+														 displayName="Medicaid"/>
+										</value>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Payer Supplemental Data Element - Private Health Insurance-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+										<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+										<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+										<code code="48768-6"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Payment Source"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD" nullFlavor="OTH">
+											<translation code="C"
+														 codeSystem="2.16.840.1.113883.3.249.12"
+														 codeSystemName="CMS Clinical Codes"
+														 displayName="Private Health Insurance"/>
+										</value>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--Payer Supplemental Data Element - Other-->
+								<entryRelationship typeCode="COMP">
+									<observation classCode="OBS" moodCode="EVN">
+										<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+										<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+										<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+										<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+										<code code="48768-6"
+											  codeSystem="2.16.840.1.113883.6.1"
+											  codeSystemName="LOINC"
+											  displayName="Payment Source"/>
+										<statusCode code="completed"/>
+										<effectiveTime>
+											<low value="20170101"/>
+											<high value="20171231"/>
+										</effectiveTime>
+										<value xsi:type="CD" nullFlavor="OTH">
+											<translation code="D"
+														 codeSystem="2.16.840.1.113883.3.249.12"
+														 codeSystemName="CMS Clinical Codes"
+														 displayName="Other"/>
+										</value>
+										<!-- Count-->
+										<entryRelationship typeCode="SUBJ" inversionInd="true">
+											<observation classCode="OBS" moodCode="EVN">
+												<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+												<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+												<code code="MSRAGG"
+													  codeSystem="2.16.840.1.113883.5.4"
+													  codeSystemName="ActCode"
+													  displayName="rate aggregation"/>
+												<statusCode code="completed"/>
+												<value xsi:type="INT" value="250"/>
+												<methodCode code="COUNT"
+															codeSystem="2.16.840.1.113883.5.84"
+															codeSystemName="ObservationMethod"
+															displayName="Count"/>
+											</observation>
+										</entryRelationship>
+									</observation>
+								</entryRelationship>
+								<!--IPOP Population ID from eMeasure-->
+								<reference typeCode="REFR">
+									<externalObservation classCode="OBS" moodCode="EVN">
+										<id root="0739FE2E-B8DE-4A56-B064-877CC8E0977D"/>
+									</externalObservation>
+								</reference>
+							</observation>
+						</component>
+					</organizer>
+				</entry>
+			</section>
+		</component>
+	</organizer>
+</root>


### PR DESCRIPTION
### Information
- QPPCT-671

### Changes proposed in this PR:
- Refactored the validation of supplemental data aggregate counts to occur within the same loop as the supplemental codes. This rendered the object that was causing the NPE to not be used anymore.
- Added new tests for each supplemental type to ensure the correct error would output instead of a null pointer exception.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
