### PR TITLE
QPPCT-748: SimpleUI sends Purpose header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - attach_workspace:
           at: /home/circleci
       - run: cd frontend; rm -f yarn.lock && yarn
-      - run: cd frontend; yarn run build;
+      - run: cd frontend; yarn run build --base-href /developers/conversion-tool-sandbox/
       - run: sudo apt-get install python-dev
       - run: curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
       - run: unzip awscli-bundle.zip
@@ -135,7 +135,7 @@ workflows:
       - deploy_api:
           filters:
             branches:
-              only: develop
+              only: story-748-simple_purpose
           requires:
             - checkout
       - integration_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ workflows:
       - deploy_api:
           filters:
             branches:
-              only: story-748-simple_purpose
+              only: develop
           requires:
             - checkout
       - integration_test:

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -11,7 +11,13 @@ const URL  = 'https://qpp.cms.gov/api/submissions/converter';
 })
 export class AppComponent {
 	title = 'Convert QRDA-III to QPP';
-	uploader: FileUploader = new FileUploader({url: URL});
+	uploader: FileUploader = new FileUploader({
+		url: URL,
+        headers: [{
+            name: 'Purpose',
+            value: 'SimpleUI'
+        }]
+	});
 	hasBaseDropZoneOver: boolean;
 	hasAnotherDropZoneOver: boolean;
 	response: string;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -13,10 +13,10 @@ export class AppComponent {
 	title = 'Convert QRDA-III to QPP';
 	uploader: FileUploader = new FileUploader({
 		url: URL,
-        headers: [{
-            name: 'Purpose',
-            value: 'SimpleUI'
-        }]
+		headers: [{
+			name: 'Purpose',
+			value: 'SimpleUI'
+		}]
 	});
 	hasBaseDropZoneOver: boolean;
 	hasAnotherDropZoneOver: boolean;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>QRDA to QPP</title>
-    <base href="/developers/conversion-tool-sandbox/">
+    <base href="/">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
@@ -1,14 +1,5 @@
 package gov.cms.qpp.conversion.api.controllers.v1;
 
-import gov.cms.qpp.conversion.api.model.Constants;
-import gov.cms.qpp.conversion.api.model.CpcFileStatusUpdateRequest;
-import gov.cms.qpp.conversion.api.model.UnprocessedCpcFileData;
-import gov.cms.qpp.conversion.api.services.CpcFileService;
-import gov.cms.qpp.conversion.util.EnvironmentHelper;
-
-import java.io.IOException;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.InputStreamResource;
@@ -24,12 +15,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import gov.cms.qpp.conversion.api.model.Constants;
+import gov.cms.qpp.conversion.api.model.CpcFileStatusUpdateRequest;
+import gov.cms.qpp.conversion.api.model.UnprocessedCpcFileData;
+import gov.cms.qpp.conversion.api.services.CpcFileService;
+import gov.cms.qpp.conversion.util.EnvironmentHelper;
+
+import java.io.IOException;
+import java.util.List;
+
 /**
  * Controller to handle cpc file data
  */
 @RestController
 @RequestMapping("/cpc")
-@CrossOrigin
+@CrossOrigin(allowCredentials = "true")
 public class CpcFileControllerV1 {
 
 	private static final String BLOCKED_BY_FEATURE_FLAG =

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1.java
@@ -1,14 +1,5 @@
 package gov.cms.qpp.conversion.api.controllers.v1;
 
-import gov.cms.qpp.conversion.ConversionReport;
-import gov.cms.qpp.conversion.InputStreamSupplierSource;
-import gov.cms.qpp.conversion.api.exceptions.AuditException;
-import gov.cms.qpp.conversion.api.exceptions.InvalidPurposeException;
-import gov.cms.qpp.conversion.api.model.Constants;
-import gov.cms.qpp.conversion.api.model.Metadata;
-import gov.cms.qpp.conversion.api.services.AuditService;
-import gov.cms.qpp.conversion.api.services.QrdaService;
-import gov.cms.qpp.conversion.api.services.ValidationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +15,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import gov.cms.qpp.conversion.ConversionReport;
+import gov.cms.qpp.conversion.InputStreamSupplierSource;
+import gov.cms.qpp.conversion.api.exceptions.AuditException;
+import gov.cms.qpp.conversion.api.exceptions.InvalidPurposeException;
+import gov.cms.qpp.conversion.api.model.Constants;
+import gov.cms.qpp.conversion.api.model.Metadata;
+import gov.cms.qpp.conversion.api.services.AuditService;
+import gov.cms.qpp.conversion.api.services.QrdaService;
+import gov.cms.qpp.conversion.api.services.ValidationService;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -35,7 +36,7 @@ import java.util.concurrent.ExecutionException;
  */
 @RestController
 @RequestMapping("/")
-@CrossOrigin
+@CrossOrigin(allowCredentials = "true")
 public class QrdaControllerV1 {
 
 	private static final Logger API_LOG = LoggerFactory.getLogger(QrdaControllerV1.class);

--- a/tools/bin/docker_deploy.sh
+++ b/tools/bin/docker_deploy.sh
@@ -13,7 +13,7 @@ function run_ansible() {
 	ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "$1," --extra-vars "remote_username=$2 sudoer_password=$3" ./tools/ansible/conversion_playbook.yml
 }
 
-if [[ "$CIRCLE_BRANCH" == "story-748-simple_purpose" || ( ! -z $DOCKER_DEPLOY_OTHER_BRANCH && "$CIRCLE_BRANCH" == "$DOCKER_DEPLOY_OTHER_BRANCH" ) ]]; then
+if [[ "$CIRCLE_BRANCH" == "develop" || ( ! -z $DOCKER_DEPLOY_OTHER_BRANCH && "$CIRCLE_BRANCH" == "$DOCKER_DEPLOY_OTHER_BRANCH" ) ]]; then
 	build_and_tar_converter_image
 	run_ansible ${DOCKER_DEPLOY_HOSTS} ${DOCKER_DEPLOY_REMOTE_USERNAME} ${DOCKER_DEPLOY_SUDOER_PASSWORD}
 	if [[ $? -ne 0 ]]; then

--- a/tools/bin/docker_deploy.sh
+++ b/tools/bin/docker_deploy.sh
@@ -13,7 +13,7 @@ function run_ansible() {
 	ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "$1," --extra-vars "remote_username=$2 sudoer_password=$3" ./tools/ansible/conversion_playbook.yml
 }
 
-if [[ "$CIRCLE_BRANCH" == "develop" || ( ! -z $DOCKER_DEPLOY_OTHER_BRANCH && "$CIRCLE_BRANCH" == "$DOCKER_DEPLOY_OTHER_BRANCH" ) ]]; then
+if [[ "$CIRCLE_BRANCH" == "story-748-simple_purpose" || ( ! -z $DOCKER_DEPLOY_OTHER_BRANCH && "$CIRCLE_BRANCH" == "$DOCKER_DEPLOY_OTHER_BRANCH" ) ]]; then
 	build_and_tar_converter_image
 	run_ansible ${DOCKER_DEPLOY_HOSTS} ${DOCKER_DEPLOY_REMOTE_USERNAME} ${DOCKER_DEPLOY_SUDOER_PASSWORD}
 	if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
### Information
- JIRA story QPPCT-748.

### Changes proposed in this PR:
- The SimpleUI sends in the `Purpose` header with `SimpleUI`.
- Reset the default `base href` to `/` and set it to `/developers/conversion-tool-sandbox/` only during deployment.
- Force `allowCredentials` to `true` for CORS since Spring 5.0 defaults to `false`.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.