### PR TITLE
fix npe when APM is invalid

### DIFF
--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
@@ -23,8 +23,10 @@ public class SpecPiiValidator implements PiiValidator {
 		String npi = node.getValue(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER);
 
 		CpcValidationInfo spec = file.getApmToSpec().get(apm);
-		if (spec.getNpi() != null) {
-			if (!spec.getNpi().equalsIgnoreCase(npi)) {
+		if (spec == null) {
+			validator.addWarning(Detail.forErrorAndNode(ErrorCode.INCORRECT_API_NPI_COMBINATION, node));
+		} else {
+			if (spec.getNpi() != null && !spec.getNpi().equalsIgnoreCase(npi)) {
 				validator.addWarning(Detail.forErrorAndNode(ErrorCode.INCORRECT_API_NPI_COMBINATION, node));
 			}
 		}

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
@@ -42,6 +42,19 @@ public class SpecPiiValidatorTest {
 		Truth.assertThat(nodeValidator.viewWarnings()).isNotEmpty();
 	}
 
+	@Test
+	void testNullSpec() throws  Exception{
+		SpecPiiValidator validator = validator("Valid_DogCow_APM", "Valid_DogCow_NPI");
+		Node node = node("invalid", "Invalid_Entered_DogCow_NPI");
+		NodeValidator nodeValidator = new NodeValidator() {
+			@Override
+			protected void performValidation(Node node) {
+			}
+		};
+		validator.validateApmNpiCombination(node, nodeValidator);
+		Truth.assertThat(nodeValidator.viewWarnings()).isNotEmpty();
+	}
+
 	private SpecPiiValidator validator(String apm, String npi) throws Exception {
 		return new SpecPiiValidator(createSpecFile(apm, npi));
 	}

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
@@ -43,7 +43,7 @@ public class SpecPiiValidatorTest {
 	}
 
 	@Test
-	void testNullSpec() throws  Exception{
+	void testNullSpec() throws  Exception {
 		SpecPiiValidator validator = validator("Valid_DogCow_APM", "Valid_DogCow_NPI");
 		Node node = node("invalid", "Invalid_Entered_DogCow_NPI");
 		NodeValidator nodeValidator = new NodeValidator() {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fix for NPE on CPC+ warning validation with invalid APM

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
