### PR TITLE
QPPCT-685: ipp ipop support

### DIFF
--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
@@ -69,7 +69,7 @@ public enum SubPopulationLabel {
 	 * @param key a given alias
 	 * @return the corresponding SubPopulationLabel if any
 	 */
-	static SubPopulationLabel findPopulation(String key) {
+	public static SubPopulationLabel findPopulation(String key) {
 		return Arrays.stream(SubPopulationLabel.values())
 			.filter(subPop -> subPop.hasAlias(key))
 			.findFirst()

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
@@ -8,6 +8,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Construct that helps classify SubPopulation types.
+ */
 public enum SubPopulationLabel {
 	DENEXCEP(SubPopulation::getDenominatorExceptionsUuid, "DENEXCEP"),
 	DENEX(SubPopulation::getDenominatorExclusionsUuid, "DENEX"),
@@ -18,25 +21,54 @@ public enum SubPopulationLabel {
 	private Set<String> aka;
 	private Function<SubPopulation, String> getter;
 
+	/**
+	 * Initialize enum constituents with functions to retrieve respective sub-population ids
+	 * along with aliases to contextualize the retrieval
+	 *
+	 * @param getter {@link SubPopulation} getter
+	 * @param aliases determines to which sub-population aliases the getter applies
+	 */
 	SubPopulationLabel(Function<SubPopulation, String> getter, String... aliases) {
 		this.getter = getter;
 		this.aka = Sets.newHashSet(aliases);
 	}
 
+	/**
+	 * Retrieve the associated aliases.
+	 *
+	 * @return an array of aliases
+	 */
 	public String[] getAliases() {
 		return aka.toArray(new String[aka.size()]);
 	}
 
+	/**
+	 * Determine if the given value is a valid alias.
+	 *
+	 * @param alias Potential alias
+	 * @return whether or not the given alias is valid for this {@link SubPopulationLabel}
+	 */
 	public boolean hasAlias(String alias) {
 		return this.aka.contains(alias);
 	}
 
+	/**
+	 * Get all aliases
+	 *
+	 * @return a {@link Set} of all aliases
+	 */
 	static Set<String> aliasSet() {
 		return Arrays.stream(SubPopulationLabel.values())
 			.flatMap(pop -> pop.aka.stream())
 			.collect(Collectors.toSet());
 	}
 
+	/**
+	 * Find the {@link SubPopulationLabel} that corresponds to the given alias.
+	 *
+	 * @param key a given alias
+	 * @return the corresponding SubPopulationLabel if any
+	 */
 	static SubPopulationLabel findPopulation(String key) {
 		return Arrays.stream(SubPopulationLabel.values())
 			.filter(subPop -> subPop.hasAlias(key))
@@ -44,11 +76,22 @@ public enum SubPopulationLabel {
 			.orElse(null);
 	}
 
+	/**
+	 * Retrieve a getter for the given aliases' UUID.
+	 *
+	 * @param key a given alias
+	 * @return the appropriate {@link SubPopulation} getter
+	 */
 	static Function<SubPopulation, String> getGetter(String key) {
 		SubPopulationLabel subPopulationLabel = SubPopulationLabel.findPopulation(key);
 		return subPopulationLabel != null ? subPopulationLabel.getter : null;
 	}
 
+	/**
+	 * Retrieve a {@link Set} of all SubPopulationLabel names.
+	 *
+	 * @return Set of names
+	 */
 	static Set<String> names() {
 		return Stream.of(SubPopulationLabel.values())
 			.map(Enum::name)

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
@@ -18,12 +18,9 @@ public enum SubPopulationLabel {
 	private Set<String> aka;
 	private Function<SubPopulation, String> getter;
 
-	SubPopulationLabel(Function<SubPopulation, String> getter){
-		this.getter = getter;
-	}
 	SubPopulationLabel(Function<SubPopulation, String> getter, String... aliases) {
-		this(getter);
-		aka = Sets.newHashSet(aliases);
+		this.getter = getter;
+		this.aka = Sets.newHashSet(aliases);
 	}
 
 	public String[] getAliases() {

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
@@ -1,0 +1,60 @@
+package gov.cms.qpp.conversion.model.validation;
+
+import com.google.common.collect.Sets;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public enum SubPopulationLabel {
+	DENEXCEP(SubPopulation::getDenominatorExceptionsUuid, "DENEXCEP"),
+	DENEX(SubPopulation::getDenominatorExclusionsUuid, "DENEX"),
+	NUMER(SubPopulation::getNumeratorUuid, "NUMER"),
+	DENOM(SubPopulation::getDenominatorUuid, "DENOM"),
+	IPOP(SubPopulation::getNumeratorUuid, "IPOP", "IPP");
+
+	private Set<String> aka;
+	private Function<SubPopulation, String> getter;
+
+	SubPopulationLabel(Function<SubPopulation, String> getter){
+		this.getter = getter;
+	}
+	SubPopulationLabel(Function<SubPopulation, String> getter, String... aliases) {
+		this(getter);
+		aka = Sets.newHashSet(aliases);
+	}
+
+	public String[] getAliases() {
+		return aka.toArray(new String[aka.size()]);
+	}
+
+	public boolean hasAlias(String alias) {
+		return this.aka.contains(alias);
+	}
+
+	static Set<String> aliasSet() {
+		return Arrays.stream(SubPopulationLabel.values())
+			.flatMap(pop -> pop.aka.stream())
+			.collect(Collectors.toSet());
+	}
+
+	static SubPopulationLabel findPopulation(String key) {
+		return Arrays.stream(SubPopulationLabel.values())
+			.filter(subPop -> subPop.hasAlias(key))
+			.findFirst()
+			.orElse(null);
+	}
+
+	static Function<SubPopulation, String> getGetter(String key) {
+		SubPopulationLabel subPopulationLabel = SubPopulationLabel.findPopulation(key);
+		return subPopulationLabel != null ? subPopulationLabel.getter : null;
+	}
+
+	static Set<String> names() {
+		return Stream.of(SubPopulationLabel.values())
+			.map(Enum::name)
+			.collect(Collectors.toSet());
+	}
+}

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
@@ -47,9 +47,4 @@ public class SubPopulations {
 		exclusive.removeAll(exclusions);
 		return exclusive;
 	}
-
-	public static String[] getKeyAliases(String key) {
-		SubPopulationLabel found = SubPopulationLabel.findPopulation(key);
-		return found == null ? new String[] {} : found.getAliases();
-	}
 }

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
@@ -42,8 +42,8 @@ public class SubPopulations {
 	 * @param exclusions keys to exclude
 	 * @return exclusive key set
 	 */
-	public static Set<String> getExclusiveKeys(Set<String> exclusions) {
-		Set<String> exclusive = Sets.newHashSet(SubPopulationLabel.aliasSet());
+	public static Set<SubPopulationLabel> getExclusiveKeys(Set<SubPopulationLabel> exclusions) {
+		Set<SubPopulationLabel> exclusive = Sets.newHashSet(SubPopulationLabel.values());
 		exclusive.removeAll(exclusions);
 		return exclusive;
 	}
@@ -52,14 +52,4 @@ public class SubPopulations {
 		SubPopulationLabel found = SubPopulationLabel.findPopulation(key);
 		return found == null ? new String[] {} : found.getAliases();
 	}
-
-	/**
-	 * Gets all the valid subpopulation lookup keys
-	 *
-	 * @return DENEXCEP, DENEX, DENOM, NUMER, IPOP
-	 */
-	static Set<String> getKeys() {
-		return SubPopulationLabel.aliasSet();
-	}
-
 }

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
@@ -2,35 +2,17 @@ package gov.cms.qpp.conversion.model.validation;
 
 import com.google.common.collect.Sets;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * {@link SubPopulation} utilities
  */
 public class SubPopulations {
-
-	private static final Map<String, Function<SubPopulation, String>> KEY_TO_UNIQUEID;
-	public static final String DENEXCEP = "DENEXCEP";
-	public static final String DENEX = "DENEX";
-	public static final String NUMER = "NUMER";
-	public static final String DENOM = "DENOM";
-	public static final String IPOP = "IPOP";
-	public static final String IPP = "IPP";
-
-	static {
-		Map<String, Function<SubPopulation, String>> keyToUniqueId = new HashMap<>();
-		keyToUniqueId.put(DENEXCEP, SubPopulation::getDenominatorExceptionsUuid);
-		keyToUniqueId.put(DENEX, SubPopulation::getDenominatorExclusionsUuid);
-		keyToUniqueId.put(DENOM, SubPopulation::getDenominatorUuid);
-		keyToUniqueId.put(NUMER, SubPopulation::getNumeratorUuid);
-		keyToUniqueId.put(IPOP, SubPopulation::getNumeratorUuid);
-		KEY_TO_UNIQUEID = Collections.unmodifiableMap(keyToUniqueId);
-	}
 
 	/**
 	 * Helper class, should not be instantiated.
@@ -49,24 +31,29 @@ public class SubPopulations {
 		Objects.requireNonNull(key, "key");
 		Objects.requireNonNull(subPopulation, "subPopulation");
 
-		Function<SubPopulation, String> lookup = KEY_TO_UNIQUEID.get(key);
+		Function<SubPopulation, String> lookup = SubPopulationLabel.getGetter(key);
 		if (lookup == null) {
-			throw new IllegalArgumentException("Illegal key: " + key + ", expected one of " + KEY_TO_UNIQUEID.keySet());
+			throw new IllegalArgumentException("Illegal key: " + key + ", expected one of " + SubPopulationLabel.names());
 		}
 
 		return lookup.apply(subPopulation);
 	}
 
 	/**
-	 * Get an exclusive key set of sub population lebels.
+	 * Get an exclusive key set of sub population labels.
 	 *
 	 * @param exclusions keys to exclude
 	 * @return exclusive key set
 	 */
 	public static Set<String> getExclusiveKeys(Set<String> exclusions) {
-		Set<String> exclusive = Sets.newHashSet(KEY_TO_UNIQUEID.keySet());
+		Set<String> exclusive = Sets.newHashSet(SubPopulationLabel.aliasSet());
 		exclusive.removeAll(exclusions);
 		return exclusive;
+	}
+
+	public static String[] getKeyAliases(String key){
+		SubPopulationLabel found = SubPopulationLabel.findPopulation(key);
+		return found == null ? new String[] {} : found.getAliases();
 	}
 
 	/**
@@ -75,7 +62,7 @@ public class SubPopulations {
 	 * @return DENEXCEP, DENEX, DENOM, NUMER, IPOP
 	 */
 	static Set<String> getKeys() {
-		return KEY_TO_UNIQUEID.keySet();
+		return SubPopulationLabel.aliasSet();
 	}
 
 }

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
@@ -48,7 +48,7 @@ public class SubPopulations {
 		return exclusive;
 	}
 
-	public static String[] getKeyAliases(String key){
+	public static String[] getKeyAliases(String key) {
 		SubPopulationLabel found = SubPopulationLabel.findPopulation(key);
 		return found == null ? new String[] {} : found.getAliases();
 	}

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulations.java
@@ -2,12 +2,9 @@ package gov.cms.qpp.conversion.model.validation;
 
 import com.google.common.collect.Sets;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * {@link SubPopulation} utilities

--- a/commons/src/main/java/gov/cms/qpp/conversion/util/StringHelper.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/util/StringHelper.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.util;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -39,6 +40,17 @@ public class StringHelper {
 		}
 
 		return creator.toString();
+	}
+
+	/**
+	 * Convenience override for {@link #join(Iterable, String, String)}
+	 *
+	 * @param toIterate An array to join together
+	 * @param conjunction The {@link String} that splits the second to last and last item.
+	 * @return A joined {@link String}.
+	 */
+	public static String join(String[] toIterate, String separator, String conjunction) {
+		return join(Arrays.asList(toIterate), separator, conjunction);
 	}
 
 	/**

--- a/commons/src/main/java/gov/cms/qpp/conversion/util/StringHelper.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/util/StringHelper.java
@@ -17,6 +17,8 @@ public class StringHelper {
 	 * @return A joined {@link String}.
 	 */
 	public static String join(Iterable<String> iterable, String separator, String conjunction) {
+		separator = separator + " ";
+		conjunction = conjunction + " ";
 
 		StringBuilder creator = new StringBuilder();
 

--- a/commons/src/test/java/gov/cms/qpp/conversion/util/StringHelperTest.java
+++ b/commons/src/test/java/gov/cms/qpp/conversion/util/StringHelperTest.java
@@ -1,7 +1,8 @@
 package gov.cms.qpp.conversion.util;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -9,28 +10,29 @@ class StringHelperTest {
 
 	@Test
 	void testJoining() {
-		String joined = StringHelper.join(Lists.newArrayList("Dog", "Cow", "Moof"), ",", "or");
+		String joined = StringHelper.join(Arrays.asList("Dog", "Cow", "Moof"), ",", "or");
 
 		assertThat(joined).isEqualTo("Dog, Cow, or Moof");
 	}
 
 	@Test
 	void testJoiningOneElement() {
-		String joined = StringHelper.join(Lists.newArrayList("Dog"), ",", "or");
+		String joined = StringHelper.join(Collections.singletonList("Dog"), ",", "or");
 
 		assertThat(joined).isEqualTo("Dog");
 	}
 
 	@Test
 	void testJoiningTwoElement() {
-		String joined = StringHelper.join(Lists.newArrayList("Dog", "Cow"), ",", "or");
+		String joined = StringHelper.join(Arrays.asList("Dog", "Cow"), ",", "or");
 
 		assertThat(joined).isEqualTo("Dog or Cow");
 	}
 
 	@Test
 	void testSomethingDifferent() {
-		String joined = StringHelper.join(Lists.newArrayList("Completely", "Utterly", "Incontrovertibly", "Capriciously"), " DogCow,", "and even perhaps");
+		String joined = StringHelper.join(
+			Arrays.asList("Completely", "Utterly", "Incontrovertibly", "Capriciously"), " DogCow,", "and even perhaps");
 
 		assertThat(joined).isEqualTo("Completely DogCow, Utterly DogCow, Incontrovertibly DogCow, and even perhaps Capriciously");
 	}

--- a/commons/src/test/java/gov/cms/qpp/conversion/util/StringHelperTest.java
+++ b/commons/src/test/java/gov/cms/qpp/conversion/util/StringHelperTest.java
@@ -9,28 +9,28 @@ class StringHelperTest {
 
 	@Test
 	void testJoining() {
-		String joined = StringHelper.join(Lists.newArrayList("Dog", "Cow", "Moof"), ", ", "or ");
+		String joined = StringHelper.join(Lists.newArrayList("Dog", "Cow", "Moof"), ",", "or");
 
 		assertThat(joined).isEqualTo("Dog, Cow, or Moof");
 	}
 
 	@Test
 	void testJoiningOneElement() {
-		String joined = StringHelper.join(Lists.newArrayList("Dog"), ", ", "or ");
+		String joined = StringHelper.join(Lists.newArrayList("Dog"), ",", "or");
 
 		assertThat(joined).isEqualTo("Dog");
 	}
 
 	@Test
 	void testJoiningTwoElement() {
-		String joined = StringHelper.join(Lists.newArrayList("Dog", "Cow"), ", ", "or ");
+		String joined = StringHelper.join(Lists.newArrayList("Dog", "Cow"), ",", "or");
 
 		assertThat(joined).isEqualTo("Dog or Cow");
 	}
 
 	@Test
 	void testSomethingDifferent() {
-		String joined = StringHelper.join(Lists.newArrayList("Completely", "Utterly", "Incontrovertibly", "Capriciously"), " DogCow, ", "and even perhaps ");
+		String joined = StringHelper.join(Lists.newArrayList("Completely", "Utterly", "Incontrovertibly", "Capriciously"), " DogCow,", "and even perhaps");
 
 		assertThat(joined).isEqualTo("Completely DogCow, Utterly DogCow, Incontrovertibly DogCow, and even perhaps Capriciously");
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
@@ -55,11 +55,6 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 		measureTypeMapper.put(SubPopulationLabel.DENOM, eligiblePopulation);
 		measureTypeMapper.put(SubPopulationLabel.DENEX, "eligiblePopulationExclusion");
 		measureTypeMapper.put(SubPopulationLabel.DENEXCEP, "eligiblePopulationException");
-
-//		measureTypeMapper.put(SubPopulationLabel.NUMER.name(), "performanceMet");
-//		measureTypeMapper.put(SubPopulationLabel.DENOM.name(), eligiblePopulation);
-//		measureTypeMapper.put(SubPopulationLabel.DENEX.name(), "eligiblePopulationExclusion");
-//		measureTypeMapper.put(SubPopulationLabel.DENEXCEP.name(), "eligiblePopulationException");
 		return measureTypeMapper;
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
@@ -6,7 +6,7 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import static gov.cms.qpp.conversion.decode.AggregateCountDecoder.AGGREGATE_COUNT;
@@ -48,11 +48,9 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 	 * @return intialized measure type map
 	 */
 	private Map<SubPopulationLabel, String> initializeMeasureTypeMap() {
-		Map<SubPopulationLabel, String> measureTypeMapper = new HashMap<>();
-		final String eligiblePopulation = "eligiblePopulation";
-
+		Map<SubPopulationLabel, String> measureTypeMapper = new EnumMap<>(SubPopulationLabel.class);
 		measureTypeMapper.put(SubPopulationLabel.NUMER, "performanceMet");
-		measureTypeMapper.put(SubPopulationLabel.DENOM, eligiblePopulation);
+		measureTypeMapper.put(SubPopulationLabel.DENOM, "eligiblePopulation");
 		measureTypeMapper.put(SubPopulationLabel.DENEX, "eligiblePopulationExclusion");
 		measureTypeMapper.put(SubPopulationLabel.DENEXCEP, "eligiblePopulationException");
 		return measureTypeMapper;

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
@@ -32,11 +32,11 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
 		if (!SubPopulationLabel.IPOP.hasAlias(node.getValue(MEASURE_TYPE))) {
-			Map<String, String> measureTypeMapper = initializeMeasureTypeMap();
+			Map<SubPopulationLabel, String> measureTypeMapper = initializeMeasureTypeMap();
 			String measureType = node.getValue(MEASURE_TYPE);
 			Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
 
-			String encodeLabel = measureTypeMapper.get(measureType);
+			String encodeLabel = measureTypeMapper.get(SubPopulationLabel.findPopulation(measureType));
 			wrapper.putInteger(encodeLabel, aggCount.getValue(AGGREGATE_COUNT));
 			maintainContinuity(wrapper, aggCount, encodeLabel);
 		}
@@ -47,14 +47,19 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 	 *
 	 * @return intialized measure type map
 	 */
-	private Map<String, String> initializeMeasureTypeMap() {
-		Map<String, String> measureTypeMapper = new HashMap<>();
+	private Map<SubPopulationLabel, String> initializeMeasureTypeMap() {
+		Map<SubPopulationLabel, String> measureTypeMapper = new HashMap<>();
 		final String eligiblePopulation = "eligiblePopulation";
 
-		measureTypeMapper.put(SubPopulationLabel.NUMER.name(), "performanceMet");
-		measureTypeMapper.put(SubPopulationLabel.DENOM.name(), eligiblePopulation);
-		measureTypeMapper.put(SubPopulationLabel.DENEX.name(), "eligiblePopulationExclusion");
-		measureTypeMapper.put(SubPopulationLabel.DENEXCEP.name(), "eligiblePopulationException");
+		measureTypeMapper.put(SubPopulationLabel.NUMER, "performanceMet");
+		measureTypeMapper.put(SubPopulationLabel.DENOM, eligiblePopulation);
+		measureTypeMapper.put(SubPopulationLabel.DENEX, "eligiblePopulationExclusion");
+		measureTypeMapper.put(SubPopulationLabel.DENEXCEP, "eligiblePopulationException");
+
+//		measureTypeMapper.put(SubPopulationLabel.NUMER.name(), "performanceMet");
+//		measureTypeMapper.put(SubPopulationLabel.DENOM.name(), eligiblePopulation);
+//		measureTypeMapper.put(SubPopulationLabel.DENEX.name(), "eligiblePopulationExclusion");
+//		measureTypeMapper.put(SubPopulationLabel.DENEXCEP.name(), "eligiblePopulationException");
 		return measureTypeMapper;
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
@@ -4,13 +4,10 @@ import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Encoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static gov.cms.qpp.conversion.decode.AggregateCountDecoder.AGGREGATE_COUNT;
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
@@ -20,9 +17,6 @@ import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
  */
 @Encoder(TemplateId.MEASURE_DATA_CMS_V2)
 public class MeasureDataEncoder extends QppOutputEncoder {
-
-	protected static final Set<String> IPOP = Stream.of("IPP", "IPOP")
-			.collect(Collectors.toSet());
 
 	public MeasureDataEncoder(Context context) {
 		super(context);
@@ -37,7 +31,7 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 	 */
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
-		if (!IPOP.contains(node.getValue(MEASURE_TYPE))) {
+		if (!SubPopulationLabel.IPOP.hasAlias(node.getValue(MEASURE_TYPE))) {
 			Map<String, String> measureTypeMapper = initializeMeasureTypeMap();
 			String measureType = node.getValue(MEASURE_TYPE);
 			Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
@@ -57,10 +51,10 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 		Map<String, String> measureTypeMapper = new HashMap<>();
 		final String eligiblePopulation = "eligiblePopulation";
 
-		measureTypeMapper.put(SubPopulations.NUMER, "performanceMet");
-		measureTypeMapper.put(SubPopulations.DENOM, eligiblePopulation);
-		measureTypeMapper.put(SubPopulations.DENEX, "eligiblePopulationExclusion");
-		measureTypeMapper.put(SubPopulations.DENEXCEP, "eligiblePopulationException");
+		measureTypeMapper.put(SubPopulationLabel.NUMER.name(), "performanceMet");
+		measureTypeMapper.put(SubPopulationLabel.DENOM.name(), eligiblePopulation);
+		measureTypeMapper.put(SubPopulationLabel.DENEX.name(), "eligiblePopulationExclusion");
+		measureTypeMapper.put(SubPopulationLabel.DENEXCEP.name(), "eligiblePopulationException");
 		return measureTypeMapper;
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -9,7 +9,8 @@ import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.Strata;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -198,7 +199,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	 * @param parentNode holder of the the numerator node
 	 */
 	private void encodePerformanceMet(JsonWrapper wrapper, Node parentNode) {
-		Node numeratorNode = parentNode.findChildNode(n -> SubPopulations.NUMER.equals(n.getValue(TYPE)));
+		Node numeratorNode = parentNode.findChildNode(n -> SubPopulationLabel.NUMER.hasAlias(n.getValue(TYPE)));
 		Optional.ofNullable(numeratorNode).ifPresent(
 			node -> {
 				Node aggCount = node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT);
@@ -216,7 +217,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	 * @param measureConfig The measure configuration for the current measure.
 	 */
 	private void encodeStratum(JsonWrapper wrapper, Node parentNode, final MeasureConfig measureConfig) {
-		Node numeratorNode = parentNode.findChildNode(n -> SubPopulations.NUMER.equals(n.getValue(TYPE)));
+		Node numeratorNode = parentNode.findChildNode(n -> SubPopulationLabel.NUMER.hasAlias(n.getValue(TYPE)));
 		Optional.ofNullable(numeratorNode).ifPresent(
 				node -> {
 					maintainContinuity(wrapper, node, "stratum");
@@ -251,10 +252,10 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	 * @param parentNode holder of the denominator and denominator exclusion nodes
 	 */
 	private void encodePerformanceNotMet(JsonWrapper wrapper, Node parentNode) {
-		Node numeratorNode = parentNode.findChildNode(n -> SubPopulations.NUMER.equals(n.getValue(TYPE)));
-		Node denominatorNode = parentNode.findChildNode(n -> SubPopulations.DENOM.equals(n.getValue(TYPE)));
-		Node denomExclusionNode = parentNode.findChildNode(n -> SubPopulations.DENEX.equals(n.getValue(TYPE)));
-		Node denomExceptionNode = parentNode.findChildNode(n -> SubPopulations.DENEXCEP.equals(n.getValue(TYPE)));
+		Node numeratorNode = parentNode.findChildNode(n -> SubPopulationLabel.NUMER.hasAlias(n.getValue(TYPE)));
+		Node denominatorNode = parentNode.findChildNode(n -> SubPopulationLabel.DENOM.hasAlias(n.getValue(TYPE)));
+		Node denomExclusionNode = parentNode.findChildNode(n -> SubPopulationLabel.DENEX.hasAlias(n.getValue(TYPE)));
+		Node denomExceptionNode = parentNode.findChildNode(n -> SubPopulationLabel.DENEXCEP.hasAlias(n.getValue(TYPE)));
 
 		Optional.ofNullable(denomExclusionNode).ifPresent(
 				node -> {

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/ClinicalDocumentValidator.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 @Validator(TemplateId.CLINICAL_DOCUMENT)
 public class ClinicalDocumentValidator extends NodeValidator {
 
-	protected static final String VALID_PROGRAM_NAMES = StringHelper.join(Program.setOfAliases(), ", ", "or ");
+	protected static final String VALID_PROGRAM_NAMES = StringHelper.join(Program.setOfAliases(), ",", "or");
 
 	/**
 	 * Validates a single Clinical Document Node.

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidator.java
@@ -12,6 +12,7 @@ import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
 
 import java.util.Arrays;
@@ -64,12 +65,11 @@ public class CpcQualityMeasureIdValidator extends QualityMeasureIdValidator {
 	@Override
 	List<Consumer<Node>> prepValidations(SubPopulation subPopulation) {
 		return Arrays.asList(
-				makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulations.DENEXCEP),
-				makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulations.DENEX),
-				makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulations.NUMER),
-				makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulations.DENOM),
-				makeValidator(subPopulation, subPopulation::getInitialPopulationUuid,
-						SubPopulations.IPOP, SubPopulations.IPP),
+				makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulationLabel.DENEXCEP.name()),
+				makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulationLabel.DENEX.name()),
+				makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulationLabel.NUMER.name()),
+				makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulationLabel.DENOM.name()),
+				makeValidator(subPopulation, subPopulation::getInitialPopulationUuid, SubPopulationLabel.IPOP.getAliases()),
 				makePerformanceRateUuidValidator(subPopulation::getNumeratorUuid, PERFORMANCE_RATE_ID));
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidator.java
@@ -13,7 +13,6 @@ import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
 import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -65,11 +64,11 @@ public class CpcQualityMeasureIdValidator extends QualityMeasureIdValidator {
 	@Override
 	List<Consumer<Node>> prepValidations(SubPopulation subPopulation) {
 		return Arrays.asList(
-				makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulationLabel.DENEXCEP.name()),
-				makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulationLabel.DENEX.name()),
-				makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulationLabel.NUMER.name()),
-				makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulationLabel.DENOM.name()),
-				makeValidator(subPopulation, subPopulation::getInitialPopulationUuid, SubPopulationLabel.IPOP.getAliases()),
+				makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulationLabel.DENEXCEP),
+				makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulationLabel.DENEX),
+				makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulationLabel.NUMER),
+				makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulationLabel.DENOM),
+				makeValidator(subPopulation, subPopulation::getInitialPopulationUuid, SubPopulationLabel.IPOP),
 				makePerformanceRateUuidValidator(subPopulation::getNumeratorUuid, PERFORMANCE_RATE_ID));
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -56,10 +56,10 @@ public class MipsQualityMeasureIdValidator extends QualityMeasureIdValidator {
 	@Override
 	List<Consumer<Node>> prepValidations(SubPopulation subPopulation) {
 		return Arrays.asList(
-			makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulationLabel.DENEXCEP.name()),
-			makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulationLabel.DENEX.name()),
-			makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulationLabel.NUMER.name()),
-			makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulationLabel.DENOM.name()));
+			makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulationLabel.DENEXCEP),
+			makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulationLabel.DENEX),
+			makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulationLabel.NUMER),
+			makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulationLabel.DENOM));
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -29,7 +29,7 @@ import static gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDeco
 public class MipsQualityMeasureIdValidator extends QualityMeasureIdValidator {
 
 	MipsQualityMeasureIdValidator() {
-		subPopulationExclusions = Sets.newHashSet("IPOP", "IPP");
+		subPopulationExclusions = Sets.newHashSet(SubPopulationLabel.IPOP);
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -1,16 +1,6 @@
 package gov.cms.qpp.conversion.validate;
 
-import static gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.Sets;
-
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.Program;
 import gov.cms.qpp.conversion.model.TemplateId;
@@ -21,7 +11,16 @@ import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID;
 
 /**
  * Validates a Measure Reference Results node.
@@ -56,10 +55,11 @@ public class MipsQualityMeasureIdValidator extends QualityMeasureIdValidator {
 
 	@Override
 	List<Consumer<Node>> prepValidations(SubPopulation subPopulation) {
-		return Arrays.asList(makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulations.DENEXCEP),
-				makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulations.DENEX),
-				makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulations.NUMER),
-				makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulations.DENOM));
+		return Arrays.asList(
+			makeValidator(subPopulation, subPopulation::getDenominatorExceptionsUuid, SubPopulationLabel.DENEXCEP.name()),
+			makeValidator(subPopulation, subPopulation::getDenominatorExclusionsUuid, SubPopulationLabel.DENEX.name()),
+			makeValidator(subPopulation, subPopulation::getNumeratorUuid, SubPopulationLabel.NUMER.name()),
+			makeValidator(subPopulation, subPopulation::getDenominatorUuid, SubPopulationLabel.DENOM.name()));
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -216,13 +216,14 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 *
 	 * @param sub {@link SubPopulation} against which follow validations may be performed
 	 * @param check a property existence check
-	 * @param keys that identify measure
+	 * @param subPopulationLabel that houses sub-population aliases
 	 * @return a callback / consumer that will perform a measure specific validation against a given
 	 * node.
 	 */
-	Consumer<Node> makeValidator(SubPopulation sub, Supplier<String> check, String... keys) {
+	Consumer<Node> makeValidator(SubPopulation sub, Supplier<String> check, SubPopulationLabel subPopulationLabel) {
 		return node -> {
 			if (check.get() != null) {
+				String[] keys = subPopulationLabel.getAliases();
 				Predicate<Node> childTypeFinder = makeTypeChildFinder(keys);
 				Predicate<Node> childUuidFinder =
 						makeUuidChildFinder(check, ErrorCode.QUALITY_MEASURE_ID_MISSING_SINGLE_MEASURE_POPULATION,

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -33,7 +33,7 @@ import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
  * Validates a Measure Reference Results node.
  */
 abstract class QualityMeasureIdValidator extends NodeValidator {
-	Set<String> subPopulationExclusions = Collections.emptySet();
+	Set<SubPopulationLabel> subPopulationExclusions = Collections.emptySet();
 	protected static final Set<String> IPOP = Stream.of("IPP", "IPOP")
 			.collect(Collectors.toSet());
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(QualityMeasureIdValidator.class);
@@ -98,7 +98,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 		}
 
 		SubPopulations.getExclusiveKeys(subPopulationExclusions)
-				.forEach(key -> validateChildTypeCount(subPopulations, key, node));
+				.forEach(subPopulationLabel -> validateChildTypeCount(subPopulations, subPopulationLabel.name(), node));
 
 		for (SubPopulation subPopulation : subPopulations) {
 			validateSubPopulation(node, subPopulation);

--- a/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
@@ -44,21 +44,6 @@ class MeasureDataRoundTripTest {
 		test(label);
 	}
 
-//	@Test
-//	void decodeNumerMeasureDataAsNode() throws Exception {
-//		test(SubPopulations.NUMER);//performanceMet
-//	}
-//
-//	@Test
-//	void decodeDenexMeasureDataAsNode() throws Exception {
-//		test(SubPopulations.DENEX);//eligiblePopulationExclusion
-//	}
-//
-//	@Test
-//	void decodeDenexcepMeasureDataAsNode() throws Exception {
-//		test(SubPopulations.DENEXCEP);//eligiblePopulationException
-//	}
-
 	private void test(SubPopulationLabel type) throws Exception {
 		//setup
 		String typeLabel = type.name();

--- a/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import gov.cms.qpp.conversion.decode.QrdaDecoderEngine;
 
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +23,8 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
 import gov.cms.qpp.conversion.xml.XmlUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class MeasureDataRoundTripTest {
 
@@ -35,30 +38,32 @@ class MeasureDataRoundTripTest {
 		happy = TestHelper.getFixture("measureDataHappy.xml");
 	}
 
-	@Test
-	void decodeDenomMeasureDataAsNode() throws Exception {
-		test(SubPopulations.DENOM);
+	@ParameterizedTest
+	@EnumSource(value = SubPopulationLabel.class, mode = EnumSource.Mode.EXCLUDE, names = {"IPOP"})
+	void decodeMeasureDataAsNode(SubPopulationLabel label) throws Exception {
+		test(label);
 	}
 
-	@Test
-	void decodeNumerMeasureDataAsNode() throws Exception {
-		test(SubPopulations.NUMER);//performanceMet
-	}
+//	@Test
+//	void decodeNumerMeasureDataAsNode() throws Exception {
+//		test(SubPopulations.NUMER);//performanceMet
+//	}
+//
+//	@Test
+//	void decodeDenexMeasureDataAsNode() throws Exception {
+//		test(SubPopulations.DENEX);//eligiblePopulationExclusion
+//	}
+//
+//	@Test
+//	void decodeDenexcepMeasureDataAsNode() throws Exception {
+//		test(SubPopulations.DENEXCEP);//eligiblePopulationException
+//	}
 
-	@Test
-	void decodeDenexMeasureDataAsNode() throws Exception {
-		test(SubPopulations.DENEX);//eligiblePopulationExclusion
-	}
-
-	@Test
-	void decodeDenexcepMeasureDataAsNode() throws Exception {
-		test(SubPopulations.DENEXCEP);//eligiblePopulationException
-	}
-
-	private void test(String type) throws Exception {
+	private void test(SubPopulationLabel type) throws Exception {
 		//setup
+		String typeLabel = type.name();
 		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(happy));
-		Node measure =  placeholder.findChildNode(n -> n.getValue(MEASURE_TYPE).equals(type));
+		Node measure =  placeholder.findChildNode(n -> n.getValue(MEASURE_TYPE).equals(typeLabel));
 		String message = String.format("Should have a %s measure", type);
 
 		//when

--- a/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
@@ -49,7 +49,6 @@ class MeasureDataRoundTripTest {
 		String typeLabel = type.name();
 		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(happy));
 		Node measure =  placeholder.findChildNode(n -> n.getValue(MEASURE_TYPE).equals(typeLabel));
-		String message = String.format("Should have a %s measure", type);
 
 		//when
 		StringWriter sw = encode(placeholder);

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdMultiRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdMultiRoundTripTest.java
@@ -12,7 +12,7 @@ import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.error.TransformException;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.util.JsonHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -106,7 +106,8 @@ class QualityMeasureIdMultiRoundTripTest {
 
 	@Test
 	void testRoundTripForQualityMeasureIdWithNoDenomMeasureType() {
-		LocalizedError error = ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 3, SubPopulations.DENOM, 2);
+		LocalizedError error =
+			ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 3, SubPopulationLabel.DENOM.name(), 2);
 		String path = "/ClinicalDocument/component/structuredBody/component/section/entry/organizer/" +
 				"component[5]/observation/value/@code";
 

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -67,21 +67,21 @@ class CpcPlusAcceptanceTest {
 		return path.toString().endsWith(".xml");
 	}
 
-	@ParameterizedTest
-	@MethodSource("successData")
-	void testCpcPlusFileSuccesses(Path entry) throws IOException {
-		AllErrors errors = null;
-
-		Converter converter = new Converter(new PathSource(entry));
-
-		try {
-			converter.transform();
-		} catch (TransformException failure) {
-			errors = failure.getDetails();
-		}
-
-		assertThat(errors).isNull();
-	}
+//	@ParameterizedTest
+//	@MethodSource("successData")
+//	void testCpcPlusFileSuccesses(Path entry) throws IOException {
+//		AllErrors errors = null;
+//
+//		Converter converter = new Converter(new PathSource(entry));
+//
+//		try {
+//			converter.transform();
+//		} catch (TransformException failure) {
+//			errors = failure.getDetails();
+//		}
+//
+//		assertThat(errors).isNull();
+//	}
 
 	@ParameterizedTest
 	@MethodSource("failureData")

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -47,15 +47,15 @@ class CpcPlusAcceptanceTest {
 		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
 	}
 
-	static Stream<Path> successData() {
+	private static Stream<Path> successData() {
 		return getXml(SUCCESS);
 	}
 
-	static Stream<Path> failureData() {
+	private static Stream<Path> failureData() {
 		return getXml(FAILURE);
 	}
 
-	static Stream<Path> getXml(Path directory) {
+	private static Stream<Path> getXml(Path directory) {
 		try {
 			return Files.list(directory).filter(CpcPlusAcceptanceTest::isXml);
 		} catch (IOException e) {
@@ -63,7 +63,7 @@ class CpcPlusAcceptanceTest {
 		}
 	}
 
-	static boolean isXml(Path path) {
+	private static boolean isXml(Path path) {
 		return path.toString().endsWith(".xml");
 	}
 
@@ -109,12 +109,12 @@ class CpcPlusAcceptanceTest {
 					.that(details).hasSize(totalErrors);
 		}
 
-		expectedErrors.getErrorData().stream().forEach(expectedError -> {
+		expectedErrors.getErrorData().forEach(expectedError -> {
 			Integer expectedErrorCode = expectedError.getErrorCode();
 			String expectedErrorMessage = expectedError.getMessage();
 
 			long matchingActualErrors = details.stream()
-				.filter(actualError -> actualError.getErrorCode() == expectedErrorCode)
+				.filter(actualError -> actualError.getErrorCode().equals(expectedErrorCode))
 				.filter(actualError -> messageComparison(actualError.getMessage(), expectedErrorMessage))
 				.count();
 

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -67,21 +67,21 @@ class CpcPlusAcceptanceTest {
 		return path.toString().endsWith(".xml");
 	}
 
-//	@ParameterizedTest
-//	@MethodSource("successData")
-//	void testCpcPlusFileSuccesses(Path entry) throws IOException {
-//		AllErrors errors = null;
-//
-//		Converter converter = new Converter(new PathSource(entry));
-//
-//		try {
-//			converter.transform();
-//		} catch (TransformException failure) {
-//			errors = failure.getDetails();
-//		}
-//
-//		assertThat(errors).isNull();
-//	}
+	@ParameterizedTest
+	@MethodSource("successData")
+	void testCpcPlusFileSuccesses(Path entry) throws IOException {
+		AllErrors errors = null;
+
+		Converter converter = new Converter(new PathSource(entry));
+
+		try {
+			converter.transform();
+		} catch (TransformException failure) {
+			errors = failure.getDetails();
+		}
+
+		assertThat(errors).isNull();
+	}
 
 	@ParameterizedTest
 	@MethodSource("failureData")

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasureDataDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasureDataDecoderTest.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.decode;
 
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,8 @@ import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 
@@ -37,25 +40,26 @@ class MeasureDataDecoderTest {
 		placeholder = engine.decode(XmlUtils.stringToDom(happy));
 	}
 
-	@Test
-	void testDecodeOfDenomMeasureData() {
-		sharedTest(SubPopulations.DENOM);
+	@ParameterizedTest
+	@EnumSource(value = SubPopulationLabel.class, mode = EnumSource.Mode.EXCLUDE, names = {"IPOP"})
+	void testDecodeOfMeasureData(SubPopulationLabel label) {
+		sharedTest(label.name());
 	}
 
-	@Test
-	void testDecodeOfNumerMeasureData() {
-		sharedTest(SubPopulations.NUMER);
-	}
-
-	@Test
-	void testDecodeOfDenexMeasureData() {
-		sharedTest(SubPopulations.DENEX);
-	}
-
-	@Test
-	void testDecodeOfDenexcepMeasureData() {
-		sharedTest(SubPopulations.DENEXCEP);
-	}
+//	@Test
+//	void testDecodeOfNumerMeasureData() {
+//		sharedTest(SubPopulations.NUMER);
+//	}
+//
+//	@Test
+//	void testDecodeOfDenexMeasureData() {
+//		sharedTest(SubPopulations.DENEX);
+//	}
+//
+//	@Test
+//	void testDecodeOfDenexcepMeasureData() {
+//		sharedTest(SubPopulations.DENEXCEP);
+//	}
 
 	private void sharedTest(String type) {
 		Node measure =  placeholder.findChildNode(node -> node.getValue(MEASURE_TYPE).equals(type));

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasureDataDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/MeasureDataDecoderTest.java
@@ -1,17 +1,14 @@
 package gov.cms.qpp.conversion.decode;
 
-import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import gov.cms.qpp.TestHelper;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -24,7 +21,6 @@ class MeasureDataDecoderTest {
 
 	private static String happy;
 
-	private Context context;
 	private Node placeholder;
 
 	@BeforeAll
@@ -34,8 +30,7 @@ class MeasureDataDecoderTest {
 
 	@BeforeEach
 	void before() throws XmlException {
-		context = new Context();
-		MeasureDataDecoder measureDataDecoder = new MeasureDataDecoder(context);
+		Context context = new Context();
 		QrdaDecoderEngine engine = new QrdaDecoderEngine(context);
 		placeholder = engine.decode(XmlUtils.stringToDom(happy));
 	}
@@ -45,21 +40,6 @@ class MeasureDataDecoderTest {
 	void testDecodeOfMeasureData(SubPopulationLabel label) {
 		sharedTest(label.name());
 	}
-
-//	@Test
-//	void testDecodeOfNumerMeasureData() {
-//		sharedTest(SubPopulations.NUMER);
-//	}
-//
-//	@Test
-//	void testDecodeOfDenexMeasureData() {
-//		sharedTest(SubPopulations.DENEX);
-//	}
-//
-//	@Test
-//	void testDecodeOfDenexcepMeasureData() {
-//		sharedTest(SubPopulations.DENEXCEP);
-//	}
 
 	private void sharedTest(String type) {
 		Node measure =  placeholder.findChildNode(node -> node.getValue(MEASURE_TYPE).equals(type));

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/QualityMeasureScopedTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/QualityMeasureScopedTest.java
@@ -6,7 +6,7 @@ import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
 import gov.cms.qpp.conversion.xml.XmlException;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ class QualityMeasureScopedTest {
 	void internalDecodeValidMeasure137V5Ipop() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long ipops = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
-				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.IPOP))
+				.filter(node -> SubPopulationLabel.IPOP.hasAlias(node.getValue(MeasureDataDecoder.MEASURE_TYPE)))
 				.count();
 
 		assertThat(ipops).isEqualTo(2);
@@ -36,7 +36,7 @@ class QualityMeasureScopedTest {
 	void internalDecodeValidMeasure137V5Denom() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long denom = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
-				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.DENOM))
+				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulationLabel.DENOM.name()))
 				.count();
 
 		assertThat(denom).isEqualTo(2);
@@ -46,7 +46,7 @@ class QualityMeasureScopedTest {
 	void internalDecodeValidMeasure137V5Denex() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long denex = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
-				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.DENEX))
+				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulationLabel.DENEX.name()))
 				.count();
 
 		assertThat(denex).isEqualTo(2);
@@ -56,7 +56,7 @@ class QualityMeasureScopedTest {
 	void internalDecodeValidMeasure137V5Numer() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, location);
 		long numer = pluckDescendants(result, TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2, TemplateId.MEASURE_DATA_CMS_V2)
-				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulations.NUMER))
+				.filter(node -> node.getValue(MeasureDataDecoder.MEASURE_TYPE).equals(SubPopulationLabel.NUMER.name()))
 				.count();
 
 		assertThat(numer).isEqualTo(2);

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/MeasureDataEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/MeasureDataEncoderTest.java
@@ -3,48 +3,35 @@ package gov.cms.qpp.conversion.encode;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static com.google.common.truth.Truth.assertThat;
 import static gov.cms.qpp.conversion.decode.AggregateCountDecoder.AGGREGATE_COUNT;
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
 
 class MeasureDataEncoderTest {
-	private final String PERFORMANCE_MET = "performanceMet"; //NUMER
-	private final String ELIGIBLE_POPULATION = "eligiblePopulation";//DENUM
-	private final String ELIGIBLE_POPULATION_EX = "eligiblePopulationExclusion";//DENEX
-	private final String ELIGIBLE_POPULATION_EXCEP = "eligiblePopulationException";//DENEXCP
+	private enum Fixture {
+		NUMER("performanceMet"),
+		DENOM("eligiblePopulation"),
+		DENEX("eligiblePopulationExclusion"),
+		DENEXCEP("eligiblePopulationException");
 
-	@Test
-	void testDenominator() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.DENOM.name());
-		JsonWrapper jsonWrapper = encode(measureDataNode);
-		assertThat(jsonWrapper.getInteger(ELIGIBLE_POPULATION))
-				.isEqualTo(900);
+		private String value;
+
+		Fixture(String value) {
+			this.value = value;
+		}
 	}
 
-	@Test
-	void testEligiblePopulationException() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.DENEXCEP.name());
+	@DisplayName("Verify measure data retrieval")
+	@ParameterizedTest(name = "retrieval of ''{0}''")
+	@EnumSource(Fixture.class)
+	void testDenominator(Fixture fixture) throws EncodeException {
+		Node measureDataNode = setUpMeasureDataNode(fixture.name());
 		JsonWrapper jsonWrapper = encode(measureDataNode);
-		assertThat(jsonWrapper.getInteger(ELIGIBLE_POPULATION_EXCEP))
-				.isEqualTo(900);
-	}
-
-	@Test
-	void testEligiblePopulationExclusion() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.DENEX.name());
-		JsonWrapper jsonWrapper = encode(measureDataNode);
-		assertThat(jsonWrapper.getInteger(ELIGIBLE_POPULATION_EX))
-				.isEqualTo(900);
-	}
-
-	@Test
-	void testPerformanceMet() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.NUMER.name());
-		JsonWrapper jsonWrapper = encode(measureDataNode);
-		assertThat(jsonWrapper.getInteger(PERFORMANCE_MET))
+		assertThat(jsonWrapper.getInteger(fixture.value))
 				.isEqualTo(900);
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/MeasureDataEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/MeasureDataEncoderTest.java
@@ -3,7 +3,7 @@ package gov.cms.qpp.conversion.encode;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -18,7 +18,7 @@ class MeasureDataEncoderTest {
 
 	@Test
 	void testDenominator() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulations.DENOM);
+		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.DENOM.name());
 		JsonWrapper jsonWrapper = encode(measureDataNode);
 		assertThat(jsonWrapper.getInteger(ELIGIBLE_POPULATION))
 				.isEqualTo(900);
@@ -26,7 +26,7 @@ class MeasureDataEncoderTest {
 
 	@Test
 	void testEligiblePopulationException() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulations.DENEXCEP);
+		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.DENEXCEP.name());
 		JsonWrapper jsonWrapper = encode(measureDataNode);
 		assertThat(jsonWrapper.getInteger(ELIGIBLE_POPULATION_EXCEP))
 				.isEqualTo(900);
@@ -34,7 +34,7 @@ class MeasureDataEncoderTest {
 
 	@Test
 	void testEligiblePopulationExclusion() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulations.DENEX);
+		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.DENEX.name());
 		JsonWrapper jsonWrapper = encode(measureDataNode);
 		assertThat(jsonWrapper.getInteger(ELIGIBLE_POPULATION_EX))
 				.isEqualTo(900);
@@ -42,7 +42,7 @@ class MeasureDataEncoderTest {
 
 	@Test
 	void testPerformanceMet() throws EncodeException {
-		Node measureDataNode = setUpMeasureDataNode(SubPopulations.NUMER);
+		Node measureDataNode = setUpMeasureDataNode(SubPopulationLabel.NUMER.name());
 		JsonWrapper jsonWrapper = encode(measureDataNode);
 		assertThat(jsonWrapper.getInteger(PERFORMANCE_MET))
 				.isEqualTo(900);

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -1,17 +1,16 @@
 package gov.cms.qpp.conversion.encode;
 
-import static com.google.common.truth.Truth.assertThat;
-
-import java.util.LinkedHashMap;
-
+import gov.cms.qpp.conversion.Context;
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import gov.cms.qpp.conversion.Context;
-import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import java.util.LinkedHashMap;
+
+import static com.google.common.truth.Truth.assertThat;
 
 class QualityMeasureIdEncoderTest {
 
@@ -21,7 +20,6 @@ class QualityMeasureIdEncoderTest {
 	private Node numeratorNode;
 	private Node denominatorNode;
 	private Node aggregateCountNode;
-	private Node paymentNode;
 	private JsonWrapper wrapper;
 	private QualityMeasureIdEncoder encoder;
 	private String type = "type";
@@ -35,24 +33,24 @@ class QualityMeasureIdEncoderTest {
 		aggregateCountNode = new Node(TemplateId.ACI_AGGREGATE_COUNT);
 		aggregateCountNode.putValue("aggregateCount", "600");
 
-		paymentNode = new Node(TemplateId.PAYER_SUPPLEMENTAL_DATA_ELEMENT_CMS_V2);
+		Node paymentNode = new Node(TemplateId.PAYER_SUPPLEMENTAL_DATA_ELEMENT_CMS_V2);
 		paymentNode.putValue("place", "holder");
 
 		populationNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		populationNode.putValue(type, SubPopulations.IPOP);
+		populationNode.putValue(type, SubPopulationLabel.IPOP.name());
 		populationNode.addChildNode(aggregateCountNode);
 
 		denomExclusionNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		denomExclusionNode.putValue(type, SubPopulations.DENEX);
+		denomExclusionNode.putValue(type, SubPopulationLabel.DENEX.name());
 		denomExclusionNode.addChildNode(aggregateCountNode);
 
 		numeratorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		numeratorNode.putValue(type, SubPopulations.NUMER);
+		numeratorNode.putValue(type, SubPopulationLabel.NUMER.name());
 		numeratorNode.addChildNode(aggregateCountNode);
 		numeratorNode.addChildNode(paymentNode);
 
 		denominatorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		denominatorNode.putValue(type, SubPopulations.DENOM);
+		denominatorNode.putValue(type, SubPopulationLabel.DENOM.name());
 		denominatorNode.addChildNode(paymentNode);
 		denominatorNode.addChildNode(aggregateCountNode);
 
@@ -90,7 +88,7 @@ class QualityMeasureIdEncoderTest {
 	@Test
 	void testPopulationAltTotalIsEncoded() {
 		populationNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		populationNode.putValue(type, SubPopulations.IPP);
+		populationNode.putValue(type, "IPP");
 		populationNode.addChildNode(aggregateCountNode);
 		executeInternalEncode();
 		LinkedHashMap<String, Object> childValues = getChildValues();

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdMultiEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdMultiEncoderTest.java
@@ -1,22 +1,20 @@
 package gov.cms.qpp.conversion.encode;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
-import java.util.LinkedHashMap;
-import java.util.List;
-
+import gov.cms.qpp.conversion.Context;
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import gov.cms.qpp.conversion.Context;
-import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import java.util.LinkedHashMap;
+import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 class QualityMeasureIdMultiEncoderTest {
 
@@ -45,7 +43,6 @@ class QualityMeasureIdMultiEncoderTest {
 	private Node numeratorNodeTwo;
 	private Node denominatorNode;
 	private Node denominatorNodeTwo;
-	private Node aggregateCountNode;
 	private JsonWrapper wrapper;
 	private QualityMeasureIdEncoder encoder;
 
@@ -64,57 +61,57 @@ class QualityMeasureIdMultiEncoderTest {
 		qualityMeasureId = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2);
 		qualityMeasureId.putValue(MEASURE_ID, "test1");
 
-		aggregateCountNode = new Node(TemplateId.ACI_AGGREGATE_COUNT);
+		Node aggregateCountNode = new Node(TemplateId.ACI_AGGREGATE_COUNT);
 		aggregateCountNode.putValue("aggregateCount", "600");
 
 		eligiblePopulationNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		eligiblePopulationNode.putValue(TYPE, SubPopulations.IPOP);
+		eligiblePopulationNode.putValue(TYPE, SubPopulationLabel.IPOP.name());
 		eligiblePopulationNode.putValue(POPULATION_ID, "ipop1");
 		eligiblePopulationNode.addChildNode(aggregateCountNode);
 
 		eligiblePopulationNodeTwo = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		eligiblePopulationNodeTwo.putValue(TYPE, SubPopulations.IPOP);
+		eligiblePopulationNodeTwo.putValue(TYPE, SubPopulationLabel.IPOP.name());
 		eligiblePopulationNodeTwo.putValue(POPULATION_ID, "ipop2");
 		eligiblePopulationNodeTwo.addChildNode(aggregateCountNode);
 
 		eligiblePopulationExclusionNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		eligiblePopulationExclusionNode.putValue(TYPE, SubPopulations.DENEX);
+		eligiblePopulationExclusionNode.putValue(TYPE, SubPopulationLabel.DENEX.name());
 		eligiblePopulationExclusionNode.putValue(POPULATION_ID, "denex1");
 		eligiblePopulationExclusionNode.addChildNode(aggregateCountNode);
 
 		eligiblePopulationExclusionNodeTwo = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		eligiblePopulationExclusionNodeTwo.putValue(TYPE, SubPopulations.DENEX);
+		eligiblePopulationExclusionNodeTwo.putValue(TYPE, SubPopulationLabel.DENEX.name());
 		eligiblePopulationExclusionNodeTwo.putValue(POPULATION_ID, "denex2");
 		eligiblePopulationExclusionNodeTwo.addChildNode(aggregateCountNode);
 
 		eligiblePopulationExceptionNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		eligiblePopulationExceptionNode.putValue(TYPE, SubPopulations.DENEXCEP);
+		eligiblePopulationExceptionNode.putValue(TYPE, SubPopulationLabel.DENEXCEP.name());
 		eligiblePopulationExceptionNode.putValue(POPULATION_ID, "denexcep1");
 		eligiblePopulationExceptionNode.addChildNode(aggregateCountNode);
 
 		eligiblePopulationExceptionNodeTwo = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		eligiblePopulationExceptionNodeTwo.putValue(TYPE, SubPopulations.DENEXCEP);
+		eligiblePopulationExceptionNodeTwo.putValue(TYPE, SubPopulationLabel.DENEXCEP.name());
 		eligiblePopulationExceptionNodeTwo.putValue(POPULATION_ID, "denexcep2");
 		eligiblePopulationExceptionNodeTwo.addChildNode(aggregateCountNode);
 
 		numeratorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
 
-		numeratorNode.putValue(TYPE, SubPopulations.NUMER);
+		numeratorNode.putValue(TYPE, SubPopulationLabel.NUMER.name());
 		numeratorNode.putValue(POPULATION_ID, "numer1");
 		numeratorNode.addChildNode(aggregateCountNode);
 
 		numeratorNodeTwo = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		numeratorNodeTwo.putValue(TYPE, SubPopulations.NUMER);
+		numeratorNodeTwo.putValue(TYPE, SubPopulationLabel.NUMER.name());
 		numeratorNodeTwo.putValue(POPULATION_ID, "numer2");
 		numeratorNodeTwo.addChildNode(aggregateCountNode);
 
 		denominatorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		denominatorNode.putValue(TYPE, SubPopulations.DENOM);
+		denominatorNode.putValue(TYPE, SubPopulationLabel.DENOM.name());
 		denominatorNode.putValue(POPULATION_ID, "denom1");
 		denominatorNode.addChildNode(aggregateCountNode);
 
 		denominatorNodeTwo = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		denominatorNodeTwo.putValue(TYPE, SubPopulations.DENOM);
+		denominatorNodeTwo.putValue(TYPE, SubPopulationLabel.DENOM.name());
 		denominatorNodeTwo.putValue(POPULATION_ID, "denom2");
 		denominatorNodeTwo.addChildNode(aggregateCountNode);
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
@@ -25,20 +25,19 @@ class SubPopulationsTest {
 
 	@Test
 	void testGetExclusiveKeysExcludesExpected() {
-		String label = SubPopulationLabel.DENEXCEP.name();
-		Set<String> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(label));
-		assertWithMessage("Excluded key %s should be absent", label)
-				.that(keys).doesNotContain(label);
+		Set<SubPopulationLabel> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.DENEXCEP));
+		assertWithMessage("Excluded key %s should be absent", SubPopulationLabel.DENEXCEP)
+				.that(keys).doesNotContain(SubPopulationLabel.DENEXCEP);
 	}
 
 	@Test
 	void testGetExclusiveKeysIncludesOthers() {
-		Set<String> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.DENEX.name()));
+		Set<SubPopulationLabel> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.DENEX));
 
  		assertWithMessage("Non excluded keys should be present")
 				.that(keys)
-				.containsExactly(SubPopulationLabel.DENEXCEP.name(), SubPopulationLabel.DENOM.name(),
-					SubPopulationLabel.NUMER.name(), SubPopulationLabel.IPOP.name(), "IPP");
+				.containsExactly(SubPopulationLabel.DENEXCEP, SubPopulationLabel.DENOM,
+					SubPopulationLabel.NUMER, SubPopulationLabel.IPOP);
 	}
 
 	@Test
@@ -72,9 +71,9 @@ class SubPopulationsTest {
 		subPopulation.setDenominatorUuid(expected.get(SubPopulationLabel.DENOM.name()));
 		subPopulation.setNumeratorUuid(expected.get(SubPopulationLabel.NUMER.name()));
 
-		for (String key : SubPopulations.getExclusiveKeys(Sets.newHashSet("IPOP", "IPP"))) {
-			assertThat(SubPopulations.getUniqueIdForKey(key, subPopulation))
-					.isSameAs(expected.get(key));
+		for (SubPopulationLabel key : SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.IPOP))) {
+			assertThat(SubPopulations.getUniqueIdForKey(key.name(), subPopulation))
+					.isSameAs(expected.get(key.name()));
 		}
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
@@ -15,28 +15,30 @@ import com.google.common.collect.Sets;
 
 class SubPopulationsTest {
 
-	@Test
-	void testGetKeysContainsExpected() {
-		assertThat(SubPopulations.getKeys())
-				.containsExactly(SubPopulations.DENEXCEP, SubPopulations.DENEX,
-						SubPopulations.DENOM, SubPopulations.NUMER, SubPopulations.IPOP);
-	}
+	//TODO: move to new test for SubPopulationLabel
+//	@Test
+//	void testGetKeysContainsExpected() {
+//		assertThat(SubPopulations.getKeys())
+//				.containsExactly(SubPopulations.DENEXCEP, SubPopulations.DENEX,
+//						SubPopulations.DENOM, SubPopulations.NUMER, SubPopulations.IPOP);
+//	}
 
 	@Test
 	void testGetExclusiveKeysExcludesExpected() {
-		Set<String> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulations.DENEXCEP));
-		assertWithMessage("Excluded key %s should be absent", SubPopulations.DENEXCEP)
-				.that(keys).doesNotContain(SubPopulations.DENEXCEP);
+		String label = SubPopulationLabel.DENEXCEP.name();
+		Set<String> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(label));
+		assertWithMessage("Excluded key %s should be absent", label)
+				.that(keys).doesNotContain(label);
 	}
 
 	@Test
 	void testGetExclusiveKeysIncludesOthers() {
-		Set<String> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulations.DENEX));
+		Set<String> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.DENEX.name()));
 
  		assertWithMessage("Non excluded keys should be present")
 				.that(keys)
-				.containsExactly(SubPopulations.DENEXCEP, SubPopulations.DENOM,
-						SubPopulations.NUMER, SubPopulations.IPOP);
+				.containsExactly(SubPopulationLabel.DENEXCEP.name(), SubPopulationLabel.DENOM.name(),
+					SubPopulationLabel.NUMER.name(), SubPopulationLabel.IPOP.name(), "IPP");
 	}
 
 	@Test
@@ -60,15 +62,15 @@ class SubPopulationsTest {
 	@Test
 	void testGetUniqueIdForKeyReturnsExpectedValue() {
 		Map<String, String> expected = new HashMap<>();
-		for (String key : SubPopulations.getKeys()) {
+		for (String key : SubPopulationLabel.aliasSet()) {
 			expected.put(key, UUID.randomUUID().toString());
 		}
 
 		SubPopulation subPopulation = new SubPopulation();
-		subPopulation.setDenominatorExceptionsUuid(expected.get(SubPopulations.DENEXCEP));
-		subPopulation.setDenominatorExclusionsUuid(expected.get(SubPopulations.DENEX));
-		subPopulation.setDenominatorUuid(expected.get(SubPopulations.DENOM));
-		subPopulation.setNumeratorUuid(expected.get(SubPopulations.NUMER));
+		subPopulation.setDenominatorExceptionsUuid(expected.get(SubPopulationLabel.DENEXCEP.name()));
+		subPopulation.setDenominatorExclusionsUuid(expected.get(SubPopulationLabel.DENEX.name()));
+		subPopulation.setDenominatorUuid(expected.get(SubPopulationLabel.DENOM.name()));
+		subPopulation.setNumeratorUuid(expected.get(SubPopulationLabel.NUMER.name()));
 
 		for (String key : SubPopulations.getExclusiveKeys(Sets.newHashSet("IPOP", "IPP"))) {
 			assertThat(SubPopulations.getUniqueIdForKey(key, subPopulation))

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
@@ -15,14 +15,6 @@ import com.google.common.collect.Sets;
 
 class SubPopulationsTest {
 
-	//TODO: move to new test for SubPopulationLabel
-//	@Test
-//	void testGetKeysContainsExpected() {
-//		assertThat(SubPopulations.getKeys())
-//				.containsExactly(SubPopulations.DENEXCEP, SubPopulations.DENEX,
-//						SubPopulations.DENOM, SubPopulations.NUMER, SubPopulations.IPOP);
-//	}
-
 	@Test
 	void testGetExclusiveKeysExcludesExpected() {
 		Set<SubPopulationLabel> keys = SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.DENEXCEP));

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
@@ -1,8 +1,5 @@
 package gov.cms.qpp.conversion.validate;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import gov.cms.qpp.TestHelper;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.decode.QrdaDecoderEngine;
@@ -12,9 +9,11 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.model.validation.SupplementalData;
 import gov.cms.qpp.conversion.xml.XmlUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -49,7 +48,7 @@ class CpcMeasureDataValidatorTest {
 		validator.internalValidateSingleNode(underTest);
 
 		LocalizedError expectedError = ErrorCode.CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT.format(
-			SupplementalData.MALE.getCode(), SubPopulations.IPOP, MEASURE_ID);
+			SupplementalData.MALE.getCode(), SubPopulationLabel.IPOP.name(), MEASURE_ID);
 
 		Set<Detail> errors = validator.getDetails();
 
@@ -109,7 +108,7 @@ class CpcMeasureDataValidatorTest {
 
 				LocalizedError expectedError = ErrorCode.CPC_PLUS_MISSING_SUPPLEMENTAL_CODE
 					.format(supplementalData.getType(), supplementalData, supplementalData.getCode(),
-						MEASURE_ID, SubPopulations.IPOP);
+						MEASURE_ID, SubPopulationLabel.IPOP.name());
 
 				Set<Detail> errors = validator.getDetails();
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureScopedValidatonTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureScopedValidatonTest.java
@@ -95,7 +95,7 @@ class CpcQualityMeasureScopedValidatonTest {
 	void validateCms137V5FailMissingMeasure() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, "cms137v5_MissingMeasure.xml");
 		Set<Detail> details = validateNode(result);
-		LocalizedError message = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS137v5", "IPOP,IPP", "EC2C5F63-AF76-4D3C-85F0-5423F8C28541");
+		LocalizedError message = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS137v5", "IPP,IPOP", "EC2C5F63-AF76-4D3C-85F0-5423F8C28541");
 
 		assertWithMessage("Missing CMS137v5 IPOP strata should result in errors")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureScopedValidatonTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureScopedValidatonTest.java
@@ -1,6 +1,19 @@
 package gov.cms.qpp.conversion.validate;
 
-import static com.google.common.truth.Truth.assertWithMessage;
+import com.google.common.collect.Sets;
+import gov.cms.qpp.conversion.Converter;
+import gov.cms.qpp.conversion.PathSource;
+import gov.cms.qpp.conversion.decode.MeasureDataDecoder;
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.error.Detail;
+import gov.cms.qpp.conversion.model.error.ErrorCode;
+import gov.cms.qpp.conversion.model.error.LocalizedError;
+import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+import gov.cms.qpp.conversion.segmentation.QrdaScope;
+import gov.cms.qpp.conversion.xml.XmlException;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -12,22 +25,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Sets;
-
-import gov.cms.qpp.conversion.Converter;
-import gov.cms.qpp.conversion.PathSource;
-import gov.cms.qpp.conversion.decode.MeasureDataDecoder;
-import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.error.Detail;
-import gov.cms.qpp.conversion.model.error.ErrorCode;
-import gov.cms.qpp.conversion.model.error.LocalizedError;
-import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
-import gov.cms.qpp.conversion.segmentation.QrdaScope;
-import gov.cms.qpp.conversion.xml.XmlException;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 class CpcQualityMeasureScopedValidatonTest {
 	private static Path baseDir = Paths.get("src/test/resources/fixtures/qppct298/");
@@ -44,12 +42,12 @@ class CpcQualityMeasureScopedValidatonTest {
 	@Test
 	void validateCms137V5FailMissingDenomStrata() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, "cms137v5.xml");
-		removeMeasureStrata(result, SubPopulations.DENOM);
+		removeMeasureStrata(result, SubPopulationLabel.DENOM.name());
 		Set<Detail> details = validateNode(result);
 
 		assertWithMessage("Missing CMS137v5 DENOM strata should result in errors")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(getMessages(SubPopulations.DENOM,
+				.containsExactly(getMessages(SubPopulationLabel.DENOM.name(),
 						"BC948E65-B908-493B-B48B-04AC342D3E6C",
 						"EFB5B088-CE10-43DE-ACCD-9913B7AC12A2", "94B9555F-8700-45EF-B69F-433EBEDE8051"));
 	}
@@ -57,12 +55,12 @@ class CpcQualityMeasureScopedValidatonTest {
 	@Test
 	void validateCms137V5FailMissingDenexStrata() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, "cms137v5.xml");
-		removeMeasureStrata(result, SubPopulations.DENEX);
+		removeMeasureStrata(result, SubPopulationLabel.DENEX.name());
 		Set<Detail> details = validateNode(result);
 
 		assertWithMessage("Missing CMS137v5 DENEX strata should result in errors")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(getMessages(SubPopulations.DENEX,
+				.containsExactly(getMessages(SubPopulationLabel.DENEX.name(),
 						"56BC7FA2-C22A-4440-8652-2D3568852C60",
 						"EFB5B088-CE10-43DE-ACCD-9913B7AC12A2", "94B9555F-8700-45EF-B69F-433EBEDE8051"));
 	}
@@ -70,12 +68,12 @@ class CpcQualityMeasureScopedValidatonTest {
 	@Test
 	void validateCms137V5FailMissingNumerStrata() throws IOException, XmlException {
 		Node result = scopedConversion(QrdaScope.MEASURE_REFERENCE_RESULTS_CMS_V2, "cms137v5.xml");
-		removeMeasureStrata(result, SubPopulations.NUMER);
+		removeMeasureStrata(result, SubPopulationLabel.NUMER.name());
 		Set<Detail> details = validateNode(result);
 
 		assertWithMessage("Missing CMS137v5 NUMER strata should result in errors")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(getMessages(SubPopulations.NUMER,
+				.containsExactly(getMessages(SubPopulationLabel.NUMER.name(),
 						"0BBF8596-4CFE-47F4-A0D7-9BEAB94BA4CD",
 						"EFB5B088-CE10-43DE-ACCD-9913B7AC12A2", "94B9555F-8700-45EF-B69F-433EBEDE8051"));
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -389,8 +389,8 @@ class QualityMeasureIdValidatorTest {
 			Lists.newArrayList(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID,
 				MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER3_GUID,
 				MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER2_GUID),
-			", ",
-			"or ");
+			",",
+			"or");
 		LocalizedError expectedErrorMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5",
 			PERFORMANCE_RATE_ID, expectedUuids);
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -9,7 +9,7 @@ import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.MeasureIndexInit;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ import static gov.cms.qpp.conversion.validate.QualityMeasureIdValidator.MEASURE_
 
 class QualityMeasureIdValidatorTest {
 
-	public static final String ONE_HUNDRED = "100";
+	static final String ONE_HUNDRED = "100";
 
 	private static final String REQUIRES_DENOM_EXCLUSION_GUID = "requiresDenominatorExclusionGuid";
 	private static final String REQUIRES_DENOM_EXCLUSION_IPOP_GUID = "3AD33404-E734-4F67-9144-E4B63CB3F4BE";
@@ -131,10 +131,14 @@ class QualityMeasureIdValidatorTest {
 			"40280381-51f0-825b-0152-227617db152e", "40280381-51f0-825b-0152-22a112d2172a");
 		Node measureReferenceResultsNode = new MeasureReferenceBuilder()
 				.addMeasureId(measureId)
-				.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP, REQUIRES_DENOM_EXCLUSION_IPOP_GUID, ONE_HUNDRED)
-				.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM, REQUIRES_DENOM_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
-				.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER, REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
-				.addSubPopulationMeasureDataWithCounts(SubPopulations.DENEX, REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(
+					SubPopulationLabel.IPOP.name(), REQUIRES_DENOM_EXCLUSION_IPOP_GUID, ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(
+					SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(
+					SubPopulationLabel.NUMER.name(), REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(
+					SubPopulationLabel.DENEX.name(), REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
 				.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -149,10 +153,14 @@ class QualityMeasureIdValidatorTest {
 		String measureId = "InvalidMeasureId";
 		Node measureReferenceResultsNode = new MeasureReferenceBuilder()
 			.addMeasureId(measureId)
-			.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP, REQUIRES_DENOM_EXCLUSION_IPOP_GUID, ONE_HUNDRED)
-			.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM, REQUIRES_DENOM_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
-			.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER, REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
-			.addSubPopulationMeasureDataWithCounts(SubPopulations.DENEX, REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
+			.addSubPopulationMeasureDataWithCounts(
+				SubPopulationLabel.IPOP.name(), REQUIRES_DENOM_EXCLUSION_IPOP_GUID, ONE_HUNDRED)
+			.addSubPopulationMeasureDataWithCounts(
+				SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
+			.addSubPopulationMeasureDataWithCounts(
+				SubPopulationLabel.NUMER.name(), REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
+			.addSubPopulationMeasureDataWithCounts(
+				SubPopulationLabel.DENEX.name(), REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -165,12 +173,12 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testDenominatorExclusionMissing() {
 		LocalizedError incorrectCount = ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format(
-				"CMS165v5", 1, SubPopulations.DENEX, 0);
+				"CMS165v5", 1, SubPopulationLabel.DENEX.name(), 0);
 		LocalizedError incorrectUuid = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(
-				"CMS165v5", SubPopulations.DENEX, REQUIRES_DENOM_EXCLUSION_DENEX_GUID);
+				"CMS165v5", SubPopulationLabel.DENEX.name(), REQUIRES_DENOM_EXCLUSION_DENEX_GUID);
 
 		Node measureReferenceResultsNode = createCorrectMeasureReference(REQUIRES_DENOM_EXCLUSION_GUID)
-			.removeSubPopulationMeasureData(SubPopulations.DENEX, REQUIRES_DENOM_EXCLUSION_DENEX_GUID)
+			.removeSubPopulationMeasureData(SubPopulationLabel.DENEX.name(), REQUIRES_DENOM_EXCLUSION_DENEX_GUID)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -190,7 +198,9 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testInternalIPPMeasure() {
 		Node measureReferenceResultsNode = createCorrectMeasureReference(REQUIRES_DENOM_EXCEPTION_GUID)
-			.replaceSubPopulationMeasureData(SubPopulations.IPOP, REQUIRES_DENOM_EXCEPTION_IPOP_GUID, SubPopulations.IPP, REQUIRES_DENOM_EXCEPTION_IPOP_GUID)
+			.replaceSubPopulationMeasureData(
+				SubPopulationLabel.IPOP.name(), REQUIRES_DENOM_EXCEPTION_IPOP_GUID,
+				"IPP", REQUIRES_DENOM_EXCEPTION_IPOP_GUID)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -200,12 +210,13 @@ class QualityMeasureIdValidatorTest {
 
 	@Test
 	void testInternalMissingDenexcepMeasure() {
-		LocalizedError countMessage = ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS68v6", 1, SubPopulations.DENEXCEP, 0);
+		LocalizedError countMessage =
+			ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS68v6", 1, SubPopulationLabel.DENEXCEP.name(), 0);
 		LocalizedError uuidMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(
-				"CMS68v6", SubPopulations.DENEXCEP, REQUIRES_DENOM_EXCEPTION_DENEXCEP_GUID);
+				"CMS68v6", SubPopulationLabel.DENEXCEP.name(), REQUIRES_DENOM_EXCEPTION_DENEXCEP_GUID);
 
 		Node measureReferenceResultsNode = createCorrectMeasureReference(REQUIRES_DENOM_EXCEPTION_GUID)
-			.removeSubPopulationMeasureData(SubPopulations.DENEXCEP, REQUIRES_DENOM_EXCEPTION_DENEXCEP_GUID)
+			.removeSubPopulationMeasureData(SubPopulationLabel.DENEXCEP.name(), REQUIRES_DENOM_EXCEPTION_DENEXCEP_GUID)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -227,12 +238,14 @@ class QualityMeasureIdValidatorTest {
 
 	@Test
 	void testInternalDenexcepMultipleSupPopulationsInvalidMeasureId() {
-		LocalizedError message = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5", SubPopulations.DENEXCEP, MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID);
+		LocalizedError message =
+			ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(
+				"CMS52v5", SubPopulationLabel.DENEXCEP.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID);
 
 		Node measureReferenceResultsNode = createCorrectMeasureReference(MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID)
 			.replaceSubPopulationMeasureData(
-					SubPopulations.DENEXCEP, MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID,
-					SubPopulations.DENEXCEP, MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID+"INVALID")
+					SubPopulationLabel.DENEXCEP.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID,
+					SubPopulationLabel.DENEXCEP.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID+"INVALID")
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -243,12 +256,14 @@ class QualityMeasureIdValidatorTest {
 
 	@Test
 	void testInternalDenexcepMultipleSupPopulationsMissingMeasureId() {
-		LocalizedError countMessage = ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 2, SubPopulations.DENEXCEP, 1);
-		LocalizedError uuidMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5", SubPopulations.DENEXCEP,
+		LocalizedError countMessage =
+			ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 2, SubPopulationLabel.DENEXCEP.name(), 1);
+		LocalizedError uuidMessage =
+			ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5", SubPopulationLabel.DENEXCEP.name(),
 				MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID);
 
 		Node measureReferenceResultsNode = createCorrectMeasureReference(MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID)
-			.removeSubPopulationMeasureData(SubPopulations.DENEXCEP, MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID)
+			.removeSubPopulationMeasureData(SubPopulationLabel.DENEXCEP.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -260,13 +275,14 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testTooManyCriteriaExists() {
 		Node measureReferenceResultsNode = createCorrectMeasureReference(MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID)
-			.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER,
+			.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(),
 					MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID, ONE_HUNDRED)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
 
-		LocalizedError expectedErrorMessage = ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 3, SubPopulations.NUMER, 4);
+		LocalizedError expectedErrorMessage =
+			ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 3, SubPopulationLabel.NUMER.name(), 4);
 		assertWithMessage("Incorrect validation error.")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(expectedErrorMessage);
@@ -275,13 +291,15 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testTooFewCriteriaExists() {
 		Node measureReferenceResultsNode = createCorrectMeasureReference(MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID)
-			.removeSubPopulationMeasureData(SubPopulations.NUMER, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID)
+			.removeSubPopulationMeasureData(SubPopulationLabel.NUMER.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID)
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
 
-		LocalizedError expectedErrorMessage = ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 3, SubPopulations.NUMER, 2);
-		LocalizedError expectedUuidErrorMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5", SubPopulations.NUMER,
+		LocalizedError expectedErrorMessage =
+			ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format("CMS52v5", 3, SubPopulationLabel.NUMER.name(), 2);
+		LocalizedError expectedUuidErrorMessage =
+			ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5", SubPopulationLabel.NUMER.name(),
 				MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID);
 
 		assertWithMessage("Incorrect validation error.")
@@ -292,14 +310,14 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testIncorrectUuid() {
 		Node measureReferenceResultsNode = createCorrectMeasureReference(MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID)
-			.replaceSubPopulationMeasureData(SubPopulations.NUMER, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID,
-					SubPopulations.NUMER, "incorrectUUID")
+			.replaceSubPopulationMeasureData(SubPopulationLabel.NUMER.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID,
+					SubPopulationLabel.NUMER.name(), "incorrectUUID")
 			.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
 
 		LocalizedError expectedErrorMessage = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format("CMS52v5",
-				SubPopulations.NUMER, MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID);
+				SubPopulationLabel.NUMER.name(), MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID);
 
 		assertWithMessage("Incorrect validation error.")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
@@ -309,8 +327,8 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testInternalDenomCountLessThanIpopCount() {
 		Node measureReferenceResultsNode = createCorrectMeasureReference(REQUIRES_DENOM_EXCEPTION_GUID)
-				.removeSubPopulationMeasureData(SubPopulations.DENOM, REQUIRES_DENOM_EXCEPTION_DENOM_GUID)
-				.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM, REQUIRES_DENOM_EXCEPTION_DENOM_GUID, "50")
+				.removeSubPopulationMeasureData(SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCEPTION_DENOM_GUID)
+				.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCEPTION_DENOM_GUID, "50")
 				.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -331,8 +349,8 @@ class QualityMeasureIdValidatorTest {
 	@Test
 	void testInternalDenomCountGreaterThanIpopCount() {
 		Node measureReferenceResultsNode = createCorrectMeasureReference(REQUIRES_DENOM_EXCEPTION_GUID)
-				.removeSubPopulationMeasureData(SubPopulations.DENOM, REQUIRES_DENOM_EXCEPTION_DENOM_GUID)
-				.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM, REQUIRES_DENOM_EXCEPTION_DENOM_GUID, "101")
+				.removeSubPopulationMeasureData(SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCEPTION_DENOM_GUID)
+				.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCEPTION_DENOM_GUID, "101")
 				.build();
 
 		Set<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode);
@@ -361,48 +379,48 @@ class QualityMeasureIdValidatorTest {
 
 		if (MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID.equals(measureId)) {
 			measureReferenceResultsNode
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.IPOP.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_IPOP1_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_DENOM1_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENEXCEP,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENEXCEP.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXCEP1_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID, ONE_HUNDRED)
 					.addSubPopulationPerformanceRate(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER1_GUID)
 
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.IPOP.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_IPOP2_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_DENOM2_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENEXCEP,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENEXCEP.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_DENEXECEP2_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER2_GUID, ONE_HUNDRED)
 					.addSubPopulationPerformanceRate(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER2_GUID)
 
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.IPOP.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_IPOP3_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_DENOM3_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(),
 							MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER3_GUID, ONE_HUNDRED)
 					.addSubPopulationPerformanceRate(MULTIPLE_POPULATION_DENOM_EXCEPTION_NUMER3_GUID);
 		} else if (REQUIRES_DENOM_EXCEPTION_GUID.equals(measureId)) {
 			measureReferenceResultsNode
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENEXCEP,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENEXCEP.name(),
 							REQUIRES_DENOM_EXCEPTION_DENEXCEP_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP, REQUIRES_DENOM_EXCEPTION_IPOP_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM, REQUIRES_DENOM_EXCEPTION_DENOM_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER, REQUIRES_DENOM_EXCEPTION_NUMER_GUID, ONE_HUNDRED)
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.IPOP.name(), REQUIRES_DENOM_EXCEPTION_IPOP_GUID, ONE_HUNDRED)
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCEPTION_DENOM_GUID, ONE_HUNDRED)
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(), REQUIRES_DENOM_EXCEPTION_NUMER_GUID, ONE_HUNDRED)
 					.addSubPopulationPerformanceRate(REQUIRES_DENOM_EXCEPTION_NUMER_GUID);
 		} else if (REQUIRES_DENOM_EXCLUSION_GUID.equals(measureId)) {
 			measureReferenceResultsNode
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.IPOP, REQUIRES_DENOM_EXCLUSION_IPOP_GUID,
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.IPOP.name(), REQUIRES_DENOM_EXCLUSION_IPOP_GUID,
 							ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENOM, REQUIRES_DENOM_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.NUMER, REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
-					.addSubPopulationMeasureDataWithCounts(SubPopulations.DENEX, REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(), REQUIRES_DENOM_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(), REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
+					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENEX.name(), REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
 					.addSubPopulationPerformanceRate(REQUIRES_DENOM_EXCLUSION_NUMER_GUID);
 		}
 

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -470,8 +470,13 @@
 		"errorData": [
 			{
 				"errorCode": 14,
+				"subs": ["CMS137v5", 2, "IPP or IPOP", 3],
+				"occurrences": 1
+			},
+			{
+				"errorCode": 14,
 				"subs": ["CMS137v5", 2, "[A-Z]{3,8}", 3],
-				"occurrences": 4
+				"occurrences": 3
 			},
 			{
 				"errorCode": 59,

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -353,7 +353,7 @@
 			{
 				"errorCode": 59,
 				"subs": ["CMS\\d{2,3}v\\d{1}",
-					"IPOP,IPP",
+					"IPP,IPOP",
 					"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"],
 				"occurrences": 1
 			},

--- a/converter/src/test/resources/fixtures/qppct298/cms137v5_MissingMeasure.xml
+++ b/converter/src/test/resources/fixtures/qppct298/cms137v5_MissingMeasure.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3">
     <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2017-07-01"/>
+    <informationRecipient>
+        <intendedRecipient>
+            <id root="2.16.840.1.113883.3.249.7" extension="CPCPLUS" />
+        </intendedRecipient>
+    </informationRecipient>
 
-    <meep>
+    <component>
+    <structuredBody>
+        <component>
+            <section>
+                <templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01"/>
+                <entry>
+                <organizer>
         <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
         <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
         <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
@@ -4779,5 +4790,12 @@
                 </reference>
             </observation>
         </component>
-    </meep>
+                </organizer>
+                </entry>
+            </section>
+
+        </component>
+    </structuredBody>
+    </component>
+
 </ClinicalDocument>

--- a/generate/src/main/java/gov/cms/qpp/generator/QrdaGenerator.java
+++ b/generate/src/main/java/gov/cms/qpp/generator/QrdaGenerator.java
@@ -5,7 +5,7 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
-import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -140,17 +140,17 @@ public class QrdaGenerator {
 	}
 
 	private enum PopulationValue {
-		IPOP(SubPopulations.IPOP, 100),
-		DENOM(SubPopulations.DENOM, 100),
-		DENEX(SubPopulations.DENEX, 10),
-		DENEXCEP(SubPopulations.DENEXCEP, 10),
-		NUMER(SubPopulations.NUMER, 80);
+		IPOP(SubPopulationLabel.IPOP, 100),
+		DENOM(SubPopulationLabel.DENOM, 100),
+		DENEX(SubPopulationLabel.DENEX, 10),
+		DENEXCEP(SubPopulationLabel.DENEXCEP, 10),
+		NUMER(SubPopulationLabel.NUMER, 80);
 
 		String measure;
 		int value;
 
-		PopulationValue(String measure, int factor) {
-			this.measure = measure;
+		PopulationValue(SubPopulationLabel measure, int factor) {
+			this.measure = measure.name();
 			this.value = factor * getSubPopCount();
 		}
 


### PR DESCRIPTION
### Information
- QPPCT-685

### Changes proposed in this PR:
- replaced string based subpopulation references with an enum type that allows aliasing.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
