### PR TITLE
Remove error code 38 and update error code 39

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -36,8 +36,7 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 35 : CT - One and only one Alternative Payment Model (APM) Entity Identifier should be specified. Here is a link to the IG section on identifiers: https://ecqi.healthit.gov/system/files/eCQM_QRDA_EC-508_0.pdf#page=15
 * 36 : CT - CPC+ submissions must contain one Measure section
 * 37 : CT - CPC+ submissions must contain correct number of performance rate(s). Correct Number is `(Expected value)` for measure `(Given measure id)`
-* 38 : CT - This ACI `(Numerator or Denominator)` element does not have any child elements
-* 39 : CT - This ACI `(Numerator or Denominator)` element must have exactly one Aggregate Count element
+* 39 : CT - This ACI `(Numerator or Denominator)` element has an incorrect number of Aggregate Count children. An ACI `(Numerator or Denominator)` must have exactly one Aggregate Count element
 * 41 : CT - This ACI `(Numerator or Denominator)` element Aggregate Value '`(value)`' is not an integer
 * 42 : CT - This ACI `(Numerator or Denominator)` element Aggregate Value has an invalid value of '`(value)`'
 * 43 : CT - The IA Section must have at least one Improvement Activity

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -88,10 +88,9 @@ public enum ErrorCode implements LocalizedError {
 	CPC_CLINICAL_DOCUMENT_ONE_MEASURE_SECTION_REQUIRED(36, "CPC+ submissions must contain one Measure section"),
 	CPC_QUALITY_MEASURE_ID_INVALID_PERFORMANCE_RATE_COUNT(37, "CPC+ submissions must contain correct number of performance rate(s). "
 			+ "Correct Number is `(Expected value)` for measure `(Given measure id)`", true),
-	NUMERATOR_DENOMINATOR_MISSING_CHILDREN(38,
-			"This ACI `(Numerator or Denominator)` element does not have any child elements", true),
 	NUMERATOR_DENOMINATOR_CHILD_EXACT(39,
-			"This ACI `(Numerator or Denominator)` element must have exactly one Aggregate Count element", true),
+			"This ACI `(Numerator or Denominator)` element has an incorrect number of Aggregate Count children. An ACI "
+			+ "`(Numerator or Denominator)` must have exactly one Aggregate Count element", true),
 	NUMERATOR_DENOMINATOR_MUST_BE_INTEGER(41,
 			"This ACI `(Numerator or Denominator)` element Aggregate Value '`(value)`' is not an integer", true),
 	NUMERATOR_DENOMINATOR_INVALID_VALUE(42,

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CommonNumeratorDenominatorValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CommonNumeratorDenominatorValidator.java
@@ -22,8 +22,7 @@ public class CommonNumeratorDenominatorValidator extends NodeValidator {
 	 */
 	@Override
 	protected void internalValidateSingleNode(Node node) {
-		check(node).hasChildren(format(ErrorCode.NUMERATOR_DENOMINATOR_MISSING_CHILDREN))
-				.childExact(format(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT), 1, TemplateId.ACI_AGGREGATE_COUNT);
+		check(node).childExact(format(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT), 1, TemplateId.ACI_AGGREGATE_COUNT);
 		if (getDetails().isEmpty()) {
 			validateAggregateCount(
 					node.findFirstNode(TemplateId.ACI_AGGREGATE_COUNT));
@@ -51,7 +50,7 @@ public class CommonNumeratorDenominatorValidator extends NodeValidator {
 	}
 
 	private LocalizedError format(ErrorCode error) {
-		return error.format(nodeName);
+		return error.format(nodeName, nodeName);
 	}
 
 	private LocalizedError format(ErrorCode error, String value) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/AciDenominatorValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/AciDenominatorValidatorTest.java
@@ -48,8 +48,8 @@ class AciDenominatorValidatorTest {
 
 		assertWithMessage("No Children Validation Error not issued")
 				.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_MISSING_CHILDREN.format(
-						AciDenominatorValidator.DENOMINATOR_NAME));
+				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT
+					.format(AciDenominatorValidator.DENOMINATOR_NAME, AciDenominatorValidator.DENOMINATOR_NAME));
 	}
 
 	@Test
@@ -66,7 +66,7 @@ class AciDenominatorValidatorTest {
 		assertWithMessage("Incorrect child Validation Error not issued")
 				.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT.format(
-						AciDenominatorValidator.DENOMINATOR_NAME));
+						AciDenominatorValidator.DENOMINATOR_NAME, AciDenominatorValidator.DENOMINATOR_NAME));
 
 	}
 
@@ -89,7 +89,7 @@ class AciDenominatorValidatorTest {
 		assertWithMessage("Too many children Validation Error not issued")
 				.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT.format(
-						AciDenominatorValidator.DENOMINATOR_NAME));
+						AciDenominatorValidator.DENOMINATOR_NAME, AciDenominatorValidator.DENOMINATOR_NAME));
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/AciNumeratorValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/AciNumeratorValidatorTest.java
@@ -49,7 +49,8 @@ class AciNumeratorValidatorTest {
 		assertWithMessage("Should result in Children Validation Error")
 				.that(errors)
 				.comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_MISSING_CHILDREN.format(AciNumeratorValidator.NUMERATOR_NAME));
+				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT
+					.format(AciNumeratorValidator.NUMERATOR_NAME, AciNumeratorValidator.NUMERATOR_NAME));
 	}
 
 	@Test
@@ -88,7 +89,7 @@ class AciNumeratorValidatorTest {
 		assertWithMessage("Too many children Validation Error not issued")
 				.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(ErrorCode.NUMERATOR_DENOMINATOR_CHILD_EXACT.format(
-						AciNumeratorValidator.NUMERATOR_NAME));
+						AciNumeratorValidator.NUMERATOR_NAME, AciNumeratorValidator.NUMERATOR_NAME));
 	}
 
 	@Test


### PR DESCRIPTION
### Information
- QPPCT-827

### Changes proposed in this PR:
- Removes error code 38 due to duplicate error messages
- Updates error code 39 with better messaging.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
