### PR TITLE
MeasureConfigHelper

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -10,6 +10,8 @@ import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.Strata;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.util.MeasureConfigHelper;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -44,8 +46,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	 */
 	@Override
 	public void internalEncode(JsonWrapper wrapper, Node node) {
-		Map<String, MeasureConfig> configurationMap = MeasureConfigs.getConfigurationMap();
-		MeasureConfig measureConfig = configurationMap.get(node.getValue(MEASURE_ID));
+		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node);
 		String measureId = measureConfig.getMeasureId();
 		wrapper.putString(MEASURE_ID, measureId);
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/util/MeasureConfigHelper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/util/MeasureConfigHelper.java
@@ -1,0 +1,19 @@
+package gov.cms.qpp.conversion.util;
+
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.validation.MeasureConfig;
+import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
+
+public class MeasureConfigHelper {
+
+	public static final String MEASURE_ID = "measureId";
+
+	private MeasureConfigHelper() {
+		// private for this helper class
+	}
+
+	public static MeasureConfig getMeasureConfig(Node node) {
+		String measureId =  node.getValue(MEASURE_ID);
+		return MeasureConfigs.getConfigurationMap().get(measureId);
+	}
+}

--- a/converter/src/main/java/gov/cms/qpp/conversion/util/MeasureConfigHelper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/util/MeasureConfigHelper.java
@@ -12,6 +12,12 @@ public class MeasureConfigHelper {
 		// private for this helper class
 	}
 
