### PR TITLE
QPPCT-825: Update deployment version of yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
   ui_test:
     <<: *container_config
     docker:
-      - image: circleci/node:7.10.0-browsers
+      - image: circleci/node:8.11.1-browsers
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -99,7 +99,7 @@ jobs:
   ui_deployment:
     <<: *container_config
     docker:
-      - image: circleci/node:7.10.0-browsers
+      - image: circleci/node:8.11.1-browsers
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -114,7 +114,7 @@ jobs:
   signal_success:
     <<: *container_config
     docker:
-      - image: circleci/node:7.10.0-browsers
+      - image: circleci/node:8.11.1-browsers
     steps:
       - attach_workspace:
           at: /home/circleci


### PR DESCRIPTION
### Information
- JIRA story QPPCT-825.

### Changes proposed in this PR:
- Upgraded to a newer version of CircleCI's Node Docker image.  This uses a new version of Yarn that passes the command line arguments to Angular CLI (`ng`).
- I tested this by running the same commands in our `ui_deployment` CircleCI job associated with building the frontend in a `circleci/node:8.11.1-browsers` Docker container.  I then inspected the output to make sure the base href was set correctly.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.