### PR TITLE
Force to use us-east-1 for our acceptance tests

### DIFF
--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/CpcApiAcceptance.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/CpcApiAcceptance.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.api.acceptance;
 
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.AttributeEncryptor;
@@ -10,8 +11,6 @@ import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.springframework.core.env.Environment;
 
 import gov.cms.qpp.conversion.api.config.DynamoDbConfigFactory;
 import gov.cms.qpp.conversion.api.helper.JwtPayloadHelper;
@@ -45,9 +44,9 @@ class CpcApiAcceptance {
 		+ "/*[local-name() = 'intendedRecipient' and namespace-uri() = 'urn:hl7-org:v3']"
 		+ "/*[local-name() = 'id' and namespace-uri() = 'urn:hl7-org:v3'][@root='2.16.840.1.113883.3.249.7']/@extension";
 	private static final String CPC_PLUS_PROGRAM_NAME = "CPCPLUS";
-	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().build();
+	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static DynamoDBMapper mapper;
-	private static AWSKMS kmsClient = AWSKMSClientBuilder.defaultClient();
+	private static AWSKMS kmsClient = AWSKMSClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static final String TEST_KMS_KEY_ENV_VARIABLE = "TEST_KMS_KEY";
 	private static final String DEFAULT_KMS_ARN = "arn:aws:kms:us-east-1:850094054452:key/8b19f7e9-b58c-4b7a-8162-e01809a8a2e9";
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/CpcApiAcceptance.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/CpcApiAcceptance.java
@@ -1,14 +1,9 @@
 package gov.cms.qpp.conversion.api.acceptance;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.AttributeEncryptor;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.DirectKmsMaterialProvider;
-import com.amazonaws.services.kms.AWSKMS;
-import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -44,9 +39,7 @@ class CpcApiAcceptance {
 		+ "/*[local-name() = 'intendedRecipient' and namespace-uri() = 'urn:hl7-org:v3']"
 		+ "/*[local-name() = 'id' and namespace-uri() = 'urn:hl7-org:v3'][@root='2.16.840.1.113883.3.249.7']/@extension";
 	private static final String CPC_PLUS_PROGRAM_NAME = "CPCPLUS";
-	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static DynamoDBMapper mapper;
-	private static AWSKMS kmsClient = AWSKMSClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static final String TEST_KMS_KEY_ENV_VARIABLE = "TEST_KMS_KEY";
 	private static final String DEFAULT_KMS_ARN = "arn:aws:kms:us-east-1:850094054452:key/8b19f7e9-b58c-4b7a-8162-e01809a8a2e9";
 
@@ -54,9 +47,9 @@ class CpcApiAcceptance {
 	static void setUp() {
 		String kmsKey = EnvironmentHelper.getOrDefault(TEST_KMS_KEY_ENV_VARIABLE, DEFAULT_KMS_ARN);
 		mapper = DynamoDbConfigFactory
-			.createDynamoDbMapper(dynamoClient, DynamoDBMapperConfig.builder()
+			.createDynamoDbMapper(AwsTestHelper.getDynamoClient(), DynamoDBMapperConfig.builder()
 				.withTableNameOverride(new DynamoDBMapperConfig.TableNameOverride(AwsTestHelper.TEST_DYNAMO_TABLE_NAME))
-				.build(), new AttributeEncryptor(new DirectKmsMaterialProvider(kmsClient, kmsKey)));
+				.build(), new AttributeEncryptor(new DirectKmsMaterialProvider(AwsTestHelper.getKmsClient(), kmsKey)));
 
 		given()
 			.multiPart("file", Paths.get("../sample-files/CPCPlus_Success_PreProd.xml").toFile())

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/QrdaApiAcceptance.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/QrdaApiAcceptance.java
@@ -1,12 +1,9 @@
 package gov.cms.qpp.conversion.api.acceptance;
 
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,10 +23,6 @@ class QrdaApiAcceptance {
 	private static final String QRDA_API_PATH = "/";
 	private static final String MULTIPART_FORM_DATA_KEY = "file";
 	private static final String TEST_S3_BUCKET_NAME = "qpp-qrda3converter-acceptance-test";
-
-	private AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
-
-	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 
 	private long beforeObjectCount;
 	private long beforeDynamoCount;
@@ -89,6 +82,7 @@ class QrdaApiAcceptance {
 	}
 
 	private long getS3ObjectCount() {
+		AmazonS3 s3Client = AwsTestHelper.getS3Client();
 
 		ObjectListing objectListing = s3Client.listObjects(TEST_S3_BUCKET_NAME);
 		long objectCount = objectListing.getObjectSummaries().size();
@@ -102,6 +96,7 @@ class QrdaApiAcceptance {
 	}
 
 	private long getDynamoItemCount() {
+		AmazonDynamoDB dynamoClient = AwsTestHelper.getDynamoClient();
 
 		ScanResult scanResult = dynamoClient.scan(AwsTestHelper.TEST_DYNAMO_TABLE_NAME, Lists.newArrayList("Uuid"));
 		long itemCount = scanResult.getCount();

--- a/test-commons/src/main/java/gov/cms/qpp/test/helper/AwsTestHelper.java
+++ b/test-commons/src/main/java/gov/cms/qpp/test/helper/AwsTestHelper.java
@@ -19,7 +19,7 @@ import java.util.Map;
  * A helper class for aws testing
  */
 public class AwsTestHelper {
-	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().build();
+	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	public static final String TEST_DYNAMO_TABLE_NAME = "qpp-qrda3converter-acceptance-test";
 	private static final String TEST_S3_BUCKET_NAME = "qpp-qrda3converter-acceptance-test";

--- a/test-commons/src/main/java/gov/cms/qpp/test/helper/AwsTestHelper.java
+++ b/test-commons/src/main/java/gov/cms/qpp/test/helper/AwsTestHelper.java
@@ -23,52 +23,52 @@ import java.util.Map;
 public class AwsTestHelper {
 	public static final String TEST_DYNAMO_TABLE_NAME = "qpp-qrda3converter-acceptance-test";
 
-	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
-	private static AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
-	private static AWSKMS kmsClient = AWSKMSClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
+	private static final  AmazonDynamoDB DYNAMO_CLIENT = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
+	private static final AmazonS3 S3_CLIENT = AmazonS3ClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
+	private static final AWSKMS KMS_CLIENT = AWSKMSClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static final String TEST_S3_BUCKET_NAME = "qpp-qrda3converter-acceptance-test";
 
 	public static AmazonDynamoDB getDynamoClient() {
-		return dynamoClient;
+		return DYNAMO_CLIENT;
 	}
 
 	public static AmazonS3 getS3Client() {
-		return s3Client;
+		return S3_CLIENT;
 	}
 
 	public static AWSKMS getKmsClient() {
-		return kmsClient;
+		return KMS_CLIENT;
 	}
 
 	/**
 	 * Cleans dynamodb items until via batch scan and delete for performance purposes
 	 */
 	public static void cleanDynamoDb() {
-		ScanResult scanResult = dynamoClient.scan(TEST_DYNAMO_TABLE_NAME, Lists.newArrayList("Uuid"));
+		ScanResult scanResult = DYNAMO_CLIENT.scan(TEST_DYNAMO_TABLE_NAME, Lists.newArrayList("Uuid"));
 		List<Map<String, AttributeValue>> metadataList = scanResult.getItems();
 		while (scanResult.getLastEvaluatedKey() != null && !scanResult.getLastEvaluatedKey().isEmpty()) {
-			scanResult = dynamoClient.scan(new ScanRequest().withTableName(TEST_DYNAMO_TABLE_NAME).withAttributesToGet("Uuid")
+			scanResult = DYNAMO_CLIENT.scan(new ScanRequest().withTableName(TEST_DYNAMO_TABLE_NAME).withAttributesToGet("Uuid")
 				.withExclusiveStartKey(scanResult.getLastEvaluatedKey()));
 			metadataList.addAll(scanResult.getItems());
 		}
 
-		metadataList.forEach(map -> dynamoClient.deleteItem(TEST_DYNAMO_TABLE_NAME, map));
+		metadataList.forEach(map -> DYNAMO_CLIENT.deleteItem(TEST_DYNAMO_TABLE_NAME, map));
 	}
 
 	/**
 	 * Cleans up the test s3 bucket by batch for performance purposes
 	 */
 	public static void cleanS3() {
-		ObjectListing objectListing = s3Client.listObjects(TEST_S3_BUCKET_NAME);
+		ObjectListing objectListing = S3_CLIENT.listObjects(TEST_S3_BUCKET_NAME);
 		boolean firstTimeThrough = true;
 
 		do {
 			if (!firstTimeThrough) {
-				objectListing = s3Client.listNextBatchOfObjects(objectListing);
+				objectListing = S3_CLIENT.listNextBatchOfObjects(objectListing);
 			}
 
 			for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
-				s3Client.deleteObject(TEST_S3_BUCKET_NAME, objectSummary.getKey());
+				S3_CLIENT.deleteObject(TEST_S3_BUCKET_NAME, objectSummary.getKey());
 			}
 
 

--- a/test-commons/src/main/java/gov/cms/qpp/test/helper/AwsTestHelper.java
+++ b/test-commons/src/main/java/gov/cms/qpp/test/helper/AwsTestHelper.java
@@ -6,6 +6,8 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectListing;
@@ -19,10 +21,24 @@ import java.util.Map;
  * A helper class for aws testing
  */
 public class AwsTestHelper {
+	public static final String TEST_DYNAMO_TABLE_NAME = "qpp-qrda3converter-acceptance-test";
+
 	private static AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
-	public static final String TEST_DYNAMO_TABLE_NAME = "qpp-qrda3converter-acceptance-test";
+	private static AWSKMS kmsClient = AWSKMSClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
 	private static final String TEST_S3_BUCKET_NAME = "qpp-qrda3converter-acceptance-test";
+
+	public static AmazonDynamoDB getDynamoClient() {
+		return dynamoClient;
+	}
+
+	public static AmazonS3 getS3Client() {
+		return s3Client;
+	}
+
+	public static AWSKMS getKmsClient() {
+		return kmsClient;
+	}
 
 	/**
 	 * Cleans dynamodb items until via batch scan and delete for performance purposes


### PR DESCRIPTION
### Information
Fixes our acceptance tests in master.

### Changes proposed in this PR:
- Forces us to use `us-east-1` with our acceptance tests since CircleCI doesn't know what region to use.  We were already forcing the region with other clients we were making in our acceptance tests, so now we are consistent.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
