### PR TITLE
Now we don't want TIN in APM CPC+.

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -42,7 +42,6 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 43 : CT - The IA Section must have at least one Improvement Activity
 * 44 : CT - The IA Section must have one Reporting Parameter Act. Please ensure the Reporting Parameters Act complies with the Implementation Guide (IG). Here is a link to the IG Reporting Parameter Act section: https://ecqi.healthit.gov/system/files/2018_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG_v2_508.pdf#page=82
 * 45 : CT - The IA Section must contain only Improvement Activities and a Reporting Parameter Act
-* 46 : CT - Clinical Document Node must have a valid Tax Identification Number
 * 47 : CT - Clinical Document Node must have a valid National Provider Identifier
 * 48 : CT - Missing strata `(Reporting Stratum UUID)` for `(Current subpopulation type)` measure `(Current subpopulation UUID)`. Here is a link to the IG valid Measure Ids section: https://ecqi.healthit.gov/system/files/2018_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG_v2_508.pdf#page=94
 * 49 : CT - Amount of stratifications `(Current number of Reporting Stratifiers)` does not meet expectations `(Number of stratifiers required)` for `(Current subpopulation type)` measure `(Current Subpopulation UUID)`. Expected strata: `(Expected strata uuid list)`. Please refer to the Implementation Guide for correct stratification UUID's here: https://ecqi.healthit.gov/system/files/2018_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG_v2_508.pdf#page=94

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -100,7 +100,6 @@ public enum ErrorCode implements LocalizedError {
 			+ "Please ensure the Reporting Parameters Act complies with the Implementation Guide (IG). "
 			+ "Here is a link to the IG Reporting Parameter Act section: " + DocumentationReference.REPORTING_PARAMETERS_ACT),
 	IA_SECTION_WRONG_CHILD(45, "The IA Section must contain only Improvement Activities and a Reporting Parameter Act"),
-	TIN_INVALID_CLINICAL_DOCUMENT(46, "Clinical Document Node must have a valid Tax Identification Number"),
 	NPI_INVALID_CLINICAL_DOCUMENT(47, "Clinical Document Node must have a valid National Provider Identifier"),
 	CPC_QUALITY_MEASURE_ID_MISSING_STRATA(48, "Missing strata `(Reporting Stratum UUID)` for "
 			+ "`(Current subpopulation type)` measure `(Current subpopulation UUID)`. "

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
@@ -58,14 +58,17 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 		setProgramNameOnNode(element, thisNode);
 		setEntityIdOnNode(element, thisNode);
 		setPracticeSiteAddress(element, thisNode);
-		if (ENTITY_INDIVIDUAL.equals(thisNode.getValue(ENTITY_TYPE))
-			|| ENTITY_APM.equals(thisNode.getValue(ENTITY_TYPE))) {
+		String entityType = thisNode.getValue(ENTITY_TYPE);
+		if (ENTITY_INDIVIDUAL.equals(entityType)
+			|| ENTITY_APM.equals(entityType)) {
 			setNationalProviderIdOnNode(element, thisNode);
-		} else if (ENTITY_VIRTUAL_GROUP.equals(thisNode.getValue(ENTITY_TYPE))) {
+		} else if (ENTITY_VIRTUAL_GROUP.equals(entityType)) {
 			setVirtualGroupOnNode(element, thisNode);
 		}
 
-		setTaxProviderTaxIdOnNode(element, thisNode);
+		if (!ENTITY_APM.equals(entityType)) {
+			setTaxProviderTaxIdOnNode(element, thisNode);
+		}
 
 		return DecodeResult.TREE_CONTINUE;
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidator.java
@@ -48,8 +48,6 @@ public class CpcClinicalDocumentValidator extends NodeValidator {
 				.format(Context.REPORTING_YEAR);
 
 			check(node)
-					.valueRegex(ErrorCode.TIN_INVALID_CLINICAL_DOCUMENT,
-						ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER, TIN_REGEX)
 					.valueRegex(ErrorCode.NPI_INVALID_CLINICAL_DOCUMENT,
 						ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER, NPI_REGEX)
 					.valueIsNotEmpty(addressError, ClinicalDocumentDecoder.PRACTICE_SITE_ADDR)

--- a/converter/src/test/java/gov/cms/qpp/acceptance/CpcPlusRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/CpcPlusRoundTripTest.java
@@ -52,7 +52,7 @@ class CpcPlusRoundTripTest {
 	@Test
 	void hasNoInAppropriateTopLevelAttributes() {
 		assertThat(json.keySet()).containsExactly("entityId", "entityType", "measurementSets",
-			"performanceYear", "nationalProviderIdentifier", "taxpayerIdentificationNumber");
+			"performanceYear", "nationalProviderIdentifier");
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidatorTest.java
@@ -49,18 +49,6 @@ class CpcClinicalDocumentValidatorTest {
 	}
 
 	@Test
-	void validTinExistence() {
-		Node clinicalDocumentNode = createValidCpcPlusClinicalDocument();
-		clinicalDocumentNode.removeValue(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER);
-		cpcValidator.internalValidateSingleNode(clinicalDocumentNode);
-		Set<Detail> errors = cpcValidator.getDetails();
-
-		assertWithMessage("Must NPI error")
-			.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.containsExactly(ErrorCode.TIN_INVALID_CLINICAL_DOCUMENT);
-	}
-
-	@Test
 	void validNPIExistence() {
 		Node clinicalDocumentNode = createValidCpcPlusClinicalDocument();
 		clinicalDocumentNode.removeValue(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER);
@@ -70,19 +58,6 @@ class CpcClinicalDocumentValidatorTest {
 		assertWithMessage("Must TIN error")
 			.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 			.containsExactly(ErrorCode.NPI_INVALID_CLINICAL_DOCUMENT);
-	}
-
-	@ParameterizedTest
-	@ValueSource(strings = {"9900000999", "99000009"})
-	void failInvalidTINs(String value) {
-		Node clinicalDocumentNode = createValidCpcPlusClinicalDocument();
-		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER, value);
-		cpcValidator.internalValidateSingleNode(clinicalDocumentNode);
-		Set<Detail> errors = cpcValidator.getDetails();
-
-		assertWithMessage("Invalid TIN error")
-			.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.containsExactly(ErrorCode.TIN_INVALID_CLINICAL_DOCUMENT);
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
### Changes proposed in this PR:
- Removes TIN from apm cpc+

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
