### PR TITLE
QPPCT-717: Command line doesn't work on Windows

### DIFF
--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineMain.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineMain.java
@@ -1,7 +1,5 @@
 package gov.cms.qpp.conversion;
 
-import gov.cms.qpp.conversion.segmentation.QrdaScope;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -10,6 +8,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import gov.cms.qpp.conversion.segmentation.QrdaScope;
 
 /**
  * Entry point for the converter when ran from the command line
@@ -56,6 +56,7 @@ public class CommandLineMain {
 		CommandLine commandLine = cli(arguments);
 
 		if (commandLine != null) {
+			DEV_LOG.info("Commandline is not null");
 			new CommandLineRunner(commandLine).run();
 		}
 	}

--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineMain.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineMain.java
@@ -56,7 +56,6 @@ public class CommandLineMain {
 		CommandLine commandLine = cli(arguments);
 
 		if (commandLine != null) {
-			DEV_LOG.info("Commandline is not null");
 			new CommandLineRunner(commandLine).run();
 		}
 	}

--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
@@ -1,5 +1,9 @@
 package gov.cms.qpp.conversion;
 
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
 import gov.cms.qpp.conversion.util.Finder;
 
@@ -22,10 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.cli.CommandLine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Responsible for executing the given command line instructions
  */
@@ -33,7 +33,7 @@ public class CommandLineRunner implements Runnable {
 
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(CommandLineMain.class);
 	private static final Pattern LITERAL_COMMA = Pattern.compile(",", Pattern.LITERAL);
-	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/]+");
+	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/\\\\]+");
 	private static final Pattern GLOB_FINDER = Pattern.compile("(" + NORMAL_PATH.pattern() + ").+");
 
 	private final CommandLine commandLine;

--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
@@ -203,6 +203,13 @@ public class CommandLineRunner implements Runnable {
 		return getNormalPathPattern().matcher(path).matches();
 	}
 
