### PR TITLE
QPPCT-762: Add better context to messages

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -405,10 +405,22 @@ public class Node {
 		return !nodes.isEmpty();
 	}
 
+	/**
+	 * Finds the first parent of this {@code Node} that has a human readable {@link TemplateId}.
+	 *
+	 * @return The parent node.
+	 */
 	public Node findParentNodeWithHumanReadableTemplateId() {
 		return findParentNodeWithHumanReadableTemplateId(this);
 	}
 
+	/**
+	 * Recursively searches for a parent {@code Node} with a human readable {@link TemplateId}.
+	 *
+	 * @param node The {@code Node} to see if it or its parent has a human readable {@link TemplateId}
+	 * @return The passed in {@code Node} if it has a human readable {@link TemplateId}, {@code null} if this {@code Node} is {@code null}, or
+	 * whatever the parent {@code Node} has.
+	 */
 	private Node findParentNodeWithHumanReadableTemplateId(Node node) {
 		if (node == null) {
 			return null;

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -1,21 +1,13 @@
 package gov.cms.qpp.conversion.model;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Lists;
 
 /**
  * Represents a node of data that should be converted. Consists of a key/value
@@ -402,6 +394,26 @@ public class Node {
 	 */
 	private static boolean foundNode(List<?> nodes) {
 		return !nodes.isEmpty();
+	}
+
+	public Node findParentNodeWithHumanReadableTemplateId() {
+		if (this.getType() == TemplateId.CLINICAL_DOCUMENT) {
+			return this;
+		}
+
+		return findParentNodeWithHumanReadableTemplateId(getParent());
+	}
+
+	private Node findParentNodeWithHumanReadableTemplateId(Node node) {
+		if (node == null) {
+			return null;
+		}
+
+		if (!StringUtils.isEmpty(node.getType().getHumanReadableTitle())) {
+			return node;
+		}
+
+		return findParentNodeWithHumanReadableTemplateId(node.getParent());
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -4,7 +4,16 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Node.java
@@ -397,11 +397,7 @@ public class Node {
 	}
 
 	public Node findParentNodeWithHumanReadableTemplateId() {
-		if (this.getType() == TemplateId.CLINICAL_DOCUMENT) {
-			return this;
-		}
-
-		return findParentNodeWithHumanReadableTemplateId(getParent());
+		return findParentNodeWithHumanReadableTemplateId(this);
 	}
 
 	private Node findParentNodeWithHumanReadableTemplateId(Node node) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
@@ -21,7 +21,7 @@ public enum TemplateId {
 	ACI_NUMERATOR_DENOMINATOR("2.16.840.1.113883.10.20.27.3.28", Extension.JUNE_2017, "ACI Measure"),
 	ACI_NUMERATOR("2.16.840.1.113883.10.20.27.3.31", Extension.SEPTEMBER_2016),
 	ACI_DENOMINATOR("2.16.840.1.113883.10.20.27.3.32", Extension.SEPTEMBER_2016),
-	IA_MEASURE("2.16.840.1.113883.10.20.27.3.33", Extension.SEPTEMBER_2016, "IA Measure"),
+	IA_MEASURE("2.16.840.1.113883.10.20.27.3.33", Extension.SEPTEMBER_2016, "Improvement Activity"),
 	REPORTING_PARAMETERS_ACT("2.16.840.1.113883.10.20.17.3.8"),
 	MEASURE_DATA_CMS_V2("2.16.840.1.113883.10.20.27.3.16", Extension.NOVEMBER_2016),
 	PERFORMANCE_RATE_PROPORTION_MEASURE("2.16.840.1.113883.10.20.27.3.25", Extension.NOVEMBER_2016),
@@ -94,10 +94,6 @@ public enum TemplateId {
 	 */
 	TemplateId(String root) {
 		this(root, Extension.NONE);
-	}
-
-	TemplateId(String root, String humanReadableTitle) {
-		this(root, Extension.NONE, humanReadableTitle);
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
@@ -127,6 +127,9 @@ public enum TemplateId {
 		return extension.toString();
 	}
 
+	/**
+	 * @return The human readable title, if any.
+	 */
 	public String getHumanReadableTitle() {
 		return humanReadableTitle;
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
@@ -131,6 +131,10 @@ public enum TemplateId {
 		return extension.toString();
 	}
 
+	public String getHumanReadableTitle() {
+		return humanReadableTitle;
+	}
+
 	/**
 	 * String representation of this template id
 	 *
@@ -140,10 +144,6 @@ public enum TemplateId {
 	 */
 	public String getTemplateId(Context context) {
 		return generateTemplateIdString(root, getExtension(), context);
-	}
-
-	public String getHumanReadableTitle() {
-		return humanReadableTitle;
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
@@ -1,31 +1,32 @@
 package gov.cms.qpp.conversion.model;
 
+import com.google.common.base.Strings;
+
 import gov.cms.qpp.conversion.Context;
+import gov.cms.qpp.conversion.util.EnvironmentHelper;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-
-import com.google.common.base.Strings;
-import gov.cms.qpp.conversion.util.EnvironmentHelper;
 
 /**
  * An enumeration of known templates IDs.
  */
 public enum TemplateId {
-	CLINICAL_DOCUMENT("2.16.840.1.113883.10.20.27.1.2", Extension.JULY_2017),
+	CLINICAL_DOCUMENT("2.16.840.1.113883.10.20.27.1.2", Extension.JULY_2017, "Clinical Document"),
 	ACI_AGGREGATE_COUNT("2.16.840.1.113883.10.20.27.3.3"),
-	IA_SECTION("2.16.840.1.113883.10.20.27.2.4", Extension.JUNE_2017),
-	ACI_SECTION("2.16.840.1.113883.10.20.27.2.5", Extension.JUNE_2017),
+	IA_SECTION("2.16.840.1.113883.10.20.27.2.4", Extension.JUNE_2017, "IA Section"),
+	ACI_SECTION("2.16.840.1.113883.10.20.27.2.5", Extension.JUNE_2017, "ACI Section"),
 	MEASURE_PERFORMED("2.16.840.1.113883.10.20.27.3.27", Extension.SEPTEMBER_2016),
-	ACI_NUMERATOR_DENOMINATOR("2.16.840.1.113883.10.20.27.3.28", Extension.JUNE_2017),
+	ACI_NUMERATOR_DENOMINATOR("2.16.840.1.113883.10.20.27.3.28", Extension.JUNE_2017, "ACI Measure"),
 	ACI_NUMERATOR("2.16.840.1.113883.10.20.27.3.31", Extension.SEPTEMBER_2016),
 	ACI_DENOMINATOR("2.16.840.1.113883.10.20.27.3.32", Extension.SEPTEMBER_2016),
-	IA_MEASURE("2.16.840.1.113883.10.20.27.3.33", Extension.SEPTEMBER_2016),
+	IA_MEASURE("2.16.840.1.113883.10.20.27.3.33", Extension.SEPTEMBER_2016, "IA Measure"),
 	REPORTING_PARAMETERS_ACT("2.16.840.1.113883.10.20.17.3.8"),
 	MEASURE_DATA_CMS_V2("2.16.840.1.113883.10.20.27.3.16", Extension.NOVEMBER_2016),
 	PERFORMANCE_RATE_PROPORTION_MEASURE("2.16.840.1.113883.10.20.27.3.25", Extension.NOVEMBER_2016),
-	MEASURE_SECTION_V2("2.16.840.1.113883.10.20.27.2.3", Extension.JULY_2017),
-	MEASURE_REFERENCE_RESULTS_CMS_V2("2.16.840.1.113883.10.20.27.3.17", Extension.NOVEMBER_2016),
+	MEASURE_SECTION_V2("2.16.840.1.113883.10.20.27.2.3", Extension.JULY_2017, "Measure Section"),
+	MEASURE_REFERENCE_RESULTS_CMS_V2("2.16.840.1.113883.10.20.27.3.17", Extension.NOVEMBER_2016, "Quality Measure"),
 	ACI_MEASURE_PERFORMED_REFERENCE_AND_RESULTS("2.16.840.1.113883.10.20.27.3.29", Extension.SEPTEMBER_2016),
 	REPORTING_STRATUM_CMS("2.16.840.1.113883.10.20.27.3.20"),
 	ETHNICITY_SUPPLEMENTAL_DATA_ELEMENT_CMS_V2("2.16.840.1.113883.10.20.27.3.22", Extension.NOVEMBER_2016),
@@ -84,6 +85,7 @@ public enum TemplateId {
 	private final String root;
 	private final Extension extension;
 	private final boolean alwaysStrict;
+	private final String humanReadableTitle;
 
 	/**
 	 * Constructs a TemplateId with just a root.
@@ -94,6 +96,10 @@ public enum TemplateId {
 		this(root, Extension.NONE);
 	}
 
+	TemplateId(String root, String humanReadableTitle) {
+		this(root, Extension.NONE, humanReadableTitle);
+	}
+
 	/**
 	 * Constructs a TemplateId with a root and an extension.
 	 *
@@ -101,9 +107,14 @@ public enum TemplateId {
 	 * @param extension The extension of the template ID.  Normally a date.
 	 */
 	TemplateId(String root, Extension extension) {
+		this(root, extension, null);
+	}
+
+	TemplateId(String root, Extension extension, String humanReadableTitle) {
 		this.root = root;
 		this.extension = extension;
 		this.alwaysStrict = "CLINICAL_DOCUMENT".equals(this.name());
+		this.humanReadableTitle = humanReadableTitle;
 	}
 
 	/**
@@ -129,6 +140,10 @@ public enum TemplateId {
 	 */
 	public String getTemplateId(Context context) {
 		return generateTemplateIdString(root, getExtension(), context);
+	}
+
+	public String getHumanReadableTitle() {
+		return humanReadableTitle;
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -62,16 +62,7 @@ public class Detail implements Serializable {
 
 		Detail detail = forErrorCode(error);
 		detail.setPath(node.getPath());
-
-		Node importantParentNode = node.findParentNodeWithHumanReadableTemplateId();
-
-		if (importantParentNode != null) {
-			String importantParentTitle = importantParentNode.getType().getHumanReadableTitle();
-
-			String possibleMeasureId = importantParentNode.getValue("measureId");
-
-			detail.setLocation(importantParentTitle + (StringUtils.isEmpty(possibleMeasureId) ? "" : " " + possibleMeasureId));
-		}
+		detail.setLocation(computeLocation(node));
 
 		return detail;
 	}
@@ -89,6 +80,26 @@ public class Detail implements Serializable {
 		detail.setErrorCode(error.getErrorCode().getCode());
 		detail.setMessage(error.getMessage());
 		return detail;
+	}
+
+	private static String computeLocation(Node node) {
+
+		String location = null;
+
+		Node importantParentNode = node.findParentNodeWithHumanReadableTemplateId();
+
+		if (importantParentNode != null) {
+			String importantParentTitle = importantParentNode.getType().getHumanReadableTitle();
+			String possibleMeasureId = importantParentNode.getValue("measureId");
+
+			location = importantParentTitle;
+
+			if (!StringUtils.isEmpty(possibleMeasureId)) {
+				location += " " + possibleMeasureId;
+			}
+		}
+
+		return location;
 	}
 
 	/**
@@ -171,6 +182,14 @@ public class Detail implements Serializable {
 		this.type = type;
 	}
 
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(final String location) {
+		this.location = location;
+	}
+
 	/**
 	 * @return A string representation.
 	 */
@@ -220,13 +239,5 @@ public class Detail implements Serializable {
 	@Override
 	public int hashCode() {
 		return Objects.hash(errorCode, message, path, value, type, location);
-	}
-
-	public String getLocation() {
-		return location;
-	}
-
-	public void setLocation(final String location) {
-		this.location = location;
 	}
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -1,13 +1,14 @@
 package gov.cms.qpp.conversion.model.error;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import org.apache.commons.lang3.StringUtils;
 
 import gov.cms.qpp.conversion.model.Node;
+
+import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Holds the error information from Validators.
@@ -26,6 +27,8 @@ public class Detail implements Serializable {
 	private String value;
 	@JsonProperty("type")
 	private String type;
+
+	private String location;
 
 	/**
 	 * Dummy constructor for ORM
@@ -59,6 +62,17 @@ public class Detail implements Serializable {
 
 		Detail detail = forErrorCode(error);
 		detail.setPath(node.getPath());
+
+		Node importantParentNode = node.findParentNodeWithHumanReadableTemplateId();
+
+		if (importantParentNode != null) {
+			String importantParentTitle = importantParentNode.getType().getHumanReadableTitle();
+
+			String possibleMeasureId = importantParentNode.getValue("measureId");
+
+			detail.setLocation(importantParentTitle + (StringUtils.isEmpty(possibleMeasureId) ? "" : " " + possibleMeasureId));
+		}
+
 		return detail;
 	}
 
@@ -194,6 +208,7 @@ public class Detail implements Serializable {
 		equals &= Objects.equals(path, that.path);
 		equals &= Objects.equals(value, that.value);
 		equals &= Objects.equals(type, that.type);
+		equals &= Objects.equals(location, that.location);
 		return equals;
 	}
 
@@ -204,6 +219,14 @@ public class Detail implements Serializable {
 	 */
 	@Override
 	public int hashCode() {
-		return Objects.hash(errorCode, message, path, value, type);
+		return Objects.hash(errorCode, message, path, value, type, location);
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(final String location) {
+		this.location = location;
 	}
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -41,6 +41,7 @@ public class Detail implements Serializable {
 		path = detail.path;
 		value = detail.value;
 		type = detail.type;
+		location = detail.location;
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -166,10 +166,20 @@ public class Detail implements Serializable {
 		this.type = type;
 	}
 
+	/**
+	 * The human readable location where this error occurred.
+	 *
+	 * @return The location.
+	 */
 	public String getLocation() {
 		return location;
 	}
 
+	/**
+	 * Sets the human readable location where this error occurred.
+	 *
+	 * @param location The location.
+	 */
 	public void setLocation(final String location) {
 		this.location = location;
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -1,7 +1,6 @@
 package gov.cms.qpp.conversion.model.error;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import org.apache.commons.lang3.StringUtils;
 
@@ -17,17 +16,11 @@ import java.util.Objects;
 public class Detail implements Serializable {
 	private static final long serialVersionUID = 8818544157552590676L;
 
-	@JsonProperty("errorCode")
 	private Integer errorCode;
-	@JsonProperty("message")
 	private String message;
-	@JsonProperty("path")
 	private String path = "";
-	@JsonProperty("value")
 	private String value;
-	@JsonProperty("type")
 	private String type;
-
 	private String location;
 
 	/**
@@ -107,12 +100,10 @@ public class Detail implements Serializable {
 	 *
 	 * @return An {@link ErrorCode}
 	 */
-	@JsonProperty("errorCode")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
 
-	@JsonProperty("errorCode")
 	public void setErrorCode(Integer errorCode) {
 		this.errorCode = errorCode;
 	}
@@ -122,12 +113,10 @@ public class Detail implements Serializable {
 	 *
 	 * @return An error description.
 	 */
-	@JsonProperty("message")
 	public String getMessage() {
 		return message;
 	}
 
-	@JsonProperty("message")
 	public void setMessage(String message) {
 		this.message = message;
 	}
@@ -137,7 +126,6 @@ public class Detail implements Serializable {
 	 *
 	 * @return The path that this error references.
 	 */
-	@JsonProperty("path")
 	public String getPath() {
 		return path;
 	}
@@ -147,7 +135,6 @@ public class Detail implements Serializable {
 	 *
 	 * @param path The path that this error references.
 	 */
-	@JsonProperty("path")
 	public void setPath(String path) {
 		this.path = path;
 	}
@@ -157,12 +144,10 @@ public class Detail implements Serializable {
 	 *
 	 * @return The value that this error references.
 	 */
-	@JsonProperty("value")
 	public String getValue() {
 		return value;
 	}
 
-	@JsonProperty("value")
 	public void setValue(String value) {
 		this.value = value;
 	}
@@ -172,12 +157,10 @@ public class Detail implements Serializable {
 	 *
 	 * @return The type that this error references.
 	 */
-	@JsonProperty("type")
 	public String getType() {
 		return type;
 	}
 
-	@JsonProperty("type")
 	public void setType(String type) {
 		this.type = type;
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/error/Detail.java
@@ -78,7 +78,7 @@ public class Detail implements Serializable {
 
 	private static String computeLocation(Node node) {
 
-		String location = null;
+		StringBuilder location = new StringBuilder();
 
 		Node importantParentNode = node.findParentNodeWithHumanReadableTemplateId();
 
@@ -86,14 +86,15 @@ public class Detail implements Serializable {
 			String importantParentTitle = importantParentNode.getType().getHumanReadableTitle();
 			String possibleMeasureId = importantParentNode.getValue("measureId");
 
-			location = importantParentTitle;
+			location.append(importantParentTitle);
 
 			if (!StringUtils.isEmpty(possibleMeasureId)) {
-				location += " " + possibleMeasureId;
+				location.append(" ");
+				location.append(possibleMeasureId);
 			}
 		}
 
-		return location;
+		return location.toString();
 	}
 
 	/**

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/NodeTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/NodeTest.java
@@ -1,17 +1,15 @@
 package gov.cms.qpp.conversion.model;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
+import com.google.common.collect.Lists;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Lists;
-
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 class NodeTest {
 
@@ -249,6 +247,36 @@ class NodeTest {
 	void testRemoveChildNodeSelf() {
 		Node node = new Node();
 		assertThat(node.removeChildNode(node)).isFalse();
+	}
+
+	@Test
+	void testFindParentNodeWithHumanReadableTemplateIdTraverse() {
+		Node topLevelNode = new Node(TemplateId.IA_MEASURE);
+		Node middleLevelNode = new Node(TemplateId.ACI_SECTION, topLevelNode);
+		Node bottomLevelNode = new Node(TemplateId.ACI_AGGREGATE_COUNT, middleLevelNode);
+
+		Node humanReadableNode = bottomLevelNode.findParentNodeWithHumanReadableTemplateId();
+
+		assertThat(humanReadableNode).isSameAs(middleLevelNode);
+		assertThat(humanReadableNode).isNotSameAs(topLevelNode);
+	}
+
+	@Test
+	void testFindParentNodeWithHumanReadableTemplateIdSame() {
+		Node node = new Node(TemplateId.IA_MEASURE);
+
+		Node humanReadableNode = node.findParentNodeWithHumanReadableTemplateId();
+
+		assertThat(humanReadableNode).isSameAs(node);
+	}
+
+	@Test
+	void testFindParentNodeWithHumanReadableTemplateIdNull() {
+		Node node = new Node(TemplateId.ACI_AGGREGATE_COUNT);
+
+		Node humanReadableNode = node.findParentNodeWithHumanReadableTemplateId();
+
+		assertThat(humanReadableNode).isNull();
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/TemplateIdTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/TemplateIdTest.java
@@ -1,14 +1,15 @@
 package gov.cms.qpp.conversion.model;
 
-import gov.cms.qpp.conversion.Context;
-import gov.cms.qpp.conversion.model.TemplateId.Extension;
-import gov.cms.qpp.test.enums.EnumContract;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import gov.cms.qpp.conversion.Context;
+import gov.cms.qpp.conversion.model.TemplateId.Extension;
+import gov.cms.qpp.test.enums.EnumContract;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
@@ -35,6 +36,16 @@ class TemplateIdTest implements EnumContract {
 	@Test
 	void testExtension() {
 		assertThat(TemplateId.CLINICAL_DOCUMENT.getExtension()).isSameAs("2017-07-01");
+	}
+
+	@Test
+	void testHumanReadableTitle() {
+		assertThat(TemplateId.CLINICAL_DOCUMENT.getHumanReadableTitle()).isSameAs("Clinical Document");
+	}
+
+	@Test
+	void testHumanReadableTitleDoesntExist() {
+		assertThat(TemplateId.ETHNICITY_SUPPLEMENTAL_DATA_ELEMENT_CMS_V2.getHumanReadableTitle()).isNull();
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/error/DetailTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/error/DetailTest.java
@@ -4,6 +4,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+
 import static com.google.common.truth.Truth.assertThat;
 
 class DetailTest {
@@ -20,8 +23,38 @@ class DetailTest {
 		detail.setMessage("message");
 		detail.setType("type");
 		detail.setValue("value");
+		detail.setLocation("location");
 		Detail otherDetail = new Detail(detail);
 
 		assertThat(detail).isEqualTo(otherDetail);
+	}
+
+	@Test
+	void testComputeLocation() {
+		Node node = new Node(TemplateId.CLINICAL_DOCUMENT);
+
+		Detail detail = Detail.forErrorAndNode(ErrorCode.UNEXPECTED_ERROR, node);
+
+		assertThat(detail.getLocation()).isEqualTo(node.getType().getHumanReadableTitle());
+	}
+
+	@Test
+	void testComputeLocationMeasure() {
+		Node node = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V2);
+		String measureId = "Moof";
+		node.putValue("measureId", measureId);
+
+		Detail detail = Detail.forErrorAndNode(ErrorCode.UNEXPECTED_ERROR, node);
+
+		assertThat(detail.getLocation()).isEqualTo(node.getType().getHumanReadableTitle() + " " + measureId);
+	}
+
+	@Test
+	void testComputeLocationNull() {
+		Node node = new Node(TemplateId.ACI_AGGREGATE_COUNT);
+
+		Detail detail = Detail.forErrorAndNode(ErrorCode.UNEXPECTED_ERROR, node);
+
+		assertThat(detail.getLocation()).isNull();
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/error/DetailTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/error/DetailTest.java
@@ -50,11 +50,11 @@ class DetailTest {
 	}
 
 	@Test
-	void testComputeLocationNull() {
+	void testComputeLocationEmpty() {
 		Node node = new Node(TemplateId.ACI_AGGREGATE_COUNT);
 
 		Detail detail = Detail.forErrorAndNode(ErrorCode.UNEXPECTED_ERROR, node);
 
-		assertThat(detail.getLocation()).isNull();
+		assertThat(detail.getLocation()).isEmpty();
 	}
 }


### PR DESCRIPTION
### Information
- JIRA story QPPCT-762.

### Changes proposed in this PR:
- Added another field to `Detail`, the class that gets serialized to report validation errors to our users, called `location`.
  - That field holds a human readable location.
- Gave human readable titles to certain `TemplateId`s.
- When an validation error occurs, the first `Node` or its parent that contains a human readable `TemplateId` is searched for.  The subsequently created `Detail` fills this human readable title as the `location`.
  - If this `Node` is a measure, the measure ID is obtained and appended to the human readable `location`.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
