### PR TITLE
Fix ERROR_MESSAGES.md written in converter project dir.

### DIFF
--- a/generate/pom.xml
+++ b/generate/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.2</version>
+            	<version>3.5.2</version> <!-- 3.5.3 is not available -->
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
@@ -48,26 +48,19 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.3</version>
+            <version>${maven.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.5.2</version>
-            <scope>provided</scope>
         </dependency>
 
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>2.2.1</version>
-		    <exclusions>
-		        <exclusion>
-		            <groupId>*</groupId>
-		            <artifactId>*</artifactId>
-		        </exclusion>
-		    </exclusions>			
+			<artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
 		</dependency>
 
         <dependency>
@@ -75,6 +68,37 @@
             <artifactId>commons</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter-engine</artifactId>
+		    <scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		    <scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.truth</groupId>
+			<artifactId>truth</artifactId>
+		    <scope>test</scope>
+		</dependency>
+        
+        <dependency>
+		    <groupId>org.junit.platform</groupId>
+		    <artifactId>junit-platform-launcher</artifactId>
+		    <scope>test</scope>
+		</dependency>
+		
     </dependencies>
 
 </project>

--- a/generate/pom.xml
+++ b/generate/pom.xml
@@ -58,6 +58,18 @@
             <scope>provided</scope>
         </dependency>
 
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-project</artifactId>
+			<version>2.2.1</version>
+		    <exclusions>
+		        <exclusion>
+		            <groupId>*</groupId>
+		            <artifactId>*</artifactId>
+		        </exclusion>
+		    </exclusions>			
+		</dependency>
+
         <dependency>
             <groupId>gov.cms.qpp.conversion</groupId>
             <artifactId>commons</artifactId>

--- a/generate/src/main/java/gov/cms/qpp/generator/ErrorCodeDocumentationGenerator.java
+++ b/generate/src/main/java/gov/cms/qpp/generator/ErrorCodeDocumentationGenerator.java
@@ -8,11 +8,14 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.MavenProject;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @Mojo(name = "generateErrorCodeDoc")
 public class ErrorCodeDocumentationGenerator extends AbstractMojo {
@@ -21,7 +24,7 @@ public class ErrorCodeDocumentationGenerator extends AbstractMojo {
 		MustacheFactory mf = new DefaultMustacheFactory();
 		Mustache mdTemplate = mf.compile("error-code/error-code-tempate.md");
 
-		try (FileWriter fw = new FileWriter("./ERROR_MESSAGES.md")) {
+		try (FileWriter fw = new FileWriter(args[0] + "ERROR_MESSAGES.md")) {
 			List<ErrorCode> errorCodes = Arrays.asList(ErrorCode.values());
 			mdTemplate.execute(fw, errorCodes).flush();
 			fw.flush();
@@ -30,9 +33,33 @@ public class ErrorCodeDocumentationGenerator extends AbstractMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		String parentDir = "";
+		
 		try {
 			getLog().info("Running Error Code documentation plugin");
-			ErrorCodeDocumentationGenerator.main();
+			
+			@SuppressWarnings("rawtypes")
+			Map context = getPluginContext();
+			MavenProject project = (MavenProject) context.get("project");
+			MavenProject parent = project.getParent();
+			
+			if (parent != null) {
+				String parentPath = parent.getBasedir().getAbsolutePath();
+				String workingDir = new File(".").getAbsolutePath();
+				workingDir = workingDir.substring(0, workingDir.length() - 2);
+				
+				if (parentPath.equals(workingDir)) {
+					// when the working dir is the parent project dir, use the working dir
+					parentDir = "./";
+				} else {
+					// when the working dir is the subproject dir, use the parent dir
+					// this ensure the error messages file is written to the parent project dir
+					parentDir = "../"; 
+				}
+			}
+			getLog().info("Parent project work directory offset " + parentDir);
+			
+			ErrorCodeDocumentationGenerator.main(parentDir.toString());
 		} catch (IOException e) {
 			throw new MojoExecutionException("Error code documentation problems", e);
 		}

--- a/generate/src/main/java/gov/cms/qpp/generator/ErrorCodeDocumentationGenerator.java
+++ b/generate/src/main/java/gov/cms/qpp/generator/ErrorCodeDocumentationGenerator.java
@@ -46,7 +46,7 @@ public class ErrorCodeDocumentationGenerator extends AbstractMojo {
 		}
 	}
 
-	private String determinOffsetPath() {
+	protected String determinOffsetPath() {
 		// raw types used in legacy maven plugin API
 		@SuppressWarnings("rawtypes")
 		Map context = getPluginContext();
@@ -57,8 +57,7 @@ public class ErrorCodeDocumentationGenerator extends AbstractMojo {
 		
 		if (parent != null) {
 			String parentPath = parent.getBasedir().getAbsolutePath();
-			String workingDir = new File(".").getAbsolutePath();
-			workingDir = workingDir.substring(0, workingDir.length() - 2);
+			String workingDir = System.getProperty("user.dir");
 			
 			if (parentPath.equals(workingDir)) {
 				// when the working dir is the parent project dir, use the working dir

--- a/generate/src/test/java/gov/cms/qpp/generator/ErrorCodeDocumentationGeneratorTest.java
+++ b/generate/src/test/java/gov/cms/qpp/generator/ErrorCodeDocumentationGeneratorTest.java
@@ -1,0 +1,77 @@
+package gov.cms.qpp.generator;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class ErrorCodeDocumentationGeneratorTest {
+	
+	ErrorCodeDocumentationGenerator gen;
+	
+	@BeforeEach
+	protected void setUp() throws Exception {
+		gen = new ErrorCodeDocumentationGenerator();
+	}
+	
+	@Test
+	public void test_determinOffsetPath_doubledot() {
+		String workingDir = System.getProperty("user.dir");
+		File mockBaseDir = new File(workingDir);
+
+		String generate = "/generate";
+		File mockParentDir = new File(workingDir.substring(0, workingDir.length()-generate.length()));
+		MavenProject mockParentProject = mock(MavenProject.class);
+		when(mockParentProject.getBasedir()).thenReturn(mockParentDir);
+
+		MavenProject mockProject = mock(MavenProject.class);
+		when(mockProject.getBasedir()).thenReturn(mockBaseDir);
+		when(mockProject.getParent()).thenReturn(mockParentProject);
+
+		Map<String, Object> mockContext = new HashMap<>();
+		mockContext.put("project", mockProject);
+		gen.setPluginContext(mockContext);
+		
+		String expected = "../";
+		String actual = gen.determinOffsetPath();
+		
+		assertWithMessage("When the working directory is the subproject then use the parent dir.")
+			.that(actual).isEqualTo(expected);
+	}
+	
+	@Test
+	public void test_determinOffsetPath_dot() {
+		String workingDir = System.getProperty("user.dir");
+		File mockBaseDir = new File(workingDir);
+		
+		String generate = "/generate";
+		workingDir = workingDir.substring(0, workingDir.length()-generate.length());
+		System.setProperty("user.dir", workingDir);
+		
+		File mockParentDir = new File(workingDir);
+		MavenProject mockParentProject = mock(MavenProject.class);
+		when(mockParentProject.getBasedir()).thenReturn(mockParentDir);
+
+		MavenProject mockProject = mock(MavenProject.class);
+		when(mockProject.getBasedir()).thenReturn(mockBaseDir);
+		when(mockProject.getParent()).thenReturn(mockParentProject);
+
+		Map<String, Object> mockContext = new HashMap<>();
+		mockContext.put("project", mockProject);
+		gen.setPluginContext(mockContext);
+		
+		String expected = "./";
+		String actual = gen.determinOffsetPath();
+		
+		assertWithMessage("When the working directory is the parent project then use the working dir.")
+			.that(actual).isEqualTo(expected);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 		<powermock.version>1.7.4</powermock.version>
 		<junit.excludes>integration, acceptance</junit.excludes>
 		<junit.includes></junit.includes>
+		<maven.version>3.5.3</maven.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION

### Information
- The generate maven plugin writes in the working dir even if that dir is the converter project.

### Changes proposed in this PR:
- ErrorCodeDocumentationGenerator now checks the working dir compared to the parent project path and creates an appropriate path modifier to compensate for running in either the parent project or the converter project.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [-] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
