### PR TITLE
Error messages 55 and 56 updates

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -51,8 +51,8 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 52 : CT - The measure data with population id '`(population id)`' must have exactly one Aggregate Count.
 * 53 : CT - Measure data must be a positive integer value
 * 54 : CT - Must have at least one NPI/TIN combination
-* 55 : CT - Must be 01/01/2017
-* 56 : CT - Must be 12/31/2017
+* 55 : CT - A CPC Plus Performance period start must be 01/01/2017. Please refer to the IG for more information here: https://ecqi.healthit.gov/system/files/eCQM_QRDA_EC-508_0.pdf#page=14
+* 56 : CT - A CPC Plus Performance period end must be 12/31/2017. Please refer to the IG for more information here: https://ecqi.healthit.gov/system/files/eCQM_QRDA_EC-508_0.pdf#page=14
 * 57 : CT - The measure reference results must have a single measure population
 * 58 : CT - The measure reference results must have a single measure type
 * 59 : CT - The electronic measure id: `(Current eMeasure ID)` requires a `(Subpopulation type)` with the correct UUID of `(Correct uuid required)`

--- a/commons/src/main/java/gov/cms/qpp/conversion/DocumentationReference.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/DocumentationReference.java
@@ -7,7 +7,8 @@ public enum DocumentationReference {
 	PRACTICE_SITE_ADDRESS(25),
 	REPORTING_PARAMETERS_ACT(80),
 	MEASURE_IDS(88),
-	PERFORMANCE_PERIOD(17);
+	PERFORMANCE_PERIOD(17),
+	CPC_PLUS_SUBMISSIONS(14);
 
 	private static final String BASE_PATH = "https://ecqi.healthit.gov/system/files/eCQM_QRDA_EC-508_0.pdf#page=";
 	private final String path;

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -116,9 +116,9 @@ public enum ErrorCode implements LocalizedError {
 	MEASURE_DATA_VALUE_NOT_INTEGER(53, "Measure data must be a positive integer value"),
 	CPC_NPI_TIN_COMBINATION_MISSING_NPI_TIN_COMBINATION(54, "Must have at least one NPI/TIN combination"),
 	CPC_PERFORMANCE_PERIOD_START_JAN12017(55, "A CPC Plus Performance period start must be 01/01/2017. "
-			+ "Please refer to the IG for more information here: " +DocumentationReference.CPC_PLUS_SUBMISSIONS),
+			+ "Please refer to the IG for more information here: " + DocumentationReference.CPC_PLUS_SUBMISSIONS),
 	CPC_PERFORMANCE_PERIOD_END_DEC312017(56, "A CPC Plus Performance period end must be 12/31/2017. "
-			+ "Please refer to the IG for more information here: " +DocumentationReference.CPC_PLUS_SUBMISSIONS),
+			+ "Please refer to the IG for more information here: " + DocumentationReference.CPC_PLUS_SUBMISSIONS),
 	QUALITY_MEASURE_ID_MISSING_SINGLE_MEASURE_POPULATION(57, "The measure reference results must have a single "
 			+ "measure population"),
 	QUALITY_MEASURE_ID_MISSING_SINGLE_MEASURE_TYPE(58, "The measure reference results must have a single "

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -115,8 +115,10 @@ public enum ErrorCode implements LocalizedError {
 			+ "Aggregate Count.", true),
 	MEASURE_DATA_VALUE_NOT_INTEGER(53, "Measure data must be a positive integer value"),
 	CPC_NPI_TIN_COMBINATION_MISSING_NPI_TIN_COMBINATION(54, "Must have at least one NPI/TIN combination"),
-	CPC_PERFORMANCE_PERIOD_START_JAN12017(55, "Must be 01/01/2017"),
-	CPC_PERFORMANCE_PERIOD_END_DEC312017(56, "Must be 12/31/2017"),
+	CPC_PERFORMANCE_PERIOD_START_JAN12017(55, "A CPC Plus Performance period start must be 01/01/2017. "
+			+ "Please refer to the IG for more information here: " +DocumentationReference.CPC_PLUS_SUBMISSIONS),
+	CPC_PERFORMANCE_PERIOD_END_DEC312017(56, "A CPC Plus Performance period end must be 12/31/2017. "
+			+ "Please refer to the IG for more information here: " +DocumentationReference.CPC_PLUS_SUBMISSIONS),
 	QUALITY_MEASURE_ID_MISSING_SINGLE_MEASURE_POPULATION(57, "The measure reference results must have a single "
 			+ "measure population"),
 	QUALITY_MEASURE_ID_MISSING_SINGLE_MEASURE_TYPE(58, "The measure reference results must have a single "


### PR DESCRIPTION
### Information
- QPPCT-836 and QPPCT-837

### Changes proposed in this PR:
- CPC+ Performance period start and end error messages updated to reflect they are CPC+ submissions.
- Add a pointer to the IG for both errors.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