+	/**
+	 * Generates a regex {@link Pattern} to determine if a path is for a normal file.
+	 *
+	 * The regex is based on the path separator of the {@link FileSystem} used.
+	 *
+	 * @return A regex pattern.
+	 */
 	protected Pattern getNormalPathPattern() {
 		if (normalPathPattern == null) {
 			String separator = "\\" + this.fileSystem.getSeparator();
@@ -212,6 +219,13 @@ public class CommandLineRunner implements Runnable {
 		return normalPathPattern;
 	}
 
+	/**
+	 * Generates a regex {@link Pattern} to determine if a path is a glob path.
+	 *
+	 * The regex is based on the {@link #getNormalPathPattern()} regex.
+	 *
+	 * @return A regex pattern.
+	 */
 	protected Pattern getGlobFinderPattern() {
 		if (globFinderPattern == null) {
 			globFinderPattern = Pattern.compile("(" + getNormalPathPattern().pattern() + ").+");

--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
@@ -1,9 +1,5 @@
 package gov.cms.qpp.conversion;
 
-import org.apache.commons.cli.CommandLine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
 import gov.cms.qpp.conversion.util.Finder;
 
@@ -26,6 +22,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Responsible for executing the given command line instructions
  */
@@ -33,7 +33,7 @@ public class CommandLineRunner implements Runnable {
 
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(CommandLineMain.class);
 	private static final Pattern LITERAL_COMMA = Pattern.compile(",", Pattern.LITERAL);
-	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/\\\\]+");
+	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/]+");
 	private static final Pattern GLOB_FINDER = Pattern.compile("(" + NORMAL_PATH.pattern() + ").+");
 
 	private final CommandLine commandLine;
@@ -74,25 +74,19 @@ public class CommandLineRunner implements Runnable {
 		if (isHelp()) {
 			sendHelp();
 		} else if (hasPotentialFiles()) {
-			DEV_LOG.info("Has potential files");
 			Scopes scopes = getScopes();
 			scope = scopes.getQrdaScopes();
 			if (scopes.isValid()) {
-				DEV_LOG.info("Scopes are valid");
 				Set<Path> convert = getRequestedFilesForConversion();
-				DEV_LOG.info("Convert paths={}", convert);
 
 				List<Path> invalid = convert.stream()
 						.filter(path -> !isValid(path))
 						.collect(Collectors.toList());
 				if (invalid.isEmpty()) {
-					DEV_LOG.info("No invalid paths");
 					doValidation = !commandLine.hasOption(CommandLineMain.SKIP_VALIDATION);
 					doDefaults = !commandLine.hasOption(CommandLineMain.SKIP_DEFAULTS);
 					historical = commandLine.hasOption(CommandLineMain.BYGONE);
 
-					DEV_LOG.info("Call ConversionFileWriterWrapper");
-					DEV_LOG.info("Test go.");
 					convert.parallelStream()
 						.map(ConversionFileWriterWrapper::new)
 						.peek(conversion -> conversion.setContext(createContext()))
@@ -169,7 +163,6 @@ public class CommandLineRunner implements Runnable {
 	}
 
 	private Collection<Path> getRequestedFilesForConversion(String path) {
-		DEV_LOG.info("PAK::CommandLineRunner::getRequestedFilesForConversion");
 		if (isNormalPath(path)) {
 			return Collections.singleton(fileSystem.getPath(path));
 		}

--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
@@ -1,5 +1,9 @@
 package gov.cms.qpp.conversion;
 
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
 import gov.cms.qpp.conversion.util.Finder;
 
@@ -22,10 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.cli.CommandLine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Responsible for executing the given command line instructions
  */
@@ -33,7 +33,7 @@ public class CommandLineRunner implements Runnable {
 
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(CommandLineMain.class);
 	private static final Pattern LITERAL_COMMA = Pattern.compile(",", Pattern.LITERAL);
-	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/]+");
+	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/\\\\]+");
 	private static final Pattern GLOB_FINDER = Pattern.compile("(" + NORMAL_PATH.pattern() + ").+");
 
 	private final CommandLine commandLine;
@@ -74,19 +74,25 @@ public class CommandLineRunner implements Runnable {
 		if (isHelp()) {
 			sendHelp();
 		} else if (hasPotentialFiles()) {
+			DEV_LOG.info("Has potential files");
 			Scopes scopes = getScopes();
 			scope = scopes.getQrdaScopes();
 			if (scopes.isValid()) {
+				DEV_LOG.info("Scopes are valid");
 				Set<Path> convert = getRequestedFilesForConversion();
+				DEV_LOG.info("Convert paths={}", convert);
 
 				List<Path> invalid = convert.stream()
 						.filter(path -> !isValid(path))
 						.collect(Collectors.toList());
 				if (invalid.isEmpty()) {
+					DEV_LOG.info("No invalid paths");
 					doValidation = !commandLine.hasOption(CommandLineMain.SKIP_VALIDATION);
 					doDefaults = !commandLine.hasOption(CommandLineMain.SKIP_DEFAULTS);
 					historical = commandLine.hasOption(CommandLineMain.BYGONE);
 
+					DEV_LOG.info("Call ConversionFileWriterWrapper");
+					DEV_LOG.info("Test go.");
 					convert.parallelStream()
 						.map(ConversionFileWriterWrapper::new)
 						.peek(conversion -> conversion.setContext(createContext()))
@@ -163,6 +169,7 @@ public class CommandLineRunner implements Runnable {
 	}
 
 	private Collection<Path> getRequestedFilesForConversion(String path) {
+		DEV_LOG.info("PAK::CommandLineRunner::getRequestedFilesForConversion");
 		if (isNormalPath(path)) {
 			return Collections.singleton(fileSystem.getPath(path));
 		}

--- a/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/CommandLineRunner.java
@@ -31,10 +31,8 @@ import java.util.stream.Collectors;
  */
 public class CommandLineRunner implements Runnable {
 
-	private static final Logger DEV_LOG = LoggerFactory.getLogger(CommandLineMain.class);
+	private static final Logger DEV_LOG = LoggerFactory.getLogger(CommandLineRunner.class);
 	private static final Pattern LITERAL_COMMA = Pattern.compile(",", Pattern.LITERAL);
-	private static final Pattern NORMAL_PATH = Pattern.compile("[a-zA-Z0-9_\\-\\s,.\\/\\\\]+");
-	private static final Pattern GLOB_FINDER = Pattern.compile("(" + NORMAL_PATH.pattern() + ").+");
 
 	private final CommandLine commandLine;
 	private final FileSystem fileSystem;
@@ -42,6 +40,8 @@ public class CommandLineRunner implements Runnable {
 	private boolean doValidation;
 	private boolean doDefaults;
 	private boolean historical;
+	private Pattern normalPathPattern;
+	private Pattern globFinderPattern;
 
 	/**
 	 * Creates a new CommandLineRunner from a given {@link CommandLine}
@@ -169,7 +169,7 @@ public class CommandLineRunner implements Runnable {
 
 		Path directory;
 		String glob;
-		Matcher globMatcher = GLOB_FINDER.matcher(path);
+		Matcher globMatcher = getGlobFinderPattern().matcher(path);
 		if (globMatcher.matches()) {
 			String directoryName = globMatcher.group(1);
 			if (directoryName.endsWith(".")) {
@@ -200,11 +200,27 @@ public class CommandLineRunner implements Runnable {
 	}
 
 	private boolean isNormalPath(String path) {
-		return NORMAL_PATH.matcher(path).matches();
+		return getNormalPathPattern().matcher(path).matches();
+	}
+
+	protected Pattern getNormalPathPattern() {
+		if (normalPathPattern == null) {
+			String separator = "\\" + this.fileSystem.getSeparator();
+			normalPathPattern = Pattern.compile("[a-zA-Z0-9_\\-\\s,." + separator + "]+");
+		}
+
+		return normalPathPattern;
+	}
+
+	protected Pattern getGlobFinderPattern() {
+		if (globFinderPattern == null) {
+			globFinderPattern = Pattern.compile("(" + getNormalPathPattern().pattern() + ").+");
+		}
+
+		return globFinderPattern;
 	}
 
 	private boolean isValid(Path path) {
 		return Files.isRegularFile(path) && Files.isReadable(path);
 	}
-
 }

--- a/commandline/src/main/java/gov/cms/qpp/conversion/ConversionFileWriterWrapper.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/ConversionFileWriterWrapper.java
@@ -3,11 +3,12 @@ package gov.cms.qpp.conversion;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import gov.cms.qpp.conversion.encode.JsonWrapper;
 import gov.cms.qpp.conversion.model.error.AllErrors;
 import gov.cms.qpp.conversion.model.error.TransformException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -26,6 +27,7 @@ public class ConversionFileWriterWrapper {
 	private Context context;
 
 	public ConversionFileWriterWrapper(Path inFile) {
+		DEV_LOG.info("PAK::ConversionFileWriterWrapper::init");
 		this.source = new PathSource(inFile);
 
 		fileSystem = inFile.getFileSystem();
@@ -38,6 +40,7 @@ public class ConversionFileWriterWrapper {
 	 * @return this for chaining
 	 */
 	public ConversionFileWriterWrapper setContext(Context context) {
+		DEV_LOG.info("PAK::ConversionFileWriterWrapper::setContext");
 		this.context = context;
 		return this;
 	}
@@ -46,6 +49,7 @@ public class ConversionFileWriterWrapper {
 	 * Execute the conversion.
 	 */
 	public void transform() {
+		DEV_LOG.info("PAK::ConversionFileWriterWrapper::transform");
 		Converter converter = context == null ? new Converter(source) : new Converter(source, context);
 
 		executeConverter(converter);
@@ -57,6 +61,7 @@ public class ConversionFileWriterWrapper {
 	 * @param converter The Converter to execute.
 	 */
 	private void executeConverter(Converter converter) {
+		DEV_LOG.info("PAK::ConversionFileWriterWrapper::executeConverter");
 		try {
 			JsonWrapper jsonWrapper = converter.transform();
 			Path outFile = getOutputFile(source.getName(), true);

--- a/commandline/src/main/java/gov/cms/qpp/conversion/ConversionFileWriterWrapper.java
+++ b/commandline/src/main/java/gov/cms/qpp/conversion/ConversionFileWriterWrapper.java
@@ -3,12 +3,11 @@ package gov.cms.qpp.conversion;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import gov.cms.qpp.conversion.encode.JsonWrapper;
 import gov.cms.qpp.conversion.model.error.AllErrors;
 import gov.cms.qpp.conversion.model.error.TransformException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -27,7 +26,6 @@ public class ConversionFileWriterWrapper {
 	private Context context;
 
 	public ConversionFileWriterWrapper(Path inFile) {
-		DEV_LOG.info("PAK::ConversionFileWriterWrapper::init");
 		this.source = new PathSource(inFile);
 
 		fileSystem = inFile.getFileSystem();
@@ -40,7 +38,6 @@ public class ConversionFileWriterWrapper {
 	 * @return this for chaining
 	 */
 	public ConversionFileWriterWrapper setContext(Context context) {
-		DEV_LOG.info("PAK::ConversionFileWriterWrapper::setContext");
 		this.context = context;
 		return this;
 	}
@@ -49,7 +46,6 @@ public class ConversionFileWriterWrapper {
 	 * Execute the conversion.
 	 */
 	public void transform() {
-		DEV_LOG.info("PAK::ConversionFileWriterWrapper::transform");
 		Converter converter = context == null ? new Converter(source) : new Converter(source, context);
 
 		executeConverter(converter);
@@ -61,7 +57,6 @@ public class ConversionFileWriterWrapper {
 	 * @param converter The Converter to execute.
 	 */
 	private void executeConverter(Converter converter) {
-		DEV_LOG.info("PAK::ConversionFileWriterWrapper::executeConverter");
 		try {
 			JsonWrapper jsonWrapper = converter.transform();
 			Path outFile = getOutputFile(source.getName(), true);

--- a/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineMainTest.java
+++ b/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineMainTest.java
@@ -1,10 +1,10 @@
 package gov.cms.qpp.conversion;
 
-import gov.cms.qpp.test.logging.LoggerContract;
-
 import com.google.common.truth.Truth;
 import org.apache.commons.cli.CommandLine;
 import org.junit.jupiter.api.Test;
+
+import gov.cms.qpp.test.logging.LoggerContract;
 
 class CommandLineMainTest implements LoggerContract {
 
@@ -24,7 +24,7 @@ class CommandLineMainTest implements LoggerContract {
 	@Test
 	void testMain() {
 		CommandLineMain.main();
-		Truth.assertThat(getLogs()).isNotEmpty();
+		Truth.assertThat(getLogs()).isEmpty();
 	}
 
 	@Test
@@ -36,5 +36,4 @@ class CommandLineMainTest implements LoggerContract {
 	public Class<?> getLoggerType() {
 		return CommandLineMain.class;
 	}
-
 }

--- a/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineRunnerTest.java
+++ b/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineRunnerTest.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion;
 
+import com.google.common.truth.Truth;
 import org.apache.commons.cli.CommandLine;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,42 +27,42 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 	@Test
 	void testNewNull() {
 		NullPointerException exception = Assertions.assertThrows(NullPointerException.class, () -> new CommandLineRunner(null));
-		assertThat(exception).hasMessageThat().isEqualTo("commandLine");
+		Truth.assertThat(exception).hasMessageThat().isEqualTo("commandLine");
 	}
 
 	@Test
 	void testRunHelp() {
 		CommandLineRunner runner = new CommandLineRunner(line("-" + CommandLineMain.HELP));
 		runner.run();
-		assertThat(getLogs()).isNotEmpty();
+		Truth.assertThat(getLogs()).isNotEmpty();
 	}
 
 	@Test
 	void testRunWithoutFiles() {
 		CommandLineRunner runner = new CommandLineRunner(line());
 		runner.run();
-		assertThat(getLogs()).contains("You must specify files to convert");
+		Truth.assertThat(getLogs()).contains("You must specify files to convert");
 	}
 
 	@Test
 	void testRunWithInvalidScope() {
 		CommandLineRunner runner = new CommandLineRunner(line(INVALID_FILE, "-t", "SOME_INVALID_SCOPE"));
 		runner.run();
-		assertThat(getLogs()).contains("A given template scope was invalid");
+		Truth.assertThat(getLogs()).contains("A given template scope was invalid");
 	}
 
 	@Test
 	void testRunWithValidScope() {
 		CommandLineRunner runner = new CommandLineRunner(line(INVALID_FILE, "-t", QrdaScope.CLINICAL_DOCUMENT.name()));
 		runner.run();
-		assertThat(getLogs()).doesNotContain("A given template scope was invalid");
+		Truth.assertThat(getLogs()).doesNotContain("A given template scope was invalid");
 	}
 
 	@Test
 	void testRunWithMissingFile() {
 		CommandLineRunner runner = new CommandLineRunner(line(INVALID_FILE));
 		runner.run();
-		assertThat(getLogs()).contains("Invalid or missing paths: [FILE]".replace("FILE", INVALID_FILE));
+		Truth.assertThat(getLogs()).contains("Invalid or missing paths: [FILE]".replace("FILE", INVALID_FILE));
 	}
 
 	@JimfsTest
@@ -69,7 +70,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		String path = VALID_FILE.replaceAll("/", "\\" + fileSystem.getSeparator());
 		CommandLineRunner runner = new CommandLineRunner(line(path), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -78,7 +79,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		CommandLineRunner runner = new CommandLineRunner(line(path,
 				"-" + CommandLineMain.SKIP_DEFAULTS), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -86,7 +87,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		String path = "src/test/resources/qrda_bad_denominator.xml".replaceAll("/", "\\" + fileSystem.getSeparator());
 		CommandLineRunner runner = new CommandLineRunner(line(path), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.err.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.err.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -95,7 +96,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		CommandLineRunner runner = new CommandLineRunner(line(path,
 				"-" + CommandLineMain.SKIP_VALIDATION), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.qpp.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -103,7 +104,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		Files.copy(fileSystem.getPath(VALID_FILE), fileSystem.getPath("valid-QRDA-III-abridged.xml"));
 		CommandLineRunner runner = new CommandLineRunner(line("*.xml"), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -111,7 +112,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		Files.copy(fileSystem.getPath(VALID_FILE), fileSystem.getPath("valid-QRDA-III-abridged.xml"));
 		CommandLineRunner runner = new CommandLineRunner(line("valid-QRDA-III-abridged.*"), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -119,8 +120,8 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		String path = "src/test/resources/*".replaceAll("/", "\\" + fileSystem.getSeparator());
 		CommandLineRunner runner = new CommandLineRunner(line(path), fileSystem);
 		runner.run();
-		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
-		assertThat(Files.exists(fileSystem.getPath("not-a-QRDA-III-file.err.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		Truth.assertThat(Files.exists(fileSystem.getPath("not-a-QRDA-III-file.err.json"))).isTrue();
 	}
 
 	@Test
@@ -129,7 +130,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 
 		when(mockWindowsFileSystem.getSeparator()).thenReturn("\\");
 		CommandLineRunner runner = new CommandLineRunner(line(WINDOWS_FILE), mockWindowsFileSystem);
-		assertThat(runner.getNormalPathPattern().pattern()).contains("\\\\");
+		Truth.assertThat(runner.getNormalPathPattern().pattern()).contains("\\\\");
 	}
 
 	@Test
@@ -138,7 +139,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 
 		when(mockWindowsFileSystem.getSeparator()).thenReturn("/");
 		CommandLineRunner runner = new CommandLineRunner(line(VALID_FILE), mockWindowsFileSystem);
-		assertThat(runner.getNormalPathPattern().pattern()).contains("\\/");
+		Truth.assertThat(runner.getNormalPathPattern().pattern()).contains("\\/");
 	}
 
 	@Test
@@ -148,7 +149,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		String mockSeparator = ":";
 		when(mockWindowsFileSystem.getSeparator()).thenReturn(mockSeparator);
 		CommandLineRunner runner = new CommandLineRunner(line(VALID_FILE), mockWindowsFileSystem);
-		assertThat(runner.getGlobFinderPattern().pattern()).contains(mockSeparator);
+		Truth.assertThat(runner.getGlobFinderPattern().pattern()).contains(mockSeparator);
 	}
 
 	private CommandLine line(String... arguments) {

--- a/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineRunnerTest.java
+++ b/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineRunnerTest.java
@@ -1,5 +1,9 @@
 package gov.cms.qpp.conversion;
 
+import org.apache.commons.cli.CommandLine;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import gov.cms.qpp.conversion.segmentation.QrdaScope;
 import gov.cms.qpp.test.jimfs.JimfsContract;
 import gov.cms.qpp.test.jimfs.JimfsTest;
@@ -9,85 +13,89 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 
-import com.google.common.truth.Truth;
-import org.apache.commons.cli.CommandLine;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 
 	private static final String VALID_FILE = "src/test/resources/valid-QRDA-III-abridged.xml";
 	private static final String INVALID_FILE = "THIS_FILE_SHOULD_NOT_EXIST.xml";
+	private static final String WINDOWS_FILE = "src\\test\\resources\\valid-QRDA-III-abridged.xml";
 
 	@Test
 	void testNewNull() {
 		NullPointerException exception = Assertions.assertThrows(NullPointerException.class, () -> new CommandLineRunner(null));
-		Truth.assertThat(exception).hasMessageThat().isEqualTo("commandLine");
+		assertThat(exception).hasMessageThat().isEqualTo("commandLine");
 	}
 
 	@Test
 	void testRunHelp() {
 		CommandLineRunner runner = new CommandLineRunner(line("-" + CommandLineMain.HELP));
 		runner.run();
-		Truth.assertThat(getLogs()).isNotEmpty();
+		assertThat(getLogs()).isNotEmpty();
 	}
 
 	@Test
 	void testRunWithoutFiles() {
 		CommandLineRunner runner = new CommandLineRunner(line());
 		runner.run();
-		Truth.assertThat(getLogs()).contains("You must specify files to convert");
+		assertThat(getLogs()).contains("You must specify files to convert");
 	}
 
 	@Test
 	void testRunWithInvalidScope() {
 		CommandLineRunner runner = new CommandLineRunner(line(INVALID_FILE, "-t", "SOME_INVALID_SCOPE"));
 		runner.run();
-		Truth.assertThat(getLogs()).contains("A given template scope was invalid");
+		assertThat(getLogs()).contains("A given template scope was invalid");
 	}
 
 	@Test
 	void testRunWithValidScope() {
 		CommandLineRunner runner = new CommandLineRunner(line(INVALID_FILE, "-t", QrdaScope.CLINICAL_DOCUMENT.name()));
 		runner.run();
-		Truth.assertThat(getLogs()).doesNotContain("A given template scope was invalid");
+		assertThat(getLogs()).doesNotContain("A given template scope was invalid");
 	}
 
 	@Test
 	void testRunWithMissingFile() {
 		CommandLineRunner runner = new CommandLineRunner(line(INVALID_FILE));
 		runner.run();
-		Truth.assertThat(getLogs()).contains("Invalid or missing paths: [FILE]".replace("FILE", INVALID_FILE));
+		assertThat(getLogs()).contains("Invalid or missing paths: [FILE]".replace("FILE", INVALID_FILE));
 	}
 
 	@JimfsTest
-	void testRunWithValidFile(FileSystem fileSystem) throws IOException {
-		CommandLineRunner runner = new CommandLineRunner(line(VALID_FILE), fileSystem);
+	void testRunWithValidFile(FileSystem fileSystem) {
+		String path = VALID_FILE.replaceAll("/", "\\" + fileSystem.getSeparator());
+		CommandLineRunner runner = new CommandLineRunner(line(path), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
-	void testRunWithValidFileSkipDefaults(FileSystem fileSystem) throws IOException {
-		CommandLineRunner runner = new CommandLineRunner(line(VALID_FILE,
+	void testRunWithValidFileSkipDefaults(FileSystem fileSystem) {
+		String path = VALID_FILE.replaceAll("/", "\\" + fileSystem.getSeparator());
+		CommandLineRunner runner = new CommandLineRunner(line(path,
 				"-" + CommandLineMain.SKIP_DEFAULTS), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
-	void testRunWithInvalidFile(FileSystem fileSystem) throws IOException {
-		CommandLineRunner runner = new CommandLineRunner(line("src/test/resources/qrda_bad_denominator.xml"), fileSystem);
+	void testRunWithInvalidFile(FileSystem fileSystem) {
+		String path = "src/test/resources/qrda_bad_denominator.xml".replaceAll("/", "\\" + fileSystem.getSeparator());
+		CommandLineRunner runner = new CommandLineRunner(line(path), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.err.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.err.json"))).isTrue();
 	}
 
 	@JimfsTest
-	void testRunWithInvalidFileWithoutValidation(FileSystem fileSystem) throws IOException {
-		CommandLineRunner runner = new CommandLineRunner(line("src/test/resources/qrda_bad_denominator.xml",
+	void testRunWithInvalidFileWithoutValidation(FileSystem fileSystem) {
+		String path = "src/test/resources/qrda_bad_denominator.xml".replaceAll("/", "\\" + fileSystem.getSeparator());
+		CommandLineRunner runner = new CommandLineRunner(line(path,
 				"-" + CommandLineMain.SKIP_VALIDATION), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.qpp.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("qrda_bad_denominator.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -95,7 +103,7 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		Files.copy(fileSystem.getPath(VALID_FILE), fileSystem.getPath("valid-QRDA-III-abridged.xml"));
 		CommandLineRunner runner = new CommandLineRunner(line("*.xml"), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
@@ -103,15 +111,44 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 		Files.copy(fileSystem.getPath(VALID_FILE), fileSystem.getPath("valid-QRDA-III-abridged.xml"));
 		CommandLineRunner runner = new CommandLineRunner(line("valid-QRDA-III-abridged.*"), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
 	}
 
 	@JimfsTest
-	void testRunWithValidGlobAllFiles(FileSystem fileSystem) throws IOException {
-		CommandLineRunner runner = new CommandLineRunner(line("src/test/resources/*"), fileSystem);
+	void testRunWithValidGlobAllFiles(FileSystem fileSystem) {
+		String path = "src/test/resources/*".replaceAll("/", "\\" + fileSystem.getSeparator());
+		CommandLineRunner runner = new CommandLineRunner(line(path), fileSystem);
 		runner.run();
-		Truth.assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
-		Truth.assertThat(Files.exists(fileSystem.getPath("not-a-QRDA-III-file.err.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("valid-QRDA-III-abridged.qpp.json"))).isTrue();
+		assertThat(Files.exists(fileSystem.getPath("not-a-QRDA-III-file.err.json"))).isTrue();
+	}
+
+	@Test
+	void testWindowsFileSeparator() {
+		FileSystem mockWindowsFileSystem = mock(FileSystem.class);
+
+		when(mockWindowsFileSystem.getSeparator()).thenReturn("\\");
+		CommandLineRunner runner = new CommandLineRunner(line(WINDOWS_FILE), mockWindowsFileSystem);
+		assertThat(runner.getNormalPathPattern().pattern()).contains("\\\\");
+	}
+
+	@Test
+	void testNixFileSeparator() {
+		FileSystem mockWindowsFileSystem = mock(FileSystem.class);
+
+		when(mockWindowsFileSystem.getSeparator()).thenReturn("/");
+		CommandLineRunner runner = new CommandLineRunner(line(VALID_FILE), mockWindowsFileSystem);
+		assertThat(runner.getNormalPathPattern().pattern()).contains("\\/");
+	}
+
+	@Test
+	void testGlobPattern() {
+		FileSystem mockWindowsFileSystem = mock(FileSystem.class);
+
+		String mockSeparator = ":";
+		when(mockWindowsFileSystem.getSeparator()).thenReturn(mockSeparator);
+		CommandLineRunner runner = new CommandLineRunner(line(VALID_FILE), mockWindowsFileSystem);
+		assertThat(runner.getGlobFinderPattern().pattern()).contains(mockSeparator);
 	}
 
 	private CommandLine line(String... arguments) {
@@ -120,7 +157,6 @@ class CommandLineRunnerTest implements LoggerContract, JimfsContract {
 
 	@Override
 	public Class<?> getLoggerType() {
-		return CommandLineMain.class;
+		return CommandLineRunner.class;
 	}
-
 }

--- a/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineRunnerTest.java
+++ b/commandline/src/test/java/gov/cms/qpp/conversion/CommandLineRunnerTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 
-import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
### Information
- JIRA story QPPCT-717.

### Changes proposed in this PR:
- The regex for determining if a path is correct or not only allowed `/` separators.
- This has been changed to allow a path separator based on the supplied `FileSystem`.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
