### PR TITLE
Running Docker Compose on Windows

### DIFF
--- a/DockerfileTest
+++ b/DockerfileTest
@@ -2,6 +2,7 @@ FROM maven:3-jdk-8
 
 RUN mkdir -p /usr/src/app/
 RUN mkdir -p /usr/src/run/
+RUN apt-get install dos2unix
 
 COPY ./ /usr/src/app/
 
@@ -10,6 +11,7 @@ WORKDIR /usr/src/app/
 RUN mvn install -Dmaven.test.skip -Djacoco.skip=true > /dev/null
 RUN cp ./rest-api/target/rest-api.jar /usr/src/run/
 RUN cp -r ./tools/docker/docker-test-artifacts/* /usr/src/run/
+RUN dos2unix /usr/src/run/qppConverterTest.sh
 
 WORKDIR /usr/src/run/
 

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -2,8 +2,7 @@ FROM maven:3-jdk-8
 
 RUN mkdir -p /usr/src/app/
 RUN mkdir -p /usr/src/run/
-RUN apt-get update && apt-get install
-RUN apt-get install dos2unix
+RUN apt-get update && apt-get install dos2unix
 
 COPY ./ /usr/src/app/
 

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -2,6 +2,7 @@ FROM maven:3-jdk-8
 
 RUN mkdir -p /usr/src/app/
 RUN mkdir -p /usr/src/run/
+RUN apt-get update && apt-get install
 RUN apt-get install dos2unix
 
 COPY ./ /usr/src/app/


### PR DESCRIPTION
### Information
- QPPCT-718

### Changes proposed in this PR:
- Updates the docker file to be able to run on Docker-toolbox windows 7
    - When I ran docker before the changes, I received the same error the user was getting.
    - Unable to test on windows 10 as docker doesn't work on a windows vm. (Hyper V issues.)
- I excluded our main docker file because I doubt any users would be running our spunk in their docker.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
