### PR TITLE
Fix for APM entity encoding unwanted NPI's

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
@@ -56,10 +56,12 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 
 		encodePerformanceYear(wrapper, thisNode);
 		wrapper.putString(ClinicalDocumentDecoder.ENTITY_TYPE, entityType);
+		if (!ClinicalDocumentDecoder.ENTITY_APM.equals(entityType)) {
+			wrapper.putString(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER,
+				thisNode.getValue(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER));
+		}
 		wrapper.putString(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER,
 				thisNode.getValue(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER));
-		wrapper.putString(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER,
-				thisNode.getValue(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER));
 
 		if (ClinicalDocumentDecoder.ENTITY_APM.equals(entityType)) {
 			wrapper.putString(ClinicalDocumentDecoder.ENTITY_ID,

--- a/converter/src/test/java/gov/cms/qpp/acceptance/CpcPlusRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/CpcPlusRoundTripTest.java
@@ -52,7 +52,7 @@ class CpcPlusRoundTripTest {
 	@Test
 	void hasNoInAppropriateTopLevelAttributes() {
 		assertThat(json.keySet()).containsExactly("entityId", "entityType", "measurementSets",
-			"performanceYear", "nationalProviderIdentifier");
+			"performanceYear");
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoderTest.java
@@ -228,6 +228,20 @@ class ClinicalDocumentEncoderTest {
 			.isEqualTo("x12345");
 	}
 
+	@Test
+	void testApmExcludeNpiEncoding() throws EncodeException {
+		JsonWrapper testJsonWrapper = new JsonWrapper();
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.ENTITY_TYPE, "apm");
+
+		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
+		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
+
+		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
+
+		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER))
+			.isNull();
+	}
+
 
 	@SuppressWarnings("unchecked")
 	private List<LinkedHashMap<String, Object>> getMeasurementSets(Map clinicalDocumentMap) {


### PR DESCRIPTION
### Changes proposed in this PR:
- APM was encoding NPI's. Excluding NPI when it is an APM entity

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
