### PR TITLE
Prevent log spam on isPresent and getOrDefault

### DIFF
--- a/commons/src/main/java/gov/cms/qpp/conversion/util/EnvironmentHelper.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/util/EnvironmentHelper.java
@@ -26,7 +26,7 @@ public class EnvironmentHelper {
 	 * @return true if System.getenv(variable) or System.getProperty(variable) are not null
 	 */
 	public static boolean isPresent(String variable) {
-		return get(variable) != null;
+		return getIfPresent(variable) != null;
 	}
 
 	/**
@@ -36,10 +36,7 @@ public class EnvironmentHelper {
 	 * @return value for the given variable key
 	 */
 	public static String get(String variable) {
-		String value = Stream.of(System.getProperty(variable), System.getenv(variable))
-			.filter(var -> var != null && !var.isEmpty())
-			.findFirst()
-			.orElse(null);
+		String value = getIfPresent(variable);
 		if (value == null) {
 			LOG.warn(
 				String.format(NOT_FOUND, variable));
@@ -55,7 +52,14 @@ public class EnvironmentHelper {
 	 * @return value for the given variable key or substitute
 	 */
 	public static String getOrDefault(String variable, String defaultValue) {
-		String value = get(variable);
+		String value = getIfPresent(variable);
 		return value == null ? defaultValue : value;
+	}
+
+	private static String getIfPresent(String variable) {
+		return Stream.of(System.getProperty(variable), System.getenv(variable))
+				.filter(var -> var != null && !var.isEmpty())
+				.findFirst()
+				.orElse(null);
 	}
 }

--- a/commons/src/test/java/gov/cms/qpp/conversion/util/EnvironmentHelperTest.java
+++ b/commons/src/test/java/gov/cms/qpp/conversion/util/EnvironmentHelperTest.java
@@ -37,7 +37,7 @@ class EnvironmentHelperTest implements LoggerContract {
 	void testLogEntryForFailures() {
 		String random = UUID.randomUUID().toString();
 		String message = String.format(EnvironmentHelper.NOT_FOUND, random);
-		EnvironmentHelper.isPresent(random);
+		EnvironmentHelper.get(random);
 
 		assertThat(getLogs()).contains(message);
 	}
@@ -61,14 +61,14 @@ class EnvironmentHelperTest implements LoggerContract {
 	}
 
 	@Test
-	void testLogEntryForFailureEmpty() {
+	void testLogEntryForIsPresentFailureIsEmpty() {
 		String someKey = UUID.randomUUID().toString();
 		String value = "";
 		System.setProperty(someKey, value);
 		String message = String.format(EnvironmentHelper.NOT_FOUND, someKey);
 		EnvironmentHelper.isPresent(someKey);
 
-		assertThat(getLogs()).contains(message);
+		assertThat(getLogs()).doesNotContain(message);
 	}
 
 	@Override


### PR DESCRIPTION
### Information
- JIRA story QPPCT-709.

### Changes proposed in this PR:
- Made isPresent and getOrDefault methods not print anything

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
