### PR TITLE
QPPCT-810: Error message changes for 33

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -31,7 +31,7 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 30 : CT - Must have one and only one performance end
 * 31 : CT - Must have a performance year
 * 32 : CT - The Quality Measure Section must have exactly one Reporting Parameter ACT
-* 33 : CT - Must enter a valid Performance Rate value
+* 33 : CT - The Performance Rate `(supplied value)` is invalid. It must be a decimal between 0 and 1.
 * 34 : CT - Must contain a practice site address for CPC+ conversions
 * 35 : CT - One and only one Alternative Payment Model (APM) Entity Identifier should be specified
 * 36 : CT - CPC+ submissions must contain one Measure section
@@ -65,3 +65,4 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 67 : CT - Must have one count for Supplemental Data `(Supplemental Data Code)` on Sub-population `(Sub Population)` for the measure id `(Measure Id)`
 * 68 : CT - Your CPC+ submission was made after the CPC+ Measure section submission deadline of `(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at `(CPC+ contact email)` for assistance.
 * 69 : CT - `(Performance period start or end date)` is an invalid date format. Please use a standard ISO date format. Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123
+* 70 : CT - The Performance Rate is missing

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -68,7 +68,7 @@ public enum ErrorCode implements LocalizedError {
 	REPORTING_PARAMETERS_MISSING_PERFORMANCE_YEAR(31, "Must have a performance year"),
 	QUALITY_MEASURE_SECTION_REQUIRED_REPORTING_PARAM_REQUIREMENT(32, "The Quality Measure Section must have "
 			+ "exactly one Reporting Parameter ACT"),
-	PERFORMANCE_RATE_INVALID_VALUE(33, "The Performance Rate `(supplied value)` is invalid. It must be between 0 and 1.", true),
+	PERFORMANCE_RATE_INVALID_VALUE(33, "The Performance Rate `(supplied value)` is invalid. It must be a decimal between 0 and 1.", true),
 	CPC_CLINICAL_DOCUMENT_MISSING_PRACTICE_SITE_ADDRESS(34, "Must contain a practice site address for CPC+ "
 			+ "conversions"),
 	CPC_CLINICAL_DOCUMENT_ONLY_ONE_APM_ALLOWED(35, "One and only one Alternative Payment Model (APM) Entity "
@@ -125,7 +125,8 @@ public enum ErrorCode implements LocalizedError {
 		+ "`(CPC+ contact email)` for assistance.", true),
 	INVALID_PERFORMANCE_PERIOD_FORMAT(69, "`(Performance period start or end date)` is an invalid date format. "
 		+ "Please use a standard ISO date format. "
-		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true);
+		+ "Example valid values are 2017-02-26, 2017/02/26T01:45:23, or 2017-02-26T01:45:23.123", true),
+	PERFORMANCE_RATE_MISSING(70, "The Performance Rate is missing");
 
 	private static final Map<Integer, ErrorCode> CODE_TO_VALUE = Arrays.stream(values())
 			.collect(Collectors.toMap(ErrorCode::getCode, Function.identity()));

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -68,7 +68,7 @@ public enum ErrorCode implements LocalizedError {
 	REPORTING_PARAMETERS_MISSING_PERFORMANCE_YEAR(31, "Must have a performance year"),
 	QUALITY_MEASURE_SECTION_REQUIRED_REPORTING_PARAM_REQUIREMENT(32, "The Quality Measure Section must have "
 			+ "exactly one Reporting Parameter ACT"),
-	PERFORMANCE_RATE_INVALID_VALUE(33, "Must enter a valid Performance Rate value"),
+	PERFORMANCE_RATE_INVALID_VALUE(33, "The Performance Rate `(supplied value)` is invalid. It must be between 0 and 1.", true),
 	CPC_CLINICAL_DOCUMENT_MISSING_PRACTICE_SITE_ADDRESS(34, "Must contain a practice site address for CPC+ "
 			+ "conversions"),
 	CPC_CLINICAL_DOCUMENT_ONLY_ONE_APM_ALLOWED(35, "One and only one Alternative Payment Model (APM) Entity "

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/PerformanceRateValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/PerformanceRateValidator.java
@@ -23,12 +23,16 @@ public class PerformanceRateValidator extends NodeValidator {
 	protected void internalValidateSingleNode(Node node) {
 		if (!NULL_ATTRIBUTE.equals(node.getValue(PerformanceRateProportionMeasureDecoder.NULL_PERFORMANCE_RATE))) {
 
-			//TODO: Need a new error code to generate when the performance rate doesn't exist
-			String performanceRate = node.getValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE);
-
 			check(node)
+				.valueIsNotEmpty(ErrorCode.PERFORMANCE_RATE_MISSING, PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE);
+
+			if (getDetails().isEmpty()) {
+				String performanceRate = node.getValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE);
+
+				check(node)
 					.inDecimalRangeOf(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE.format(performanceRate),
-							PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, 0F, 1F);
+						PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, 0F, 1F);
+			}
 		}
 	}
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/PerformanceRateValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/PerformanceRateValidator.java
@@ -22,8 +22,12 @@ public class PerformanceRateValidator extends NodeValidator {
 	@Override
 	protected void internalValidateSingleNode(Node node) {
 		if (!NULL_ATTRIBUTE.equals(node.getValue(PerformanceRateProportionMeasureDecoder.NULL_PERFORMANCE_RATE))) {
+
+			//TODO: Need a new error code to generate when the performance rate doesn't exist
+			String performanceRate = node.getValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE);
+
 			check(node)
-					.inDecimalRangeOf(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE,
+					.inDecimalRangeOf(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE.format(performanceRate),
 							PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, 0F, 1F);
 		}
 	}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -1,6 +1,12 @@
 package gov.cms.qpp.acceptance.cpc;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;
 import gov.cms.qpp.conversion.model.error.AllErrors;
@@ -8,11 +14,6 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.TransformException;
 import gov.cms.qpp.conversion.model.validation.ApmEntityIds;
 import gov.cms.qpp.conversion.util.JsonHelper;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/PerformanceRateValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/PerformanceRateValidatorTest.java
@@ -1,7 +1,5 @@
 package gov.cms.qpp.conversion.validate;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +8,8 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.ErrorCode;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
+
+import static com.google.common.truth.Truth.assertWithMessage;
 
 class PerformanceRateValidatorTest {
 
@@ -20,11 +20,11 @@ class PerformanceRateValidatorTest {
 	void setup() {
 		performanceRateValidator = new PerformanceRateValidator();
 		node = new Node(TemplateId.PERFORMANCE_RATE_PROPORTION_MEASURE);
-		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "0");
 	}
 
 	@Test
 	void testZeroValue() {
+		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "0");
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
 				.that(performanceRateValidator.getDetails()).isEmpty();
@@ -48,28 +48,48 @@ class PerformanceRateValidatorTest {
 
 	@Test
 	void testNegativeValue() {
-		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "-1");
+		String invalidValue = "-1";
+		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, invalidValue);
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
 				.that(performanceRateValidator.getDetails()).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE);
+				.containsExactly(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE.format(invalidValue));
 	}
 
 	@Test
 	void testInvalidValue() {
-		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "2");
+		String invalidValue = "2";
+		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, invalidValue);
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
 				.that(performanceRateValidator.getDetails()).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE);
+				.containsExactly(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE.format(invalidValue));
 	}
 
 	@Test
 	void testInvalidStringValue() {
-		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "Inval");
+		String invalidValue = "Inval";
+		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, invalidValue);
 		performanceRateValidator.internalValidateSingleNode(node);
 		assertWithMessage("Must contain a proper value")
 				.that(performanceRateValidator.getDetails()).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE);
+				.containsExactly(ErrorCode.PERFORMANCE_RATE_INVALID_VALUE.format(invalidValue));
+	}
+
+	@Test
+	void testEmptyValue() {
+		node.putValue(PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE, "");
+		performanceRateValidator.internalValidateSingleNode(node);
+		assertWithMessage("The error code is incorrect")
+			.that(performanceRateValidator.getDetails()).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.containsExactly(ErrorCode.PERFORMANCE_RATE_MISSING);
+	}
+
+	@Test
+	void testNonExistentValue() {
+		performanceRateValidator.internalValidateSingleNode(node);
+		assertWithMessage("The error code is incorrect")
+			.that(performanceRateValidator.getDetails()).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.containsExactly(ErrorCode.PERFORMANCE_RATE_MISSING);
 	}
 }

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -199,7 +199,13 @@
 		"errorData": [
 			{
 				"errorCode": 33,
-				"occurrences": 2
+				"subs": ["2.2"],
+				"occurrences": 1
+			},
+			{
+				"errorCode": 33,
+				"subs": ["String"],
+				"occurrences": 1
 			}
 		]
 	},
@@ -327,6 +333,7 @@
 		"errorData": [
 			{
 				"errorCode": 33,
+				"subs": ["null"],
 				"occurrences": 1
 			}
 		]
@@ -369,6 +376,7 @@
 		"errorData": [
 			{
 				"errorCode": 33,
+				"subs": ["1.888889"],
 				"occurrences": 1
 			}
 		]
@@ -407,6 +415,7 @@
 		"errorData": [
 			{
 				"errorCode": 33,
+				"subs": ["-.888889"],
 				"occurrences": 1
 			}
 		]
@@ -416,6 +425,7 @@
 		"errorData": [
 			{
 				"errorCode": 33,
+				"subs": ["true"],
 				"occurrences": 1
 			}
 		]

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -332,8 +332,7 @@
 		"strict": true,
 		"errorData": [
 			{
-				"errorCode": 33,
-				"subs": ["null"],
+				"errorCode": 70,
 				"occurrences": 1
 			}
 		]


### PR DESCRIPTION
### Information
- JIRA story QPPCT-810.

### Changes proposed in this PR:
- Updated error code 33 to mention the supplied invalid value and specify the valid value range.
- Added the new error code 70 when the performance rate is missing.
- Did not add additional context to the error message because that'll be covered by #711.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
