### PR TITLE
QPPCT-693: Error message for invalid performanceRateUuid is incorrect

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -18,6 +18,7 @@ import gov.cms.qpp.conversion.util.StringHelper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -101,10 +102,11 @@ public class MipsQualityMeasureIdValidator extends QualityMeasureIdValidator {
 					.orElse(null);
 
 			if (subPopulation == null) {
-				String expectedPerformanceUuids = StringHelper.join(subPopulations.stream()
+				Set<String> expectedPerformanceUuids = subPopulations.stream()
 					.map(SubPopulation::getNumeratorUuid)
-					.collect(Collectors.toSet()), ", ", "or ");
-				addPerformanceRateValidationMessage(node, expectedPerformanceUuids);
+					.collect(Collectors.toSet());
+				String expectedUuidString = StringHelper.join(expectedPerformanceUuids, ", ", "or ");
+				addPerformanceRateValidationMessage(node, expectedUuidString);
 			}
 		}
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -1,14 +1,5 @@
 package gov.cms.qpp.conversion.validate;
 
-import static gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.Sets;
 
 import gov.cms.qpp.conversion.model.Node;
@@ -22,6 +13,16 @@ import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.util.StringHelper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID;
 
 /**
  * Validates a Measure Reference Results node.
@@ -100,7 +101,10 @@ public class MipsQualityMeasureIdValidator extends QualityMeasureIdValidator {
 					.orElse(null);
 
 			if (subPopulation == null) {
-				addPerformanceRateValidationMessage(node, performanceUuid);
+				String expectedPerformanceUuids = StringHelper.join(subPopulations.stream()
+					.map(SubPopulation::getNumeratorUuid)
+					.collect(Collectors.toSet()), ", ", "or ");
+				addPerformanceRateValidationMessage(node, expectedPerformanceUuids);
 			}
 		}
 	}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -1,15 +1,5 @@
 package gov.cms.qpp.acceptance;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import gov.cms.qpp.conversion.Converter;
@@ -22,7 +12,17 @@ import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.error.TransformException;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
+import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.util.JsonHelper;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 class QualityMeasureIdRoundTripTest {
 	static final Path JUNK_QRDA3_FILE = Paths.get("src/test/resources/negative/junk_in_quality_measure.xml");
@@ -32,7 +32,7 @@ class QualityMeasureIdRoundTripTest {
 			Paths.get("src/test/resources/fixtures/textInsensitiveQualityMeasureUuids.xml");
 
 	@Test
-	void testRoundTripForQualityMeasureId() throws IOException {
+	void testRoundTripForQualityMeasureId() {
 		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE));
 		JsonWrapper qpp = converter.transform();
 
@@ -46,7 +46,7 @@ class QualityMeasureIdRoundTripTest {
 	}
 
 	@Test
-	void testMeasureCMS68v6PerformanceRateUuid() throws IOException {
+	void testMeasureCMS68v6PerformanceRateUuid() {
 		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE));
 		List<Detail> details = new ArrayList<>();
 
@@ -58,16 +58,17 @@ class QualityMeasureIdRoundTripTest {
 		}
 
 		String measureId = "CMS68v6";
-		String incorrectId = "00000000-0000-0000-0000-1NV4L1D";
+		String correctId = MeasureConfigs.getConfigurationMap()
+			.get("40280381-52fc-3a32-0153-3d64af97147b").getSubPopulation().get(0).getNumeratorUuid();
 
 		LocalizedError error = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(measureId,
-				PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID, incorrectId);
+				PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID, correctId);
 		assertThat(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.contains(error);
 	}
 
 	@Test
-	void testMeasureCMS160v5PerformanceRateUuid() throws IOException {
+	void testMeasureCMS160v5PerformanceRateUuid() {
 		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE));
 		List<Detail> details = new ArrayList<>();
 
@@ -83,7 +84,7 @@ class QualityMeasureIdRoundTripTest {
 	}
 
 	@Test
-	void testMeasureCMS52v5WithInsensitiveTextUuid() throws IOException {
+	void testMeasureCMS52v5WithInsensitiveTextUuid() {
 		Converter converter = new Converter(new PathSource(INSENSITIVE_TEXT_FILE));
 		List<Detail> details = new ArrayList<>();
 
@@ -99,7 +100,7 @@ class QualityMeasureIdRoundTripTest {
 	}
 
 	@Test
-	void testMeasureCMS52v5InsensitiveMeasureDataUuid() throws IOException {
+	void testMeasureCMS52v5InsensitiveMeasureDataUuid() {
 		Converter converter = new Converter(new PathSource(INSENSITIVE_TEXT_FILE));
 		List<Detail> details = new ArrayList<>();
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.validate;
 
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.MeasureIndexInit;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.util.StringHelper;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -354,6 +356,26 @@ class QualityMeasureIdValidatorTest {
 		assertWithMessage("Must contain the correct error message.")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(expectedErrorMessage);
+	}
+
+	@Test
+	void testPerformanceRateMultipleUuidFail() {
+		Node measureReferenceResultsNode = createCorrectMeasureReference(MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID)
+			.replaceSubPopulationPerformanceRate(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID, "fail1")
+			.build();
+
+		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
+
+		String expectedUuids = StringHelper.join(
+			Lists.newArrayList(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER3_GUID, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER2_GUID),
+			", ",
+			"or ");
+		LocalizedError expectedErrorMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5",
+			PERFORMANCE_RATE_ID, expectedUuids);
+
+		assertWithMessage("Must contain the correct error message.")
+			.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.containsExactly(expectedErrorMessage);
 	}
 
 	private MeasureReferenceBuilder createCorrectMeasureReference(String measureId) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -1,5 +1,9 @@
 package gov.cms.qpp.conversion.validate;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.conversion.decode.AggregateCountDecoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
@@ -10,9 +14,6 @@ import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.MeasureIndexInit;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -349,7 +350,7 @@ class QualityMeasureIdValidatorTest {
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
 		LocalizedError expectedErrorMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS68v6",
-				PERFORMANCE_RATE_ID, "fail");
+				PERFORMANCE_RATE_ID, REQUIRES_DENOM_EXCEPTION_NUMER_GUID);
 		assertWithMessage("Must contain the correct error message.")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(expectedErrorMessage);

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -367,7 +367,9 @@ class QualityMeasureIdValidatorTest {
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
 
 		String expectedUuids = StringHelper.join(
-			Lists.newArrayList(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER3_GUID, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER2_GUID),
+			Lists.newArrayList(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID,
+				MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER3_GUID,
+				MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER2_GUID),
 			", ",
 			"or ");
 		LocalizedError expectedErrorMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5",


### PR DESCRIPTION
### Information
- JIRA story QPPCT-693.

### Changes proposed in this PR:
- Before, when the performance UUID was incorrect, we were generating an error message that stated the performance rate UUID needed to be what was already _provided_ in the QRDA3 file versus the _expected_ UUIDs.
- We now supply the expected UUIDs for the performance rate.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