+	/**
+	 * Convenience method to retrieve the measure configuration for validation from an ecqm node
+	 *
+	 * @param node Contains the id that associates with the measure config
+	 * @return
+	 */
 	public static MeasureConfig getMeasureConfig(Node node) {
 		String measureId =  node.getValue(MEASURE_ID);
 		return MeasureConfigs.getConfigurationMap().get(measureId);

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
@@ -9,9 +9,9 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.validation.MeasureConfig;
-import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SupplementalData;
 import gov.cms.qpp.conversion.model.validation.SupplementalData.SupplementalType;
+import gov.cms.qpp.conversion.util.MeasureConfigHelper;
 
 import java.util.EnumSet;
 import java.util.Map;
@@ -64,19 +64,17 @@ public class CpcMeasureDataValidator extends NodeValidator {
 				node.getChildNodes(currSupplementalDataTemplateId).collect(Collectors.toSet());
 		EnumSet<SupplementalData> codes = EnumSet.copyOf(
 				 SupplementalData.getSupplementalDataSetByType(supplementalDataType));
-
-		String measureId = node.getParent().getValue(QualityMeasureIdValidator.MEASURE_ID);
-		MeasureConfig config = MeasureConfigs.getConfigurationMap().get(measureId);
-		if (config != null) {
-			String electronicMeasureID = config.getElectronicMeasureId();
+		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node.getParent());
+		if (measureConfig != null) {
+			String electronicMeasureId = measureConfig.getElectronicMeasureId();
 			for (SupplementalData supplementalData : codes) {
 				Node validatedSupplementalNode = filterCorrectNode(supplementalDataNodes, supplementalData);
 
 				if (validatedSupplementalNode == null) {
-					addSupplementalValidationError(node, supplementalData, electronicMeasureID);
+					addSupplementalValidationError(node, supplementalData, electronicMeasureId);
 				} else {
 					LocalizedError error = makeIncorrectCountSizeLocalizedError(node, supplementalData.getCode(),
-						electronicMeasureID);
+						electronicMeasureId);
 					check(validatedSupplementalNode)
 						.childMinimum(error, 1, TemplateId.ACI_AGGREGATE_COUNT)
 						.childMaximum(error, 1, TemplateId.ACI_AGGREGATE_COUNT);

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidator.java
@@ -13,6 +13,7 @@ import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.util.MeasureConfigHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,10 +42,7 @@ public class CpcQualityMeasureIdValidator extends QualityMeasureIdValidator {
 	@Override
 	protected void internalValidateSingleNode(Node node) {
 		super.internalValidateSingleNode(node);
-		Map<String, MeasureConfig> configurationMap = MeasureConfigs.getConfigurationMap();
-		String value = node.getValue(MEASURE_ID);
-		MeasureConfig measureConfig = configurationMap.get(value);
-
+		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node);
 		if (measureConfig != null) {
 			int requiredPerformanceRateCount = measureConfig.getStrata().size();
 
@@ -58,7 +56,6 @@ public class CpcQualityMeasureIdValidator extends QualityMeasureIdValidator {
 									.format(requiredPerformanceRateCount),
 							requiredPerformanceRateCount, TemplateId.PERFORMANCE_RATE_PROPORTION_MEASURE);
 		}
-
 	}
 
 	@Override

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/MipsQualityMeasureIdValidator.java
@@ -1,6 +1,7 @@
 package gov.cms.qpp.conversion.validate;
 
 import com.google.common.collect.Sets;
+
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.Program;
 import gov.cms.qpp.conversion.model.TemplateId;
@@ -9,7 +10,6 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.LocalizedError;
 import gov.cms.qpp.conversion.model.validation.MeasureConfig;
-import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
 import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.util.MeasureConfigHelper;
@@ -17,7 +17,6 @@ import gov.cms.qpp.conversion.util.StringHelper;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -28,6 +28,7 @@ import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.SubPopulation;
 import gov.cms.qpp.conversion.model.validation.SubPopulations;
+import gov.cms.qpp.conversion.util.MeasureConfigHelper;
 
 /**
  * Validates a Measure Reference Results node.
@@ -69,13 +70,12 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 * @param node to validate
 	 */
 	private void validateMeasureConfigs(Node node) {
-		Map<String, MeasureConfig> configurationMap = MeasureConfigs.getConfigurationMap();
-		String value = node.getValue(MEASURE_ID);
-		MeasureConfig measureConfig = configurationMap.get(value);
+		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node);
 
 		if (measureConfig != null) {
 			validateAllSubPopulations(node, measureConfig);
 		} else {
+			String value = node.getValue(MEASURE_ID);
 			if (value != null) { // This check has already been made and a detail will exist if value is null.
 				DEV_LOG.error("MEASURE_GUID_MISSING " + value);
 				List<String> suggestions = MeasureConfigs.getMeasureSuggestions(value);

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -40,8 +40,6 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 			.collect(Collectors.toSet());
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(QualityMeasureIdValidator.class);
 
-	public static final String MEASURE_ID = "measureId";
-
 	/**
 	 * Validates that the Measure Reference Results node contains...
 	 *
@@ -60,7 +58,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 		//This should not be an error
 
 		thoroughlyCheck(node)
-				.singleValue(ErrorCode.MEASURE_GUID_MISSING, MEASURE_ID)
+				.singleValue(ErrorCode.MEASURE_GUID_MISSING, MeasureConfigHelper.MEASURE_ID)
 				.childMinimum(ErrorCode.CHILD_MEASURE_MISSING, 1, TemplateId.MEASURE_DATA_CMS_V2);
 		validateMeasureConfigs(node);
 	}
@@ -76,7 +74,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 		if (measureConfig != null) {
 			validateAllSubPopulations(node, measureConfig);
 		} else {
-			String value = node.getValue(MEASURE_ID);
+			String value = node.getValue(MeasureConfigHelper.MEASURE_ID);
 			if (value != null) { // This check has already been made and a detail will exist if value is null.
 				DEV_LOG.error("MEASURE_GUID_MISSING " + value);
 				List<String> suggestions = MeasureConfigs.getMeasureSuggestions(value);
@@ -123,9 +121,9 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 		long actualChildTypeCount = node.getChildNodes(TemplateId.MEASURE_DATA_CMS_V2).filter(childTypeFinder).count();
 
 		if (expectedChildTypeCount != actualChildTypeCount) {
-			MeasureConfig config = MeasureConfigs.getConfigurationMap().get(node.getValue(MEASURE_ID));
 			LocalizedError error =
-				ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format(config.getElectronicMeasureId(),
+				ErrorCode.POPULATION_CRITERIA_COUNT_INCORRECT.format(
+					MeasureConfigHelper.getMeasureConfig(node).getElectronicMeasureId(),
 					expectedChildTypeCount, StringHelper.join(key.getAliases(), ",", "or"),
 					actualChildTypeCount);
 			Detail detail = Detail.forErrorAndNode(error, node);
@@ -263,9 +261,8 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 * @param node Contains the current child nodes
 	 */
 	protected void addMeasureConfigurationValidationMessage(Supplier<String> check, String[] keys, Node node) {
-		MeasureConfig config =
-				MeasureConfigs.getConfigurationMap().get(node.getValue(MEASURE_ID));
-		LocalizedError error = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(config.getElectronicMeasureId(),
+		LocalizedError error = ErrorCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(
+				MeasureConfigHelper.getMeasureConfig(node).getElectronicMeasureId(),
 				String.join(",", keys), check.get());
 		addValidationError(Detail.forErrorAndNode(error, node));
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/util/MeasureConfigHelperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/util/MeasureConfigHelperTest.java
@@ -1,0 +1,21 @@
+package gov.cms.qpp.conversion.util;
+
+import org.junit.jupiter.api.Test;
+
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.validation.MeasureConfig;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class MeasureConfigHelperTest {
+
+	@Test
+	void testGetMeasureConfigSuccess() {
+		Node measureNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2);
+		measureNode.putValue(MeasureConfigHelper.MEASURE_ID, "40280381-51f0-825b-0152-229bdcab1702");
+		MeasureConfig config = MeasureConfigHelper.getMeasureConfig(measureNode);
+
+		assertThat(config).isNotNull();
+	}
+}

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidatorTest.java
@@ -9,6 +9,7 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
+import gov.cms.qpp.conversion.util.MeasureConfigHelper;
 
 class CpcQualityMeasureIdValidatorTest {
 
@@ -20,7 +21,7 @@ class CpcQualityMeasureIdValidatorTest {
 		validator = new CpcQualityMeasureIdValidator();
 
 		testNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2);
-		testNode.putValue(CpcQualityMeasureIdValidator.MEASURE_ID,"40280381-51f0-825b-0152-22a112d2172a");
+		testNode.putValue(MeasureConfigHelper.MEASURE_ID,"40280381-51f0-825b-0152-22a112d2172a");
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -11,6 +11,7 @@ import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 import gov.cms.qpp.conversion.model.validation.MeasureIndexInit;
 import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+import gov.cms.qpp.conversion.util.MeasureConfigHelper;
 import gov.cms.qpp.conversion.util.StringHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,9 +27,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_POPULATION;
 import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
 import static gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE_ID;
-import static gov.cms.qpp.conversion.validate.QualityMeasureIdValidator.MEASURE_ID;
-
-//import gov.cms.qpp.conversion.model.validation.SubPopulations;
 
 class QualityMeasureIdValidatorTest {
 
@@ -476,7 +474,7 @@ class QualityMeasureIdValidatorTest {
 		}
 
 		MeasureReferenceBuilder addMeasureId(String measureId) {
-			measureReferenceResultsNode.putValue(MEASURE_ID, measureId);
+			measureReferenceResultsNode.putValue(MeasureConfigHelper.MEASURE_ID, measureId);
 			return this;
 		}
 


### PR DESCRIPTION
### Information
- MeasureConfigHelper to extract the measure configuration from a node.

### Changes proposed in this PR:
- Add new helper for measure configurations.
- Refactor validations to use the MeasureConfigHelper.
- Refactor MipsQualityMeasureValidator to remove additional configuration retrieval.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
