### PR TITLE
QPPCT-681: disable javadoc for private

### DIFF
--- a/commons/src/main/java/gov/cms/qpp/conversion/util/EnvironmentHelper.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/util/EnvironmentHelper.java
@@ -30,6 +30,13 @@ public class EnvironmentHelper {
 		return System.getenv(variable);
 	}
 
+	/**
+	 * Get the value for a given property / environment variable. Substitute the given default if not found.
+	 *
+	 * @param variable key used to search for value
+	 * @param defaultValue substitute value if not found
+	 * @return value for the given variable key or substitute
+	 */
 	public static String getOrDefault(String variable, String defaultValue) {
 		String value = get(variable);
 		return value == null ? defaultValue : value;

--- a/converter/src/main/java/gov/cms/qpp/conversion/Context.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/Context.java
@@ -126,6 +126,8 @@ public class Context {
 	/**
 	 * Looks up or creates a new {@link Registry} for the given annotation type under this context
 	 *
+	 * @param <A> Marker annotation that helps identify registry types
+	 * @param <R> Types that comprise the registry
 	 * @param annotation The annotation type to use for class path searching in the {@link Registry}
 	 * @return The existing or new {@link Registry}
 	 */

--- a/converter/src/main/java/gov/cms/qpp/conversion/InputStreamSupplierSource.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/InputStreamSupplierSource.java
@@ -23,7 +23,7 @@ public class InputStreamSupplierSource extends SkeletalSource {
 	 * Because the size is not specified, this constructor loads the {@link InputStream} into memory to calculate the size.
 	 *
 	 * @param name The name of the source.
-	 * @param supplier The supplier of an {@link InputStream}.
+	 * @param source an {@link InputStream}.
 	 */
 	public InputStreamSupplierSource(String name, InputStream source) {
 		super(name);

--- a/converter/src/main/java/gov/cms/qpp/conversion/correlation/PathCorrelator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/correlation/PathCorrelator.java
@@ -39,6 +39,8 @@ public class PathCorrelator {
 
 	/**
 	 * Initializes correlations between json paths and xpaths
+	 *
+	 * @return a holder for path correlations
 	 */
 	private static PathCorrelation loadPathCorrelation() {
 		PathCorrelation pathCorrelation;

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/AciProportionNumeratorDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/AciProportionNumeratorDecoder.java
@@ -22,7 +22,7 @@ public class AciProportionNumeratorDecoder extends QrdaDecoder {
 	 *
 	 * @param element XML element that represents the ACI Numerator
 	 * @param thisNode Node that represents the ACI Numerator Measure
-	 * @return
+	 * @return carry on
 	 */
 	@Override
 	protected DecodeResult decode(Element element, Node thisNode) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
@@ -58,7 +58,7 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 
 	/**
 	 * Looks up the entity Id from the element if the program name is CPC+
-	 * <id root="2.16.840.1.113883.3.249.5.1" extension="AR000000"/>
+	 * {@code <id root="2.16.840.1.113883.3.249.5.1" extension="AR000000"/>}
 	 *
 	 * @param element Xml fragment being parsed.
 	 * @param thisNode The output internal representation of the document

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/IaSectionDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/IaSectionDecoder.java
@@ -22,7 +22,7 @@ public class IaSectionDecoder extends QrdaDecoder {
 	 * This will update the thisNode value
 	 * @param element Top element in the XML document
 	 * @param thisNode Node
-	 * @return
+	 * @return carry on
 	 */
 	@Override
 	protected DecodeResult decode(Element element, Node thisNode) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/MeasurePerformedDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/MeasurePerformedDecoder.java
@@ -26,7 +26,7 @@ public class MeasurePerformedDecoder extends QrdaDecoder {
 	 *
 	 * @param element XML parsed representation of measure performed
 	 * @param thisNode Object to hold the measure performed
-	 * @return
+	 * @return we're done with this branch of the tree
 	 */
 	@Override
 	protected DecodeResult decode(Element element, Node thisNode) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/PerformanceRateProportionMeasureDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/PerformanceRateProportionMeasureDecoder.java
@@ -32,7 +32,7 @@ public class PerformanceRateProportionMeasureDecoder extends QrdaDecoder {
 	 *
 	 * @param element Top element in the XML document
 	 * @param thisNode Top node created in the XML document
-	 * @return
+	 * @return we're done with this branch of the tree
 	 */
 	@Override
 	protected DecodeResult decode(Element element, Node thisNode) {
@@ -48,8 +48,8 @@ public class PerformanceRateProportionMeasureDecoder extends QrdaDecoder {
 	/**
 	 * Check if the first expression successfully found a performance rate value
 	 *
-	 * @param performanceRateNode
-	 * @return
+	 * @param performanceRateNode a node which describes a performance rate
+	 * @return result of the check
 	 */
 	private boolean isFirstExpressionUnsuccessful(Node performanceRateNode) {
 		return null == performanceRateNode.getValue(PERFORMANCE_RATE);
@@ -61,7 +61,6 @@ public class PerformanceRateProportionMeasureDecoder extends QrdaDecoder {
 	 * @param element Object the xpath will be evaluated upon
 	 * @param node Object to hold the value found
 	 * @param name Attribute name associated with the correct xpath
-	 * @return
 	 */
 	private void setNameOnNode(Element element, Node node, final String name) {
 		String expression = getXpath(name);

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/QrdaDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/QrdaDecoder.java
@@ -39,6 +39,8 @@ public abstract class QrdaDecoder {
 	 * Sets the xml namespace.
 	 *
 	 * Required so that we find the correct elements.  For example, XPath evaluation needs to know namespaces.
+	 *
+	 * @param defaultNs namespace assigned to decoder
 	 */
 	public void setNamespace(Namespace defaultNs) {
 		this.defaultNs = defaultNs;

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/QrdaDecoderEngine.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/QrdaDecoderEngine.java
@@ -37,6 +37,8 @@ public class QrdaDecoderEngine extends XmlDecoderEngine {
 
 	/**
 	 * Initialize a QPP xml decoder
+	 *
+	 * @param context Establish context for decoder engine
 	 */
 	public QrdaDecoderEngine(Context context) {
 		Objects.requireNonNull(context, "converter");

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/XmlDecoderEngine.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/XmlDecoderEngine.java
@@ -18,6 +18,7 @@ public abstract class XmlDecoderEngine implements InputDecoderEngine {
 	/**
 	 * decodeXml Determines what formats of xml we accept and decode to
 	 *
+	 * @param context Establish context for decoder engine
 	 * @param xmlDoc XML document whose format is to be determined
 	 * @return Root intermediate format node
 	 */

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ScopedQppOutputEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ScopedQppOutputEncoder.java
@@ -19,8 +19,7 @@ public class ScopedQppOutputEncoder extends QppOutputEncoder {
 	}
 
 	/**
-	 * Encode the decoded node. If a {@link TemplateId#PLACEHOLDER} node is detected then assume
-	 * the {@link Converter#scope} has been set to a level lower than {@link QrdaScope#CLINICAL_DOCUMENT}.
+	 * Encode the decoded node.
 	 *
 	 * @param wrapper object to encode into
 	 * @param node object to encode

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ScopedQppOutputEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ScopedQppOutputEncoder.java
@@ -1,7 +1,6 @@
 package gov.cms.qpp.conversion.encode;
 
 import gov.cms.qpp.conversion.Context;
-import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.segmentation.QrdaScope;

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Encoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Encoder.java
@@ -15,10 +15,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Encoder {
 
 	/**
-	 * The param(s) is/are the string pattern(s) that the defined handler will
-	 * act.
+	 * The template id with which this encoder is associated.
 	 *
-	 * @return
+	 * @return the template id
 	 */
 	TemplateId value();
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -108,6 +108,7 @@ public class Node {
 	 *
 	 * @param name  String key to store value under
 	 * @param value String that is stored with this xml parsed Node
+	 * @param replace replace existing value
 	 */
 	public void putValue(String name, String value, boolean replace) {
 		if (getValue(name) == null || replace) {
@@ -153,6 +154,7 @@ public class Node {
 	/**
 	 * Returns a list of child Nodes for each template id specified
 	 *
+	 * @param templateIds we're looking for these.
 	 * @return List of matching child Nodes.
 	 */
 	public Stream<Node> getChildNodes(TemplateId... templateIds) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Program.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Program.java
@@ -31,8 +31,8 @@ public enum Program {
 	/**
 	 * Checks if a node is using the CPC program
 	 *
-	 * @param node
-	 * @return
+	 * @param node to check
+	 * @return result of check
 	 */
 	public static boolean isCpc(Node node) {
 		return extractProgram(node) == Program.CPC;
@@ -41,8 +41,8 @@ public enum Program {
 	/**
 	 * Extracts a program type from a node
 	 *
-	 * @param node
-	 * @return
+	 * @param node to interrogate
+	 * @return program with which node is affiliated
 	 */
 	public static Program extractProgram(Node node) {
 		return Program.getInstance(node.getValue(ClinicalDocumentDecoder.RAW_PROGRAM_NAME));

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Registry.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Registry.java
@@ -102,7 +102,8 @@ public class Registry<R> {
 	 * Later iteration will examine the XPATH startsWith and return a most
 	 * appropriate handler
 	 *
-	 * @param registryKey String
+	 * @param registryKey template id key
+	 * @return value corresponding to registry key
 	 */
 	public R get(TemplateId registryKey) {
 		return instantiateHandler(findHandler(registryKey));

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
@@ -120,6 +120,9 @@ public enum TemplateId {
 	}
 
 	/**
+	 * String representation of this template id
+	 *
+	 * @param context allows historical check
 	 * @return The complete template ID which includes a concatenation of the root followed by a colon followed by the
 	 * extension.
 	 */
@@ -132,6 +135,7 @@ public enum TemplateId {
 	 *
 	 * @param root The root part of the templateId.
 	 * @param extension The extension part of the templateId.
+	 * @param context allows historical check
 	 * @return The template ID if found.  Else {@code TemplateId.DEFAULT}.
 	 */
 	public static TemplateId getTemplateId(final String root, final String extension, final Context context) {
@@ -158,6 +162,7 @@ public enum TemplateId {
 	 *
 	 * @param root The root part of the templateId.
 	 * @param extension The extension part of the templateId.
+	 * @param context allows historical check
 	 * @return A string that concatenates the arguments the same way the enumeration does.
 	 */
 	static String generateTemplateIdString(String root, String extension, Context context) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -36,6 +36,8 @@ public class Detail implements Serializable {
 
 	/**
 	 * Copy constructor
+	 *
+	 * @param detail object from which to copy
 	 */
 	public Detail(Detail detail) {
 		errorCode = detail.errorCode;
@@ -47,6 +49,10 @@ public class Detail implements Serializable {
 
 	/**
 	 * Creates a mutable Detail based on the given error and node
+	 *
+	 * @param error error to be added
+	 * @param node node that gives the error context
+	 * @return detail for given error
 	 */
 	public static Detail forErrorAndNode(LocalizedError error, Node node) {
 		Objects.requireNonNull(node, "node");
@@ -58,8 +64,9 @@ public class Detail implements Serializable {
 
 	/**
 	 * Creates a mutable Detail based on the given error
+	 *
 	 * @param error error to be added
-	 * @return
+	 * @return detail for given error
 	 */
 	public static Detail forErrorCode(LocalizedError error) {
 		Objects.requireNonNull(error, "error");

--- a/converter/src/main/java/gov/cms/qpp/conversion/util/JsonHelper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/util/JsonHelper.java
@@ -99,7 +99,7 @@ public class JsonHelper {
 	 * @param valueType object type representation
 	 * @param <T> generic class type
 	 * @return Object of specified type
-	 * @throws JsonReadException if problems arise while attempting to parse the json input stream
+	 * @throws IOException if problems arise while attempting to parse the json file
 	 */
 	public static <T> T readJson(Path filePath, TypeReference<T> valueType) throws IOException {
 		return new ObjectMapper().readValue(filePath.toFile(), valueType);

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/Checker.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/Checker.java
@@ -268,6 +268,7 @@ class Checker {
 	 * Checks target node for the existence of a specified parent.
 	 *
 	 * @param code that identifies the error
+	 * @param type parent template id for which to search.
 	 * @return The checker, for chaining method calls.
 	 */
 	Checker hasParent(LocalizedError code, TemplateId type) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidator.java
@@ -22,6 +22,7 @@ public class ClinicalDocumentValidator extends NodeValidator {
 	/**
 	 * Validates a single Clinical Document Node.
 	 * Validates the following.
+	 * <p>
 	 * <ul>
 	 * <li>At least one child exists.</li>
 	 * <li>At least one ACI or IA or eCQM (MEASURE_SECTION_V2) section exists.</li>

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidator.java
@@ -22,7 +22,6 @@ public class ClinicalDocumentValidator extends NodeValidator {
 	/**
 	 * Validates a single Clinical Document Node.
 	 * Validates the following.
-	 * <p>
 	 * <ul>
 	 * <li>At least one child exists.</li>
 	 * <li>At least one ACI or IA or eCQM (MEASURE_SECTION_V2) section exists.</li>
@@ -30,7 +29,6 @@ public class ClinicalDocumentValidator extends NodeValidator {
 	 * <li>TIN name is required</li>
 	 * <li>Performance year is required</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param node Node that represents a Clinical Document.
 	 */

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
@@ -79,7 +79,7 @@ public class CpcMeasureDataValidator extends NodeValidator {
 	 *
 	 * @param supplementalDataNodes List of nodes to filter
 	 * @param supplementalData Current Supplemental Data to validate against
-	 * @return
+	 * @return first matching node
 	 */
 	private Node filterCorrectNode(Set<Node> supplementalDataNodes, SupplementalData supplementalData) {
 		return supplementalDataNodes.stream()
@@ -92,7 +92,7 @@ public class CpcMeasureDataValidator extends NodeValidator {
 	 * Predicate for filtering the correct Supplemental Data node.
 	 *
 	 * @param code Required code to be validate against
-	 * @return
+	 * @return filtering predicate
 	 */
 	private Predicate<Node> filterDataBySupplementalCode(String code) {
 		return thisNode -> code.equalsIgnoreCase(thisNode.getValue(SUPPLEMENTAL_DATA_KEY));
@@ -135,7 +135,7 @@ public class CpcMeasureDataValidator extends NodeValidator {
 	 *
 	 * @param node parent node
 	 * @param thisNode current supplemental node to be validated
-	 * @return
+	 * @return initialized {@link LocalizedError}
 	 */
 	private LocalizedError makeIncorrectCountSizeLocalizedError(Node node, Node thisNode) {
 		MeasureConfig config = MeasureConfigs.getConfigurationMap().get(

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MeasureDataValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MeasureDataValidator.java
@@ -17,7 +17,7 @@ public class MeasureDataValidator extends NodeValidator {
 	 * Validates the following.
 	 * <ul>
 	 *    <li>An integer value with a name in the list from MeasureDataDecoder.MEASURES</li>
-	 *    <li>The string value is an integer/li>
+	 *    <li>The string value is an integer</li>
 	 *</ul>
 	 *
 	 * @param node Node that represents a IA Measure Performed.

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MeasurePerformedValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MeasurePerformedValidator.java
@@ -14,7 +14,7 @@ public class MeasurePerformedValidator extends NodeValidator {
 	private static final String[] BOOLEAN_VALUES = {"Y", "N"};
 
 	/**
-	 * An string value named "measurePerformed" was decoded from the source element<
+	 * An string value named "measurePerformed" was decoded from the source element
 	 * The string value is either a Y or an N
 	 *
 	 * @param node Node that represents a Measure Performed.

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -120,8 +120,8 @@ public class MipsQualityMeasureIdValidator extends QualityMeasureIdValidator {
 	 * Creates a {@link Predicate} which takes a SubPopulation and tests whether
 	 * the SubPopulation's Uuid is equal to the given unique id
 	 *
-	 * @param uuid
-	 * @return
+	 * @param uuid value that forms basis for finder comparison
+	 * @return finder predicate
 	 */
 	private Predicate<SubPopulation> makePerformanceRateUuidFinder(String uuid) {
 		return subPopulation -> uuid.equalsIgnoreCase(subPopulation.getNumeratorUuid());

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -212,6 +212,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	/**
 	 * Method template for measure validations.
 	 *
+	 * @param sub {@link SubPopulation} against which follow validations may be performed
 	 * @param check a property existence check
 	 * @param keys that identify measure
 	 * @return a callback / consumer that will perform a measure specific validation against a given

--- a/pom.xml
+++ b/pom.xml
@@ -181,9 +181,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.0.0</version>
-					<configuration>
-						<show>private</show>
-					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1.java
@@ -41,7 +41,7 @@ public class QrdaControllerV1 {
 	/**
 	 * init dependencies
 	 *
-	 * @param qrdaService {@link QrdaService} to perform QRDA -> QPP conversion
+	 * @param qrdaService {@link QrdaService} to perform QRDA to QPP conversion
 	 * @param validationService {@link ValidationService} to perform post conversion validation
 	 * @param auditService {@link AuditService} to persist audit information
 	 */

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/helper/MetadataHelper.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/helper/MetadataHelper.java
@@ -30,9 +30,9 @@ public class MetadataHelper {
 	 * Generates a {@link Metadata} object from a {@link Node}.
 	 * This {@link Metadata} does not contain data not found in a standard {@link Node}.
 	 *
-	 * @param node
-	 * @param outcome
-	 * @return
+	 * @param node from which to extract metadata
+	 * @param outcome to update with metadata
+	 * @return metadata
 	 */
 	public static Metadata generateMetadata(Node node, Outcome outcome) {
 		Objects.requireNonNull(outcome, "outcome");
@@ -55,6 +55,7 @@ public class MetadataHelper {
 	/**
 	 * Retrieves the random hash for the Cpc field if this is a CPC+ conversion.
 	 *
+	 * @param node to ensure it's a CPC+ node
 	 * @return Cpc field randomly hashed or null if this isn't a CPC+ conversion
 	 */
 	private static String deriveCpcHash(Node node) {
@@ -70,6 +71,7 @@ public class MetadataHelper {
 	/**
 	 * Retrieves the APM Entity Id from the given node
 	 *
+	 * @param node to interrogate
 	 * @return Apm Entity ID value
 	 */
 	private static String findApm(Node node) {
@@ -79,6 +81,7 @@ public class MetadataHelper {
 	/**
 	 * Retrieves the Taxpayer Identification Number from the given node
 	 *
+	 * @param node to interrogate
 	 * @return TIN value
 	 */
 	private static String findTin(Node node) {
@@ -89,6 +92,7 @@ public class MetadataHelper {
 	/**
 	 * Retrieves the National Provider Identifier from the given node
 	 *
+	 * @param node to interrogate
 	 * @return NPI value
 	 */
 	private static String findNpi(Node node) {
@@ -99,6 +103,7 @@ public class MetadataHelper {
 	/**
 	 * Retrieves the random hash for CPC Field
 	 *
+	 * @param node to interrogate
 	 * @return Cpc field randomly hashed
 	 */
 	private static boolean isCpc(Node node) {
@@ -115,10 +120,10 @@ public class MetadataHelper {
 	/**
 	 * Recursively searches a node for a value.
 	 *
-	 * @param node
-	 * @param key
-	 * @param possibleLocations
-	 * @return
+	 * @param node to interrogate
+	 * @param key value name
+	 * @param possibleLocations where the value might reside
+	 * @return the found value or null
 	 */
 	private static String findValue(Node node, String key, TemplateId... possibleLocations) {
 		String value = node.getValue(key);


### PR DESCRIPTION
### Information
- QPPCT-681

### Changes proposed in this PR:
- disabled generation of java documentation for private members

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
