### PR TITLE
Enforce error code ordering

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -34,8 +34,6 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 33 : CT - Must enter a valid Performance Rate value
 * 34 : CT - Must contain a practice site address for CPC+ conversions
 * 35 : CT - One and only one Alternative Payment Model (APM) Entity Identifier should be specified
-* 62 : CT - The Alternative Payment Model (APM) Entity Identifier must not be empty
-* 63 : CT - The Alternative Payment Model (APM) Entity Identifier is not valid
 * 36 : CT - Must contain one Measure section
 * 37 : CT - Must contain correct number of performance rate(s). Correct Number is `(Expected value)`
 * 38 : CT - This `(Numerator or Denominator)` Node does not have any child Nodes
@@ -61,6 +59,8 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 59 : CT - The electronic measure id: `(Current eMeasure ID)` requires a `(Subpopulation type)` with the correct UUID of `(Correct uuid required)`
 * 60 : CT - The electronic measure id: `(Current eMeasure ID)` has a performanceRateId with an incorrect UUID of `(Incorrect UUID)`
 * 61 : CT - A Performance Rate must contain a single Performance Rate UUID
+* 62 : CT - The Alternative Payment Model (APM) Entity Identifier must not be empty
+* 63 : CT - The Alternative Payment Model (APM) Entity Identifier is not valid
 * 64 : CT - CPC+ Submissions must have at least `(CPC+ measure group minimum)` of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`
 * 65 : CT - CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of the following measures: `(Listing of all CPC+ measure ids)`.
 * 66 : CT - Missing the `(Supplemental Type)` - `(Type Qualification)` supplemental data for code `(Supplemental Data Code)` for the measure id `(Measure Id)`'s Sub-population `(Sub Population)`

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -73,8 +73,6 @@ public enum ErrorCode implements LocalizedError {
 			+ "conversions"),
 	CPC_CLINICAL_DOCUMENT_ONLY_ONE_APM_ALLOWED(35, "One and only one Alternative Payment Model (APM) Entity "
 			+ "Identifier should be specified"),
-	CPC_CLINICAL_DOCUMENT_EMPTY_APM(62, "The Alternative Payment Model (APM) Entity Identifier must not be empty"),
-	CPC_CLINICAL_DOCUMENT_INVALID_APM(63, "The Alternative Payment Model (APM) Entity Identifier is not valid"),
 	CPC_CLINICAL_DOCUMENT_ONE_MEASURE_SECTION_REQUIRED(36, "Must contain one Measure section"),
 	CPC_QUALITY_MEASURE_ID_INVALID_PERFORMANCE_RATE_COUNT(37, "Must contain correct number of performance rate(s). "
 			+ "Correct Number is `(Expected value)`", true),
@@ -114,6 +112,8 @@ public enum ErrorCode implements LocalizedError {
 			+ "a performanceRateId with an incorrect UUID of `(Incorrect UUID)`", true),
 	QUALITY_MEASURE_ID_MISSING_SINGLE_PERFORMANCE_RATE(61, "A Performance Rate must contain a single "
 			+ "Performance Rate UUID"),
+	CPC_CLINICAL_DOCUMENT_EMPTY_APM(62, "The Alternative Payment Model (APM) Entity Identifier must not be empty"),
+	CPC_CLINICAL_DOCUMENT_INVALID_APM(63, "The Alternative Payment Model (APM) Entity Identifier is not valid"),
 	CPC_PLUS_TOO_FEW_QUALITY_MEASURE_CATEGORY(64, "CPC+ Submissions must have at least `(CPC+ measure group minimum)` "
 			+ "of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`", true),
 	CPC_PLUS_TOO_FEW_QUALITY_MEASURES(65, "CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of "

--- a/commons/src/test/java/gov/cms/qpp/conversion/ErrorCodeTest.java
+++ b/commons/src/test/java/gov/cms/qpp/conversion/ErrorCodeTest.java
@@ -96,6 +96,16 @@ class ErrorCodeTest implements EnumContract {
 		Truth.assertThat(formatted("mock")).isNotEqualTo(formattedAlt("mock2"));
 	}
 
+	@Test
+	void testErrorCodeOrder() {
+		int last = -1;
+		for (ErrorCode errorCode : ErrorCode.values()) {
+			int currentCode = errorCode.getCode();
+			Truth.assertThat(last).isLessThan(currentCode);
+			last = currentCode;
+		}
+	}
+
 	private LocalizedError formatted(String salt) {
 		return ErrorCode.NUMERATOR_DENOMINATOR_INVALID_VALUE.format(salt);
 	}


### PR DESCRIPTION
### Information
- JIRA story QPPCT-814.

### Changes proposed in this PR:
- Added a test to enforce error code orders

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [X] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [X] Updated documentation (`README.md`, etc.) depending if the changes require it.
