### PR TITLE
Replace assembly with shade in commandline

### DIFF
--- a/commandline/pom.xml
+++ b/commandline/pom.xml
@@ -21,24 +21,21 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
+				<artifactId>maven-shade-plugin</artifactId>
 				<configuration>
-					<archive>
-						<manifest>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 							<mainClass>gov.cms.qpp.conversion.CommandLineMain</mainClass>
-						</manifest>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<appendAssemblyId>false</appendAssemblyId>
+						</transformer>
+					</transformers>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
 				</configuration>
 				<executions>
 					<execution>
-						<id>make-assembly</id>
+						<id>shade</id>
 						<phase>package</phase>
 						<goals>
-							<goal>single</goal>
+							<goal>shade</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
### Information
- JIRA story QPPCT-778.

### Changes proposed in this PR:
- Replaces maven-assembly-plugin with maven-shade-plugin in the commandline module

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
