### PR TITLE
QPPCT-642: Update Sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,8 +2,8 @@ sonar.projectKey=gov.cms.qpp.conversion:qpp-conversion
 sonar.projectName=QPP Conversion
 sonar.projectVersion=0.1
 
-sonar.sources=frontend/src,converter/src/main,rest-api/src/main,commandline/src/main
-sonar.java.binaries=converter/target/classes,rest-api/target/classes,commandline/target/classes
+sonar.sources=commandline/src/main,commons/src/main,converter/src/main,frontend/src,generate/src/main,rest-api/src/main
+sonar.java.binaries=commandline/target/classes,commons/target/classes,converter/target/classes,generate/target/classes,rest-api/target/classes
 
 sonar.exclusions=**/correlation/model/**/*, **/test/**
 sonar.coverage.exclusions=**/conversion/correlation/model/**/*, **/test/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,8 +2,8 @@ sonar.projectKey=gov.cms.qpp.conversion:qpp-conversion
 sonar.projectName=QPP Conversion
 sonar.projectVersion=0.1
 
-sonar.sources=commandline/src/main,commons/src/main,converter/src/main,frontend/src,generate/src/main,rest-api/src/main
-sonar.java.binaries=commandline/target/classes,commons/target/classes,converter/target/classes,generate/target/classes,rest-api/target/classes
+sonar.sources=commandline/src/main,commons/src/main,converter/src/main,frontend/src,rest-api/src/main
+sonar.java.binaries=commandline/target/classes,commons/target/classes,converter/target/classes,rest-api/target/classes
 
 sonar.exclusions=**/correlation/model/**/*, **/test/**
 sonar.coverage.exclusions=**/conversion/correlation/model/**/*, **/test/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.projectVersion=0.1
 
 sonar.sources=commandline/src/main,commons/src/main,converter/src/main,frontend/src,rest-api/src/main
 sonar.java.binaries=commandline/target/classes,commons/target/classes,converter/target/classes,rest-api/target/classes
+sonar.java.source=8
 
 sonar.exclusions=**/correlation/model/**/*, **/test/**
 sonar.coverage.exclusions=**/conversion/correlation/model/**/*, **/test/**


### PR DESCRIPTION
### Information
- JIRA story QPPCT-642.

### Changes proposed in this PR:
- Scan our `commons` project now.
- Tell Sonar that we are using Java 8 so it is smarter with its rules.
- Modified some of the Sonar rules that we use.

### Checklist 
- [n/a] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [n/a] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.