### PR TITLE
QPPCT-1008 JsonWrapper Metadata Refactor

### DIFF
--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -157,7 +157,7 @@ public enum ErrorCode implements LocalizedError {
 	PERFORMANCE_RATE_MISSING(72, "The Performance Rate is missing"),
 	VIRTUAL_GROUP_ID_REQUIRED(78, "The Program 'Mips Virtual Group' was found. The required entity id for this "
 		+ "program name was missing. Please provide a virtual group identifier with the 'Mips Virtual Group' program name."),
-	MISSING_PII_VALIDATOR(79, "There is no PII validator present, so NPI/Alternative Payment Model (APM) "
+	MISSING_PII_VALIDATOR(79, "There is no TIN validator present, so NPI/Alternative Payment Model (APM) "
 			+ "combinations cannot be verified"),
 	INCORRECT_API_NPI_COMBINATION(80, "The given National Provider (NPI) Identifier and Alternative Payment Model (APM) "
 			+ "are not a valid combination");

--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -111,5 +111,36 @@
 			<artifactId>cloning</artifactId>
 			<version>1.9.10</version>
 		</dependency>
+
+        <dependency>
+             <groupId>org.junit.jupiter</groupId>
+             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+             <scope>test</scope>
+         </dependency>
+         <dependency>
+             <groupId>org.junit.jupiter</groupId>
+             <artifactId>junit-jupiter-engine</artifactId>
+             <scope>test</scope>
+         </dependency>
+
+         <dependency>
+                 <groupId>org.mockito</groupId>
+                 <artifactId>mockito-core</artifactId>
+             <scope>test</scope>
+         </dependency>
+
+         <dependency>
+                 <groupId>com.google.truth</groupId>
+                 <artifactId>truth</artifactId>
+             <scope>test</scope>
+         </dependency>
+
+        <dependency>
+             <groupId>org.junit.platform</groupId>
+             <artifactId>junit-platform-launcher</artifactId>
+             <scope>test</scope>
+         </dependency>
+
 	</dependencies>
 </project>

--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -63,6 +63,13 @@
 
 	<dependencies>
 		<dependency>
+		    <groupId>com.google.code.findbugs</groupId>
+		    <artifactId>annotations</artifactId>
+		    <version>3.0.1</version>
+		    <scope>compile</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.4</version>

--- a/converter/src/main/java/gov/cms/qpp/conversion/correlation/PathCorrelator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/correlation/PathCorrelator.java
@@ -113,9 +113,8 @@ public class PathCorrelator {
 	public static String getXpath(String base, String attribute, String uri) {
 		String key = PathCorrelator.getKey(base, attribute);
 		Goods goods = pathCorrelationMap.get(key);
-		return (goods == null) 
-				? null
-				: goods.getRelativeXPath().replace(uriSubstitution, uri);
+		return (goods == null) ? null :
+				goods.getRelativeXPath().replace(uriSubstitution, uri);
 	}
 
 	/**
@@ -161,13 +160,9 @@ public class PathCorrelator {
 				.sorted(labeledFirst())
 				.filter(entry -> {
 					String encodeLabel = entry.get(ENCODE_LABEL);
-					if ( encodeLabel.equals(leaf) ) {
-						if ( ! leaf.isEmpty() ) {
-							String template = entry.get("template");
-							String nsuri = entry.get("nsuri");
-							return PathCorrelator.getXpath(template, leaf, nsuri) != null;
-						}
-						return true;
+					if (encodeLabel.equals(leaf)) {
+						return leaf.isEmpty()
+								|| PathCorrelator.getXpath(entry.get("template"), leaf, entry.get("nsuri")) != null;
 					}
 					return encodeLabel.isEmpty();
 				})
@@ -190,36 +185,6 @@ public class PathCorrelator {
 		};
 	}
 
-/*	// TODO asdf del
-	private static JsonWrapper getMetaMap(JsonWrapper wrapper, final String leaf) {
-		JsonWrapper metaHolder = wrapper.getMetadata();
-		return metaHolder.stream()
-				.sorted(labeledFirstWrapper())
-				.filter(wrapperEntry -> {
-					String encodeLabel = wrapperEntry.getString(ENCODE_LABEL);
-					if (encodeLabel.equals(leaf)) {
-						return leaf.isEmpty()
-								|| PathCorrelator.getXpath(
-										wrapperEntry.getString("template"), leaf, wrapperEntry.getString("nsuri")) != null;
-					}
-					return encodeLabel.isEmpty();
-				})
-				.findFirst()
-				.orElse(null);
-	}
-	private static Comparator<JsonWrapper> labeledFirstWrapper() {
-		return (JsonWrapper jw1, JsonWrapper jw2) -> {
-			String label1 = jw1.getString(ENCODE_LABEL);
-			String label2 = jw1.getString(ENCODE_LABEL);
-			
-			return Boolean.compare(label1.isEmpty(), label2.isEmpty());
-		};
-	}
-
- */
-	
-	
-	
 	/**
 	 * Assemble base xpath with a relative xpath that identifies a leaf json attribute.
 	 *

--- a/converter/src/main/java/gov/cms/qpp/conversion/correlation/PathCorrelator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/correlation/PathCorrelator.java
@@ -1,24 +1,25 @@
 package gov.cms.qpp.conversion.correlation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.jsonpath.JsonPath;
-import gov.cms.qpp.conversion.correlation.model.CorrelationConfig;
-import gov.cms.qpp.conversion.correlation.model.Correlation;
-import gov.cms.qpp.conversion.correlation.model.Goods;
-import gov.cms.qpp.conversion.correlation.model.PathCorrelation;
-import gov.cms.qpp.conversion.encode.JsonWrapper;
-import org.reflections.util.ClasspathHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.reflections.util.ClasspathHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+
+import gov.cms.qpp.conversion.correlation.model.Correlation;
+import gov.cms.qpp.conversion.correlation.model.CorrelationConfig;
+import gov.cms.qpp.conversion.correlation.model.Goods;
+import gov.cms.qpp.conversion.correlation.model.PathCorrelation;
+import gov.cms.qpp.conversion.encode.JsonWrapper;
 
 /**
  * Maintains associations between QPP json paths and their pre-transformation xpaths.
@@ -26,7 +27,6 @@ import java.util.stream.Collectors;
 public class PathCorrelator {
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(PathCorrelator.class);
 	public static final String KEY_DELIMITER = "#";
-	private static final String ENCODE_LABEL = "encodeLabel";
 	private static String config = "pathing/path-correlation.json";
 	private static Map<String, Goods> pathCorrelationMap = new HashMap<>();
 	private static String uriSubstitution = "";
@@ -159,7 +159,7 @@ public class PathCorrelator {
 		return metaHolder.stream()
 				.sorted(labeledFirst())
 				.filter(entry -> {
-					String encodeLabel = entry.get(ENCODE_LABEL);
+					String encodeLabel = entry.get(JsonWrapper.ENCODING_KEY);
 					if (encodeLabel.equals(leaf)) {
 						return leaf.isEmpty()
 								|| PathCorrelator.getXpath(entry.get("template"), leaf, entry.get("nsuri")) != null;
@@ -178,8 +178,8 @@ public class PathCorrelator {
 	 */
 	private static Comparator<Map<String, String>> labeledFirst() {
 		return (Map<String, String> map1, Map<String, String> map2) -> {
-			String map1Label = map1.get(ENCODE_LABEL);
-			String map2Label = map2.get(ENCODE_LABEL);
+			String map1Label = map1.get(JsonWrapper.ENCODING_KEY);
+			String map2Label = map2.get(JsonWrapper.ENCODING_KEY);
 			
 			return Boolean.compare(map1Label.isEmpty(), map2Label.isEmpty());
 		};

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
@@ -40,9 +40,8 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 		Map<TemplateId, Node> childMapByTemplateId = thisNode.getChildNodes().stream().collect(
 				Collectors.toMap(Node::getType, Function.identity(), (v1, v2) -> v1, LinkedHashMap::new));
 
-		JsonWrapper measurementSets =
-			encodeMeasurementSets(childMapByTemplateId);
-		wrapper.putObject(MEASUREMENT_SETS, measurementSets);
+		JsonWrapper measurementSets = encodeMeasurementSets(childMapByTemplateId);
+		wrapper.put(MEASUREMENT_SETS, measurementSets);
 	}
 
 	/**
@@ -55,21 +54,21 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 		String entityType = thisNode.getValue(ClinicalDocumentDecoder.ENTITY_TYPE);
 
 		encodePerformanceYear(wrapper, thisNode);
-		wrapper.putString(ClinicalDocumentDecoder.ENTITY_TYPE, entityType);
+		wrapper.put(ClinicalDocumentDecoder.ENTITY_TYPE, entityType);
 		if (!ClinicalDocumentDecoder.ENTITY_APM.equals(entityType)) {
-			wrapper.putString(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER,
+			wrapper.put(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER,
 				thisNode.getValue(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER));
 		}
-		wrapper.putString(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER,
+		wrapper.put(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER,
 				thisNode.getValue(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER));
 
 		if (ClinicalDocumentDecoder.ENTITY_APM.equals(entityType)) {
-			wrapper.putString(ClinicalDocumentDecoder.ENTITY_ID,
+			wrapper.put(ClinicalDocumentDecoder.ENTITY_ID,
 				thisNode.getValue(ClinicalDocumentDecoder.PRACTICE_ID));
 		}
 
 		if (ClinicalDocumentDecoder.ENTITY_VIRTUAL_GROUP.equals(entityType)) {
-			wrapper.putString(ClinicalDocumentDecoder.ENTITY_ID,
+			wrapper.put(ClinicalDocumentDecoder.ENTITY_ID,
 				thisNode.getValue(ClinicalDocumentDecoder.ENTITY_ID));
 		}
 	}
@@ -108,7 +107,7 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 				childWrapper = new JsonWrapper();
 				sectionEncoder = encoders.get(childType);
 				sectionEncoder.encode(childWrapper, child);
-				measurementSetsWrapper.putObject(childWrapper);
+				measurementSetsWrapper.put(childWrapper);
 			} catch (NullPointerException exc) {
 				String message = "An unexpected error occured for " + child.getType();
 				throw new EncodeException(message, exc);

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
@@ -24,7 +24,7 @@ public class IaMeasureEncoder extends QppOutputEncoder {
 	 */
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
-		wrapper.putObject("measureId", node.getValue("measureId"));
+		wrapper.put("measureId", node.getValue("measureId"));
 
 		Node measurePerformedNode = node.findFirstNode(TemplateId.MEASURE_PERFORMED);
 
@@ -36,7 +36,7 @@ public class IaMeasureEncoder extends QppOutputEncoder {
 			maintainContinuity(wrapper, measurePerformedNode, VALUE);
 
 			if (null != value.getBoolean(VALUE)) {
-				wrapper.putObject(VALUE, value.getBoolean(VALUE));
+				wrapper.put(VALUE, value.getBoolean(VALUE));
 			}
 		}
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/IaMeasureEncoder.java
@@ -35,7 +35,7 @@ public class IaMeasureEncoder extends QppOutputEncoder {
 			measurePerformedEncoder.encode(value, measurePerformedNode);
 			maintainContinuity(wrapper, measurePerformedNode, VALUE);
 
-			if (null != value.getBoolean(VALUE)) {
+			if (null != value.getBoolean(VALUE)) { // TODO asdf have the wrapper check for nulls?
 				wrapper.put(VALUE, value.getBoolean(VALUE));
 			}
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonOutputEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonOutputEncoder.java
@@ -61,7 +61,7 @@ public abstract class JsonOutputEncoder implements OutputEncoder {
 	public void encode(JsonWrapper wrapper, Node node, boolean mergeMetadata) {
 		try {
 			internalEncode(wrapper, node);
-			if (mergeMetadata && wrapper.isObject()) {
+			if (mergeMetadata && wrapper.isMap()) {
 				wrapper.attachMetadata(node);
 			}
 		} catch (EncodeException exception) {

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -540,7 +540,7 @@ public class JsonWrapper {
 	 * @return <i><b>this</b></i> reference for chaining
 	 */
 	public JsonWrapper put(String name, JsonWrapper value) {
-		checkState(childrenList);
+		checkListState();
 		if (checkState(value)) {
 			value.keyForMapStream = name;
 			childrenMap.put(name, value);
@@ -559,7 +559,7 @@ public class JsonWrapper {
 	 * @return <i><b>this</b></i> reference for chaining
 	 */
 	public JsonWrapper put(JsonWrapper value) { // TODO asdf maybe refactor to add(JsW)?
-		checkState(childrenMap);
+		checkMapState();
 		if (checkState(value)) {
 			childrenList.add(value);
 			type = Type.LIST;
@@ -725,13 +725,13 @@ public class JsonWrapper {
 	 *
 	 * @param check should be null
 	 */
-	protected void checkState(Map<String, JsonWrapper> map) {
-		if ( ! map.isEmpty()) { // TODO asdf use of type state might work too
+	protected void checkMapState() {
+		if (isType(Type.MAP)) {
 			throw new IllegalStateException("Current state may not change (from object to list).");
 		}
 	}
-	protected void checkState(List<JsonWrapper> list) {
-		if ( ! list.isEmpty() ) { // TODO asdf use of type state might work too
+	protected void checkListState() {
+		if (isType(Type.LIST)) {
 			throw new IllegalStateException("Current state may not change (from list to object).");
 		}
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -953,7 +953,7 @@ public class JsonWrapper {
 		if (node.getColumn() != Node.DEFAULT_LOCATION_NUMBER) {
 			metadata.put("column", String.valueOf(node.getColumn()));
 		}
-		addMetaMap(metadata);
+		addMetadata(metadata);
 	}
 
 	public JsonWrapper getMetadata() {
@@ -968,16 +968,21 @@ public class JsonWrapper {
 			if (isMetadata()) {
 				put(other);
 			} else {
-				addMetaMap(other);
+				addMetadata(other);
 			}
 		});
 	}
 
-	public void addMetaMap(JsonWrapper metadata) { // TODO asdf refator name
+	public void addMetadata(JsonWrapper metadata) {
 		this.metadata.put(metadata.isKind(Kind.METADATA) ?metadata :metadata.metadata);
 	}
 
-	public void putMetadata(String name, String value) { // TODO asdf check consistent with other metadata actions
+	/**
+	 * add a metadata key pair to the current JsonWrapper
+	 * @param name the metadata name
+	 * @param value the metadata value
+	 */
+	public void putMetadata(String name, String value) {
 		metadata.put(name, value);
 	}
 	

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -730,11 +730,21 @@ public class JsonWrapper {
 			throw new IllegalStateException("Current state may not change (from object to list).");
 		}
 	}
+	/**
+	 * Helps enforce the initialized representation of the {@link JsonWrapper} as a hash or an array.
+	 *
+	 * @param check should be null
+	 */
 	protected void checkListState() {
 		if (isType(Type.LIST)) {
 			throw new IllegalStateException("Current state may not change (from list to object).");
 		}
 	}
+	/**
+	 * Helps enforce no null or empty values added to a {@link JsonWrapper}.
+	 *
+	 * @param check should be null
+	 */
 	protected boolean checkState(JsonWrapper wrapper) { // TODO asdf exhaustive unit test coverage
 		if (wrapper == null) { // no null entries
 			return false;
@@ -753,8 +763,16 @@ public class JsonWrapper {
 		}
 		return true; // must be good if we made it through the gauntlet
 	}
+	/**
+	 * Helps prevent duplicate entries. It is not sure why duplicates are added. 
+	 * The decoders seem to try and this prevents it without without changing decoder code.
+	 * This does not check higher level parents and deeper children. 
+	 * TODO it could recursively check children.
+	 * 
+	 * @param wrapper
+	 * @return
+	 */
 	public boolean isDuplicateEntry(JsonWrapper wrapper) {
-		// TODO asdf this does not check higher level parents and deeper children but it could if we need it.
 		boolean duplicate = wrapper == this || childrenList.contains(wrapper) && childrenMap.values().contains(wrapper);
 		if ( duplicate ) {
 			throw new UnsupportedOperationException("May not add parent to itself nor a child more than once.");
@@ -764,7 +782,7 @@ public class JsonWrapper {
 	}
 
 	/**
-	 * Identifies whether or not the {@link JsonWrapper}'s content is a hash or array.
+	 * Identifies whether or not the {@link JsonWrapper}'s content is a JSON hash.
 	 *
 	 * @return boolean is this a JSON object
 	 */
@@ -774,18 +792,38 @@ public class JsonWrapper {
 		}
 		return isType(Type.MAP);
 	}
+	/**
+	 * Identifies whether or not the {@link JsonWrapper}'s content is a JSON array.
+	 *
+	 * @return boolean is this a JSON array
+	 */
 	public boolean isList() {
 		if (type == Type.UNKNOWN) { // TODO asdf if type is unknown or list might be good 
 			return isKind(Kind.OBJECT) && ! childrenList.isEmpty() && childrenMap.isEmpty();
 		}
 		return isType(Type.LIST);
 	}
+	/**
+	 * Identifies whether or not the {@link JsonWrapper}'s content is a JSON value (leaf).
+	 *
+	 * @return boolean is this a JSON value
+	 */
 	public boolean isValue() {
 		return isKind(Kind.VALUE) && value != null;
 	}
+	/**
+	 * Identifies whether or not the {@link JsonWrapper}'s content IS metadata.
+	 *
+	 * @return boolean is this metadata
+	 */
 	public boolean isMetadata() {
 		return isKind(Kind.METADATA);
 	}
+	/**
+	 * Identifies whether or not the {@link JsonWrapper}'s content HAS metadata.
+	 *
+	 * @return boolean true if this has metadata.
+	 */
 	public boolean hasMetadata() {
 		return metadata!=null && (metadata.isObject() || metadata.isList());
 	}
@@ -814,9 +852,9 @@ public class JsonWrapper {
 	}
 
 	/**
-	 * String representation of the {@link JsonWrapper}.
+	 * Valid JSON String representation of the {@link JsonWrapper}.
 	 *
-	 * @return
+	 * @return JSON
 	 */
 	@Override
 	public String toString() {
@@ -826,6 +864,12 @@ public class JsonWrapper {
 			throw new EncodeException("Issue rendering JSON from JsonWrapper Map", e);
 		}
 	}
+	/**
+	 * Valid JSON String representation of the {@link JsonWrapper} 
+	 * with its metadata in metadata_holder hash key.
+	 *
+	 * @return JSON with metadata
+	 */
 	public String toStringWithMetadata() {
 		try {
 			return withMetadataWriter.writeValueAsString(this);

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.jayway.jsonpath.JsonPath;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import gov.cms.qpp.conversion.InputStreamSupplierSource;
 import gov.cms.qpp.conversion.Source;
 import gov.cms.qpp.conversion.model.Node;
@@ -39,11 +40,12 @@ public class JsonWrapper {
 	public static enum Kind {
 		CONTAINER, VALUE, METADATA;
 	}
+	
 	public static enum Type {
 		BOOLEAN {
 			public void json(JsonWrapper value, JsonGenerator gen) throws IOException {
 				if (hasValue(value)) {
-					gen.writeBoolean( Boolean.parseBoolean(value.toObject().toString()));
+					gen.writeBoolean(Boolean.parseBoolean(value.toObject().toString()));
 				}
 			}
 		}, DATE {
@@ -53,19 +55,19 @@ public class JsonWrapper {
 		}, INTEGER {
 			public void json(JsonWrapper value, JsonGenerator gen) throws IOException {
 				if (hasValue(value)) {
-					gen.writeNumber( Integer.parseInt(value.toObject().toString()));
+					gen.writeNumber(Integer.parseInt(value.toObject().toString()));
 				}
 			}
 		}, FLOAT {
 			public void json(JsonWrapper value, JsonGenerator gen) throws IOException {
 				if (hasValue(value)) {
-					gen.writeNumber( Float.parseFloat(value.toObject().toString()));
+					gen.writeNumber(Float.parseFloat(value.toObject().toString()));
 				}
 			}
 		}, STRING {
 			public void json(JsonWrapper value, JsonGenerator gen) throws IOException {
 				if (hasValue(value)) {
-					gen.writeString( value.toObject().toString() );
+					gen.writeString(value.toObject().toString());
 				}
 			}
 		}, MAP {
@@ -74,12 +76,13 @@ public class JsonWrapper {
 					gen.writeObject(value.toObject());
 				}
 			}
+			
 			public void metadata(JsonWrapper value, JsonGenerator gen) throws IOException {
 				gen.writeStartObject();
 				if (value.hasMetadata()) {
 					gen.writeObjectField(METADATA_HOLDER, value.getMetadata());
 				}
-				value.stream().forEach( entry -> {
+				value.stream().forEach(entry -> {
 					try {
 						gen.writeObjectField(entry.getKey(), entry);
 					} catch (IOException e) {
@@ -94,12 +97,13 @@ public class JsonWrapper {
 					gen.writeObject(value.toObject());
 				}
 			}
+			
 			public void metadata(JsonWrapper value, JsonGenerator gen) throws IOException {
 				gen.writeStartArray();
 				if (value.hasMetadata()) {
 					gen.writeObject(value.getMetadata());
 				}
-	            value.stream().forEach( entry ->{
+	            value.stream().forEach(entry -> {
 	                try {
 						gen.writeObject(entry);
 					} catch (IOException e) {
@@ -116,6 +120,7 @@ public class JsonWrapper {
 		}
 		
 		public void json(JsonWrapper value, JsonGenerator gen) throws IOException {}
+		
 		public void metadata(JsonWrapper value, JsonGenerator gen) throws IOException{}
 		
 	}
@@ -155,6 +160,7 @@ public class JsonWrapper {
 			}				
 		}
 	}
+	
 	/**
 	 * Custom JsonWrapper serialization logic to handle the metadata and type handling. 
 	 * This subclass also processes the metadata.
@@ -162,7 +168,7 @@ public class JsonWrapper {
 	static class JsonWrapperMetadataSerilizer extends JsonWrapperSerilizer {
 		
 		protected void jsonContainer(JsonWrapper value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-			if ( value.hasMetadata() ) {
+			if (value.hasMetadata()) {
 				value.getType().metadata(value, gen);
 			} else {
 				super.jsonContainer(value, gen, provider);
@@ -188,6 +194,7 @@ public class JsonWrapper {
 	static ObjectWriter standardWriter() {
 		return jsonMapper.writer().with(standardPrinter());
 	}
+	
 	static ObjectWriter metadataWriter() {
 		return metaMapper.writer().with(standardPrinter());
 	}
@@ -204,19 +211,19 @@ public class JsonWrapper {
 	
 	/**
 	 * This is the key on the JsonWrapper that was used to store it in the parent wrapper.
-	 * This allows for a single streaming implementation and avoids reference to Map.Entity<K,V>
+	 * This allows for a single streaming implementation and avoids reference to Map.Entity&lt;K,V&gt;
 	 * 
 	 * It is set upon put(String name, JsonWrapper value) calls to emulate an entity.
 	 */
 	private String keyForMapStream;
 	
-
 	/**
 	 * Constructor for Json Container use. 
 	 */
 	public JsonWrapper() {
 		this(Kind.CONTAINER);
 	}
+	
 	/**
 	 * Cunstruct a JSON container for a given kind.
 	 * @param kind
@@ -233,8 +240,9 @@ public class JsonWrapper {
 		childrenList = new LinkedList<>();
 		
 		// no metadata on metadata
-		metadata = isMetadata() ?null :new JsonWrapper(Kind.METADATA);
+		metadata = isMetadata() ? null : new JsonWrapper(Kind.METADATA);
 	}
+	
 	/**
 	 * Construct a JSON container for a string value.
 	 * A string value is a leaf node.
@@ -249,18 +257,22 @@ public class JsonWrapper {
 		childrenList = null;
 		metadata = null;
 	}
+	
 	public JsonWrapper(Boolean value) {
 		this(value.toString());
 		type = Type.BOOLEAN;
 	}
+	
 	public JsonWrapper(Integer value) {
 		this(value.toString());
 		type = Type.INTEGER;
 	}
+	
 	public JsonWrapper(Float value) {
 		this(value.toString());
 		type = Type.FLOAT;
 	}
+	
 	/**
 	 * Construct a clone of the given JSON container.
 	 * @param wrapper
@@ -268,6 +280,7 @@ public class JsonWrapper {
 	public JsonWrapper(JsonWrapper wrapper) {
 		this(wrapper, true);
 	}
+	
 	/**
 	 * Construct a clone of the given JSON container 
 	 * with the option to omit the metadata. TODO might not be necessary.
@@ -299,9 +312,11 @@ public class JsonWrapper {
 	public Type getType() {
 		return type;
 	}
+	
 	public boolean isType(Type type) {
 		return this.type == type;
 	}
+	
 	JsonWrapper setType(Type type) {
 		this.type = type;
 		return this;
@@ -314,9 +329,11 @@ public class JsonWrapper {
 	public Kind getKind() {
 		return kind;
 	}
+	
 	public boolean isKind(Kind kind) {
 		return this.kind == kind;
 	}
+	
 	/**
 	 * @return The name used to store this entry in the parent.
 	 */
@@ -333,7 +350,7 @@ public class JsonWrapper {
 	 * @return chaining self ref
 	 */
 	public JsonWrapper clear() {
-		if ( ! isValue() ) {
+		if (!isValue()) {
 			childrenMap.clear();
 			childrenList.clear();
 			// metadata do not have metadata but are clearable wrappers.
@@ -356,6 +373,40 @@ public class JsonWrapper {
 		put(name, value, Type.STRING);
 		return this;
 	}
+	
+	/**
+	 * Places an named Integer within the map container wrapper.
+	 *
+	 * @param value to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(String name, Integer value) {
+		put(name, Integer.toString(value), Type.INTEGER);
+		return this;
+	}
+
+	/**
+	 * Places an named Float within the map container wrapper.
+	 *
+	 * @param value to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(String name, Float value) {
+		put(name, Float.toString(value), Type.FLOAT);
+		return this;
+	}
+	
+	/**
+	 * Places an named Boolean within the map container wrapper.
+	 *
+	 * @param value to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(String name, Boolean value) {
+		put(name, Boolean.toString(value), Type.BOOLEAN);
+		return this;
+	}
+
 
 	/**
 	 * Places an unnamed String within the list container wrapper.
@@ -365,6 +416,107 @@ public class JsonWrapper {
 	 */
 	public JsonWrapper put(String value) {
 		put(value, Type.STRING);
+		return this;
+	}
+	
+	/**
+	 * Places an unnamed Integer within the list container wrapper.
+	 *
+	 * @param value to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(Integer value) {
+		put(value.toString(), Type.INTEGER);
+		return this;
+	}
+	
+	/**
+	 * Places an unnamed Float within the list container wrapper.
+	 *
+	 * @param value to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(Float value) {
+		put(value.toString(), Type.FLOAT);
+		return this;
+	}
+	
+	/**
+	 * Places an unnamed Boolean within the list container wrapper.
+	 *
+	 * @param value to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(Boolean value) {
+		put(value.toString(), Type.BOOLEAN);
+		return this;
+	}
+
+	/**
+	 * Places an unnamed child wrapper within the wrapper.
+	 * Think of this as adding a JSON array entry.
+	 *
+	 * @param value item to place in wrapper
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(JsonWrapper value) {
+		checkMapState();
+		if (checkState(value)) {
+			childrenList.add(value);
+			type = Type.LIST;
+		}
+		return this;
+	}
+
+	/**
+	 * The master putter of MAP elements. They must specify the type.
+	 * The JSON values are all represented as strings because JSON is a string.
+	 * The type parameter is a sort of metadata about the entry for the
+	 * wrapper to know what data was stored for toString processing, 
+	 * format validation, and value fetching.
+	 * 
+	 * @param name
+	 * @param value
+	 * @param type
+	 */
+	private void put(String name, String value, Type type) {
+		JsonWrapper wrapper = new JsonWrapper(value);
+		wrapper.type = type;
+		put(name, wrapper);
+	}
+	
+	/**
+	 * The master putter of LIST elements. They must specify the type.
+	 * The JSON values are all represented as strings because JSON is a string.
+	 * The type parameter is a sort of metadata about the entry for the
+	 * wrapper to know what data was stored for toString processing, 
+	 * format validation, and value fetching.
+	 * 
+	 * @param value
+	 * @param type
+	 */
+	private void put(String value, Type type) {
+		JsonWrapper wrapper = new JsonWrapper(value);
+		wrapper.type = type;
+		put(wrapper);
+	}
+			
+	/**
+	 * Places a named child wrapper within the wrapper.
+	 *
+	 * Think of this as adding an attribute to a JSON hash.
+	 *
+	 * @param name key for value
+	 * @param value keyed value
+	 * @return <i><b>this</b></i> reference for chaining
+	 */
+	public JsonWrapper put(String name, JsonWrapper value) {
+		checkListState();
+		if (checkState(value)) {
+			value.keyForMapStream = name;
+			childrenMap.put(name, value);
+			type = Type.MAP;
+		}
 		return this;
 	}
 
@@ -417,10 +569,6 @@ public class JsonWrapper {
 		}
 		return this;
 	}
-	public JsonWrapper put(String name, Integer value) {
-		put(name, Integer.toString(value), Type.INTEGER);
-		return this;
-	}
 
 	/**
 	 * Places an unnamed String that represents a {@link java.lang.Integer} within the wrapper.
@@ -437,11 +585,7 @@ public class JsonWrapper {
 		}
 		return this;
 	}
-	public JsonWrapper put(Integer value) {
-		put(value.toString(), Type.INTEGER);
-		return this;
-	}
-
+	
 	/**
 	 * Places an named String that represents a {@link java.lang.Float} within the wrapper.
 	 *
@@ -456,10 +600,6 @@ public class JsonWrapper {
 			put(name, value, Type.FLOAT);
 			throw e;
 		}
-		return this;
-	}
-	public JsonWrapper put(String name, Float value) {
-		put(name, Float.toString(value), Type.FLOAT);
 		return this;
 	}
 
@@ -478,11 +618,7 @@ public class JsonWrapper {
 		}
 		return this;
 	}
-	public JsonWrapper put(Float value) {
-		put(value.toString(), Type.FLOAT);
-		return this;
-	}
-
+	
 	/**
 	 * Places a named String that represents a {@link java.lang.Boolean} within the wrapper.
 	 *
@@ -499,11 +635,7 @@ public class JsonWrapper {
 		}
 		return this;
 	}
-	public JsonWrapper put(String name, Boolean value) {
-		put(name, Boolean.toString(value), Type.BOOLEAN);
-		return this;
-	}
-
+	
 	/**
 	 * Places an unnamed String that represents a {@link java.lang.Boolean} within the wrapper.
 	 *
@@ -512,88 +644,14 @@ public class JsonWrapper {
 	 */
 	public JsonWrapper putBoolean(String value) { // TODO only used in unit tests
 		try {
-			put( Boolean.toString(validBoolean(value)), Type.BOOLEAN);
+			put(Boolean.toString(validBoolean(value)), Type.BOOLEAN);
 		} catch (EncodeException e) {
 			put(value, Type.BOOLEAN);
 			throw e;
 		}
 		return this;
 	}
-	public JsonWrapper put(Boolean value) {
-		put(value.toString(), Type.BOOLEAN);
-		return this;
-	}
-
 	
-	/**
-	 * The master putter of MAP elements. They must specify the type.
-	 * The JSON values are all represented as strings because JSON is a string.
-	 * The type parameter is a sort of metadata about the entry for the
-	 * wrapper to know what data was stored for toString processing, 
-	 * format validation, and value fetching.
-	 * 
-	 * @param name
-	 * @param value
-	 * @param type
-	 */
-	private void put(String name, String value, Type type) {
-		JsonWrapper wrapper = new JsonWrapper(value);
-		wrapper.type = type;
-		put(name, wrapper);
-	}
-	
-	/**
-	 * The master putter of LIST elements. They must specify the type.
-	 * The JSON values are all represented as strings because JSON is a string.
-	 * The type parameter is a sort of metadata about the entry for the
-	 * wrapper to know what data was stored for toString processing, 
-	 * format validation, and value fetching.
-	 * 
-	 * @param value
-	 * @param type
-	 */
-	private void put(String value, Type type) {
-		JsonWrapper wrapper = new JsonWrapper(value);
-		wrapper.type = type;
-		put(wrapper);
-	}
-	
-	
-	/**
-	 * Places a named child wrapper within the wrapper.
-	 *
-	 * Think of this as adding an attribute to a JSON hash.
-	 *
-	 * @param name key for value
-	 * @param value keyed value
-	 * @return <i><b>this</b></i> reference for chaining
-	 */
-	public JsonWrapper put(String name, JsonWrapper value) {
-		checkListState();
-		if (checkState(value)) {
-			value.keyForMapStream = name;
-			childrenMap.put(name, value);
-			type = Type.MAP;
-		}
-		return this;
-	}
-
-	/**
-	 * Places an unnamed child wrapper within the wrapper.
-	 * Think of this as adding a JSON array entry.
-	 *
-	 * @param value item to place in wrapper
-	 * @return <i><b>this</b></i> reference for chaining
-	 */
-	public JsonWrapper put(JsonWrapper value) {
-		checkMapState();
-		if (checkState(value)) {
-			childrenList.add(value);
-			type = Type.LIST;
-		}
-		return this;
-	}
-
 	/**
 	 * Retrieve a named {@link String} from the {@link JsonWrapper}.
 	 *
@@ -648,6 +706,8 @@ public class JsonWrapper {
 	 * @param name key for value
 	 * @return retrieved keyed value
 	 */
+	@SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", 
+		justification = "Null is desired when not found.")
 	public Boolean getBoolean(String name) {
 		JsonWrapper wrapper = get(name);
 		if (wrapper == null) {
@@ -655,25 +715,6 @@ public class JsonWrapper {
 		}
 		String value = wrapper.value;
 		return Boolean.valueOf(value);
-	}
-
-	/**
-	 * Return the named value from the {@link JsonWrapper}.
-	 *
-	 * Think of this as retrieval of a JSON hash attribute
-	 *
-	 * @param name key for value
-	 * @param <T>
-	 * @return T retrieved keyed value
-	 */
-	public JsonWrapper get(String name) {
-		return childrenMap.get(name);
-	}
-	public JsonWrapper get(int index) {
-		if (index >= 0 && index < childrenList.size()) {
-			return childrenList.get(index);
-		}
-		return null;
 	}
 
 	/**
@@ -757,6 +798,7 @@ public class JsonWrapper {
 			throw new IllegalStateException("Current state may not change (from map to list).");
 		}
 	}
+	
 	/**
 	 * Helps enforce the initialized representation of the {@link JsonWrapper} as a hash or an array.
 	 *
@@ -767,6 +809,7 @@ public class JsonWrapper {
 			throw new IllegalStateException("Current state may not change (from list to map).");
 		}
 	}
+	
 	/**
 	 * Helps enforce no null or empty values added to a {@link JsonWrapper}.
 	 *
@@ -776,22 +819,23 @@ public class JsonWrapper {
 		if (wrapper == null) { // no null entries
 			return false;
 		}
-		try{
+		
+		try {
 			isDuplicateEntry(wrapper);  // no self references
 		} catch (Exception e) {
 			return false;
 		}
+		
 		if (wrapper.value == null && wrapper.isKind(Kind.VALUE)) { // no null values
 			return false;
-		}
-		if (wrapper.isType(Type.UNKNOWN)) { // no empty containers
+		} else if (wrapper.isType(Type.UNKNOWN)) { // no empty containers
 			return false;
-		}
-		if (wrapper.isKind(Kind.METADATA) && this.isKind(Kind.METADATA)) { // allow metadata mergers
+		} else if (wrapper.isKind(Kind.METADATA) && this.isKind(Kind.METADATA)) { // allow metadata mergers
 			return wrapper.size() > 0;
 		}
 		return true; // must be good if we made it through the gauntlet
 	}
+	
 	/**
 	 * Helps prevent duplicate entries. It is not sure why duplicates are added. 
 	 * The decoders seem to try and this prevents it without without changing decoder code.
@@ -805,7 +849,7 @@ public class JsonWrapper {
 		boolean duplicate = wrapper == this 
 				|| childrenList.contains(wrapper) 
 				|| childrenMap.values().contains(wrapper);
-		if ( duplicate ) {
+		if (duplicate) {
 			throw new UnsupportedOperationException("May not add parent to itself nor a child more than once.");
 		}
 		
@@ -823,6 +867,7 @@ public class JsonWrapper {
 		}
 		return isType(Type.MAP);
 	}
+	
 	/**
 	 * Identifies whether or not the {@link JsonWrapper}'s content is a JSON array.
 	 *
@@ -834,6 +879,7 @@ public class JsonWrapper {
 		}
 		return isType(Type.LIST);
 	}
+	
 	/**
 	 * Identifies whether or not the {@link JsonWrapper}'s content is a JSON value (leaf).
 	 *
@@ -842,6 +888,7 @@ public class JsonWrapper {
 	public boolean isValue() {
 		return isKind(Kind.VALUE);
 	}
+	
 	/**
 	 * Identifies whether or not the {@link JsonWrapper}'s content IS metadata.
 	 *
@@ -850,13 +897,14 @@ public class JsonWrapper {
 	public boolean isMetadata() {
 		return isKind(Kind.METADATA);
 	}
+	
 	/**
 	 * Identifies whether or not the {@link JsonWrapper}'s content HAS metadata.
 	 *
 	 * @return boolean true if this has metadata.
 	 */
 	public boolean hasMetadata() {
-		return metadata!=null && (metadata.isMap() || metadata.isList());
+		return metadata != null && (metadata.isMap() || metadata.isList());
 	}
 
 	/**
@@ -867,7 +915,7 @@ public class JsonWrapper {
 	public Stream<JsonWrapper> stream() {
 		Stream<JsonWrapper> stream;
 		
-		if (isValue() && value!=null) {
+		if (isValue() && value != null) {
 			stream = Stream.of(this);
 		} else if (isList()) {
 			stream = childrenList.stream();
@@ -894,6 +942,7 @@ public class JsonWrapper {
 			throw new EncodeException("Issue rendering JSON from JsonWrapper Map", e);
 		}
 	}
+	
 	/**
 	 * Valid JSON String representation of the {@link JsonWrapper} 
 	 * with its metadata in metadata_holder hash key.
@@ -957,6 +1006,7 @@ public class JsonWrapper {
 	void attachMetadata(Node node) {
 		attachMetadata(node, "");
 	}
+	
 	void attachMetadata(Node node, String encodeLabel) {
 		JsonWrapper metadata = new JsonWrapper(Kind.METADATA);
 		
@@ -1031,7 +1081,7 @@ public class JsonWrapper {
 			return 0;
 		}
 		if (isValue()) {
-			return (value==null) ?0 :1;
+			return (value == null) ? 0 : 1;
 		} 
 		if (isList()) {
 			return childrenList.size();
@@ -1055,6 +1105,7 @@ public class JsonWrapper {
 		}
 		return pathWrapper;
 	}
+	
 	/**
 	 * Accepts a bracket or dot path notation to locate a wrapper child.
 	 * It does not directly locate the node.
@@ -1069,29 +1120,32 @@ public class JsonWrapper {
 			return null; // could return new empty instance of JsonWrapper for null protection
 		}
 		
-		String jPath = jsonPath.replace("$", "");
-		if (jPath.length() == 0) {
+		String path = jsonPath.replace("$", "");
+		if (path.length() == 0) {
 			return this;
-		} else if (jPath.contains(".")) {
-			jPath = jPath
+		} else if (path.contains(".")) {
+			// conform dot containing paths to the results of bracket paths below
+			path = path
 				.replaceAll("\\]", "")
 				.replaceAll("\\[", ".[")
 				.substring(1);
 		} else {
-			jPath = jPath
+			// remove most of the brackets while retaining an index bracket for easy identification
+			path = path
 				.replaceAll("'\\]", ".")
 				.replaceAll("\\['", "")
 				.replaceAll("\\]", ".");
-			jPath = jPath.substring(0, jPath.length()-1);
+			path = path.substring(0, path.length() - 1);
 		}
 		// note that array entries keep the leading '[' for detection in the list method signature
 		
 		List<String> paths = new LinkedList<>();
-		for (String entry : jPath.split("\\.")) {
+		for (String entry : path.split("\\.")) {
 			paths.add(entry);
 		}
 		return getByJsonPath(paths);
 	}
+	
 	/**
 	 * Accepts the compiled JsonPath to locate a wrapper child.
 	 * This checks for null and definite status before calling the string parser instance.
@@ -1109,4 +1163,30 @@ public class JsonWrapper {
 		}
 		return getByJsonPath(jsonPath.getPath());
 	}
+	
+	/**
+	 * Return the named value from the {@link JsonWrapper}.
+	 *
+	 * Think of this as retrieval of a JSON hash attribute
+	 *
+	 * @param name key for value
+	 * @param <T>
+	 * @return T retrieved keyed value
+	 */
+	public JsonWrapper get(String name) {
+		return childrenMap.get(name);
+	}
+	
+	/**
+	 * Get a List element by index.
+	 * @param index integer element number starting with zero
+	 * @return the wrapper at given index or null
+	 */
+	public JsonWrapper get(int index) {
+		if (index >= 0 && index < childrenList.size()) {
+			return childrenList.get(index);
+		}
+		return null;
+	}
+
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -62,7 +62,10 @@ public class JsonWrapper {
 		return printer;
 	}
 
-	
+	/**
+	 * Custom JsonWrapper serialization logic to handle the metadata and type handling. 
+	 * This default impl ignores metadata.
+	 */
 	private static class JsonWrapperSerilizer extends StdSerializer<JsonWrapper> {
 
 		protected JsonWrapperSerilizer() {
@@ -92,6 +95,10 @@ public class JsonWrapper {
 			}
 		}
 	}
+	/**
+	 * Custom JsonWrapper serialization logic to handle the metadata and type handling. 
+	 * This subclass also processes the metadata.
+	 */
 	private static class JsonWrapperMetadataSerilizer extends JsonWrapperSerilizer {
 		
 		protected void objectHandling(JsonWrapper value, JsonGenerator gen, SerializerProvider provider) throws IOException {
@@ -132,6 +139,9 @@ public class JsonWrapper {
 		} 
 	}
 	
+	/**
+	 * Initialize the serializes
+	 */
 	static {
 		jsonMapper = new ObjectMapper();
 		SimpleModule module = new SimpleModule();
@@ -144,10 +154,10 @@ public class JsonWrapper {
 		metaMapper.registerModule(module);		
 	}
 	
-	public static ObjectWriter standardWriter() {
+	static ObjectWriter standardWriter() {
 		return jsonMapper.writer().with(standardPrinter());
 	}
-	public static ObjectWriter metadataWriter() {
+	static ObjectWriter metadataWriter() {
 		return metaMapper.writer().with(standardPrinter());
 	}
 	
@@ -169,10 +179,17 @@ public class JsonWrapper {
 	 */
 	private String keyForMapStream; // TODO maybe refactor name or concept.
 	
-	// TODO asdf JAVADOC the constructor use cases
+
+	/**
+	 * Constructor for Json Object and List use. 
+	 */
 	public JsonWrapper() {
 		this(Kind.OBJECT);
 	}
+	/**
+	 * Cunstruct a JSON container for a given kind.
+	 * @param kind
+	 */
 	public JsonWrapper(Kind kind) {
 		this.kind = kind;
 		
@@ -187,6 +204,12 @@ public class JsonWrapper {
 		// no metadata on metadata
 		metadata = isMetadata() ?null :new JsonWrapper(Kind.METADATA);
 	}
+	/**
+	 * Construct a JSON container for a string value.
+	 * A string value is a leaf node.
+	 * 
+	 * @param value
+	 */
 	public JsonWrapper(String value) {
 		kind = Kind.VALUE;
 		this.value = value;
@@ -194,10 +217,19 @@ public class JsonWrapper {
 		childrenList = null;
 		metadata = null;
 	}
-
+	/**
+	 * Construct a clone of the given JSON container.
+	 * @param wrapper
+	 */
 	public JsonWrapper(JsonWrapper wrapper) {
 		this(wrapper, true);
 	}
+	/**
+	 * Construct a clone of the given JSON container 
+	 * with the option to omit the metadata. TODO might not be necessary.
+	 * @param wrapper
+	 * @param withMetadata
+	 */
 	private JsonWrapper(JsonWrapper wrapper, boolean withMetadata) {
 		kind = wrapper.kind;
 		value = wrapper.value;
@@ -261,6 +293,10 @@ public class JsonWrapper {
 		return internalValue;
 	}
 	
+	/**
+	 * removes all data from the map, list, and metadata collections.
+	 * @return chaining self ref
+	 */
 	public JsonWrapper clear() {
 		if ( ! isValue() ) {
 			childrenMap.clear();
@@ -458,12 +494,33 @@ public class JsonWrapper {
 	}
 
 	
+	/**
+	 * The master putter of MAP elements. They must specify the type.
+	 * The JSON values are all represented as strings because JSON is a string.
+	 * The type parameter is a sort of metadata about the entry for the
+	 * wrapper to know what data was stored for toString processing, 
+	 * format validation, and value fetching.
+	 * 
+	 * @param name
+	 * @param value
+	 * @param type
+	 */
 	private void put(String name, String value, Type type) {
 		JsonWrapper wrapper = new JsonWrapper(value);
 		wrapper.type = type;
 		put(name, wrapper);
 	}
 	
+	/**
+	 * The master putter of LIST elements. They must specify the type.
+	 * The JSON values are all represented as strings because JSON is a string.
+	 * The type parameter is a sort of metadata about the entry for the
+	 * wrapper to know what data was stored for toString processing, 
+	 * format validation, and value fetching.
+	 * 
+	 * @param value
+	 * @param type
+	 */
 	private void put(String value, Type type) {
 		JsonWrapper wrapper = new JsonWrapper(value);
 		wrapper.type = type;

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -38,11 +38,11 @@ public class JsonWrapper {
 		VALUE, OBJECT, METADATA; // TODO asdf clear up object and map refs
 	}
 	public static enum Type {
-		BOOLEAN, DATE, INTEGER, FLOAT, STRING, MAP, LIST, UNKNOWN; // TODO asdf NONE type, others ?
+		BOOLEAN, DATE, INTEGER, FLOAT, STRING, MAP, LIST, UNKNOWN;
 	}
 	
 	public static final String METADATA_HOLDER = "metadata_holder";
-	public static final String ENCODING_KEY = "encodeLabel"; // TODO asdf check for other uses
+	public static final String ENCODING_KEY = "encodeLabel";
 	private static ObjectMapper jsonMapper;
 	private static ObjectMapper metaMapper;
 
@@ -159,7 +159,7 @@ public class JsonWrapper {
 	private final List<JsonWrapper> childrenList; // TODO asdf was list
 	private final JsonWrapper metadata;
 	private final Kind kind;
-	private Type type = Type.UNKNOWN; // TODO asdf cannot be final for dynamic typing but maybe never null?
+	private Type type = Type.UNKNOWN;
 	
 	/**
 	 * This is the key on the JsonWrapper that was used to store it in the parent wrapper.

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -814,8 +814,8 @@ public class JsonWrapper {
 	 *
 	 * @return boolean is this a JSON object
 	 */
-	public boolean isObject() { // TODO asdf this is confusing because of Java Object vs JS Object is a Java Map
-		if (type == Type.UNKNOWN) { // TODO asdf if type is unknown or map might be good 
+	public boolean isMap() {
+		if (isType(Type.UNKNOWN)) {
 			return isKind(Kind.OBJECT) && childrenList.isEmpty() && ! childrenMap.isEmpty();
 		}
 		return isType(Type.MAP);
@@ -826,7 +826,7 @@ public class JsonWrapper {
 	 * @return boolean is this a JSON array
 	 */
 	public boolean isList() {
-		if (type == Type.UNKNOWN) { // TODO asdf if type is unknown or list might be good 
+		if (isType(Type.UNKNOWN)) {
 			return isKind(Kind.OBJECT) && ! childrenList.isEmpty() && childrenMap.isEmpty();
 		}
 		return isType(Type.LIST);
@@ -853,7 +853,7 @@ public class JsonWrapper {
 	 * @return boolean true if this has metadata.
 	 */
 	public boolean hasMetadata() {
-		return metadata!=null && (metadata.isObject() || metadata.isList());
+		return metadata!=null && (metadata.isMap() || metadata.isList());
 	}
 
 	/**
@@ -906,7 +906,17 @@ public class JsonWrapper {
 		}
 	}
 
-	public Object toObject() { // TODO asdf refactor name
+	/**
+	 * It returns a Java Object class of the wrapped implementation.
+	 * If the instance is a leaf entity then the String value will be returned,
+	 * else if the list has entries then a List implementation will be returned,
+	 * finally, the Map instance is returned even if empty.
+	 * 
+	 * It is used in the JSON generation process to obtaine the underlying impl.
+	 * 
+	 * @return the underlying wrapped object: String, Map, or List
+	 */
+	public Object toObject() {
 		if (isValue()) {
 			return value;
 		} else if (isList()) {
@@ -916,9 +926,9 @@ public class JsonWrapper {
 	}
 
 	/**
-	 * Convenience method to get the JsonWrapper's content as an input stream.
+	 * Convenience method to get the JsonWrapper's JSON content as an input stream.
 	 *
-	 * @return input stream containing serialized json
+	 * @return input stream containing serialized JSON
 	 */
 	public Source toSource() {
 		byte[] qppBytes = toString().getBytes(StandardCharsets.UTF_8);
@@ -963,16 +973,6 @@ public class JsonWrapper {
 		});
 	}
 
-	void mergeMetadata(Map<String, String> otherMeta) { // TODO asdf refactor remove?
-		JsonWrapper metadata = new JsonWrapper();
-		otherMeta.entrySet().stream().forEach(entry ->{
-			String key = entry.getKey();
-			String value = entry.getValue();
-			metadata.put(key, value);
-		});
-		addMetaMap(metadata);
-	}
-	
 	public void addMetaMap(JsonWrapper metadata) { // TODO asdf refator name
 		this.metadata.put(metadata.isKind(Kind.METADATA) ?metadata :metadata.metadata);
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiMeasurePerformedRnREncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiMeasurePerformedRnREncoder.java
@@ -20,7 +20,7 @@ public class PiMeasurePerformedRnREncoder extends QppOutputEncoder {
 	 */
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
-		wrapper.putObject("measureId", node.getValue("measureId"));
+		wrapper.put("measureId", node.getValue("measureId"));
 		encodeChild(wrapper, node);
 	}
 
@@ -36,7 +36,7 @@ public class PiMeasurePerformedRnREncoder extends QppOutputEncoder {
 			if ("Y".equalsIgnoreCase(measureValue) || "N".equalsIgnoreCase(measureValue)) {
 				wrapper.putBoolean(VALUE, measureValue);
 			} else {
-				wrapper.putObject(VALUE, measureValue);
+				wrapper.put(VALUE, measureValue);
 			}
 		}
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiNumeratorDenominatorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiNumeratorDenominatorEncoder.java
@@ -42,8 +42,8 @@ public class PiNumeratorDenominatorEncoder extends QppOutputEncoder {
 
 		JsonWrapper childWrapper = encodeChildren(childMapByTemplateId);
 
-		wrapper.putObject("measureId", node.getValue("measureId"));
-		wrapper.putObject(VALUE, childWrapper);
+		wrapper.put("measureId", node.getValue("measureId"));
+		wrapper.put(VALUE, childWrapper);
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionDenominatorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionDenominatorEncoder.java
@@ -33,7 +33,7 @@ public class PiProportionDenominatorEncoder extends QppOutputEncoder {
 			denominatorValueEncoder.encode(value, denominatorValueNode);
 
 			if (null != value.getInteger(VALUE)) {
-				wrapper.putObject(ENCODE_LABEL, value.getInteger(VALUE));
+				wrapper.putInteger(ENCODE_LABEL, value.getInteger(VALUE));
 				wrapper.mergeMetadata(value, ENCODE_LABEL);
 			}
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionDenominatorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionDenominatorEncoder.java
@@ -33,7 +33,7 @@ public class PiProportionDenominatorEncoder extends QppOutputEncoder {
 			denominatorValueEncoder.encode(value, denominatorValueNode);
 
 			if (null != value.getInteger(VALUE)) {
-				wrapper.putInteger(ENCODE_LABEL, value.getInteger(VALUE));
+				wrapper.put(ENCODE_LABEL, value.getInteger(VALUE));
 				wrapper.mergeMetadata(value, ENCODE_LABEL);
 			}
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionNumeratorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionNumeratorEncoder.java
@@ -33,7 +33,7 @@ public class PiProportionNumeratorEncoder extends QppOutputEncoder {
 			JsonWrapper numerator = encodeChild(piNumeratorNode);
 
 			if (null != numerator.getInteger(VALUE)) {
-				wrapper.putObject(ENCODE_LABEL, numerator.getInteger(VALUE));
+				wrapper.putInteger(ENCODE_LABEL, numerator.getInteger(VALUE));
 				wrapper.mergeMetadata(numerator, ENCODE_LABEL);
 			}
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionNumeratorEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiProportionNumeratorEncoder.java
@@ -33,7 +33,7 @@ public class PiProportionNumeratorEncoder extends QppOutputEncoder {
 			JsonWrapper numerator = encodeChild(piNumeratorNode);
 
 			if (null != numerator.getInteger(VALUE)) {
-				wrapper.putInteger(ENCODE_LABEL, numerator.getInteger(VALUE));
+				wrapper.put(ENCODE_LABEL, numerator.getInteger(VALUE));
 				wrapper.mergeMetadata(numerator, ENCODE_LABEL);
 			}
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiSectionEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiSectionEncoder.java
@@ -44,15 +44,15 @@ public class PiSectionEncoder extends QppOutputEncoder {
 
 		encodeChildren(children, measurementsWrapper);
 
-		wrapper.putObject("measurements", measurementsWrapper);
+		wrapper.put("measurements", measurementsWrapper);
 
 		Optional.ofNullable(node.getParent()).ifPresent(parent -> pilferParent(wrapper, parent));
 		encodeReportingParameter(wrapper, node);
 	}
 
 	private void encodeTopLevelValues(JsonWrapper wrapper, Node node) {
-		wrapper.putString("category", node.getValue("category"));
-		wrapper.putString(SUBMISSION_METHOD, "electronicHealthRecord");
+		wrapper.put("category", node.getValue("category"));
+		wrapper.put(SUBMISSION_METHOD, "electronicHealthRecord");
 	}
 
 	/**
@@ -71,7 +71,7 @@ public class PiSectionEncoder extends QppOutputEncoder {
 
 				if (childEncoder != null) {
 					childEncoder.encode(childWrapper, currentChild);
-					measurementsWrapper.putObject(childWrapper);
+					measurementsWrapper.put(childWrapper);
 				} else {
 					addValidationError(Detail.forErrorAndNode(ErrorCode.ENCODER_MISSING, currentChild));
 				}
@@ -86,7 +86,7 @@ public class PiSectionEncoder extends QppOutputEncoder {
 	 * @param parent the clinical document node
 	 */
 	private void pilferParent(JsonWrapper wrapper, Node parent) {
-		wrapper.putString(ClinicalDocumentDecoder.PROGRAM_NAME,
+		wrapper.put(ClinicalDocumentDecoder.PROGRAM_NAME,
 				parent.getValue(ClinicalDocumentDecoder.PROGRAM_NAME));
 		maintainContinuity(wrapper, parent, ClinicalDocumentDecoder.PROGRAM_NAME);
 		encodeEntityId(wrapper, parent);
@@ -101,7 +101,7 @@ public class PiSectionEncoder extends QppOutputEncoder {
 	private void encodeEntityId(JsonWrapper wrapper, Node parent) {
 		String entityId = parent.getValue(ClinicalDocumentDecoder.PRACTICE_ID);
 		if (!StringUtils.isEmpty(entityId)) {
-			wrapper.putString(ClinicalDocumentDecoder.PRACTICE_ID, entityId);
+			wrapper.put(ClinicalDocumentDecoder.PRACTICE_ID, entityId);
 		}
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QppOutputEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QppOutputEncoder.java
@@ -56,7 +56,6 @@ public class QppOutputEncoder extends JsonOutputEncoder {
 	 * @param leafLabel encoded json attribute name
 	 */
 	void maintainContinuity(JsonWrapper wrapper, Node node, String leafLabel) {
-		Map<String, String> otherMeta = wrapper.createMetaMap(node, leafLabel);
-		wrapper.mergeMetadata(otherMeta);
+		wrapper.attachMetadata(node, leafLabel);
 	}
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -181,8 +181,8 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		this.encodePerformanceNotMet(childWrapper, parentNode);
 
 		for (Node childNode : parentNode.getChildNodes()) {
-			JsonOutputEncoder measureDataEncoder = encoders.get(childNode.getType());
-			if (null != measureDataEncoder) {
+			if (TemplateId.MEASURE_DATA_CMS_V2 == childNode.getType()) {
+				JsonOutputEncoder measureDataEncoder = encoders.get(childNode.getType());
 				measureDataEncoder.encode(childWrapper, childNode);
 			}
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -75,7 +75,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	 */
 	private void encodeChildren(JsonWrapper wrapper, Node parentNode, final MeasureConfig measureConfig) {
 		JsonWrapper childWrapper = new JsonWrapper();
-		childWrapper.putBoolean(IS_END_TO_END_REPORTED, TRUE);
+		childWrapper.put(IS_END_TO_END_REPORTED, Boolean.TRUE);
 		encodeSubPopulation(parentNode, childWrapper, false, measureConfig);
 		wrapper.put(VALUE, childWrapper);
 	}
@@ -157,7 +157,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	 */
 	private void encodeMultiPerformanceChildren(JsonWrapper wrapper, List<Node> subPopNodes, final MeasureConfig measureConfig) {
 		JsonWrapper childWrapper = new JsonWrapper();
-		childWrapper.putBoolean(IS_END_TO_END_REPORTED, TRUE);
+		childWrapper.put(IS_END_TO_END_REPORTED, Boolean.TRUE);
 		JsonWrapper strataListWrapper = new JsonWrapper();
 		for (Node subPopNode : subPopNodes) {
 			JsonWrapper strataWrapper = new JsonWrapper();

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -47,7 +47,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	public void internalEncode(JsonWrapper wrapper, Node node) {
 		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node);
 		String measureId = measureConfig.getMeasureId();
-		wrapper.putString(MEASURE_ID, measureId);
+		wrapper.put(MEASURE_ID, measureId);
 
 		if (isASinglePerformanceRate(measureConfig)) {
 			encodeChildren(wrapper, node, measureConfig);
@@ -77,7 +77,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		JsonWrapper childWrapper = new JsonWrapper();
 		childWrapper.putBoolean(IS_END_TO_END_REPORTED, TRUE);
 		encodeSubPopulation(parentNode, childWrapper, false, measureConfig);
-		wrapper.putObject(VALUE, childWrapper);
+		wrapper.put(VALUE, childWrapper);
 	}
 
 	/**
@@ -162,10 +162,10 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		for (Node subPopNode : subPopNodes) {
 			JsonWrapper strataWrapper = new JsonWrapper();
 			encodeSubPopulation(subPopNode, strataWrapper, true, measureConfig);
-			strataListWrapper.putObject(strataWrapper);
+			strataListWrapper.put(strataWrapper);
 		}
-		childWrapper.putObject("strata", strataListWrapper);
-		wrapper.putObject(VALUE, childWrapper);
+		childWrapper.put("strata", strataListWrapper);
+		wrapper.put(VALUE, childWrapper);
 	}
 
 	/**
@@ -223,7 +223,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 					String numeratorPopulationId =
 							node.getValue(MeasureDataDecoder.MEASURE_POPULATION).toUpperCase(Locale.ENGLISH);
 					String stratum = stratumForNumeratorUuid(numeratorPopulationId, measureConfig);
-					wrapper.putString("stratum", stratum);
+					wrapper.put("stratum", stratum);
 				});
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ReportingParametersActEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ReportingParametersActEncoder.java
@@ -46,7 +46,7 @@ public class ReportingParametersActEncoder extends QppOutputEncoder {
 		} catch (RuntimeException dtpe) {
 			final String message = "Error parsing reporting parameter " + key;
 			DEV_LOG.error(message, dtpe);
-			wrapper.putString(key, date);
+			wrapper.put(key, date);
 		}
 	}
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ScopedQppOutputEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ScopedQppOutputEncoder.java
@@ -35,9 +35,9 @@ public class ScopedQppOutputEncoder extends QppOutputEncoder {
 				JsonWrapper childWrapper = new JsonWrapper();
 				JsonOutputEncoder encoder = encoders.get(child.getType());
 				encoder.encode(childWrapper, child);
-				scoped.putObject(childWrapper);
+				scoped.put(childWrapper);
 			});
-			wrapper.putObject("scoped", scoped);
+			wrapper.put("scoped", scoped);
 		} else {
 			super.internalEncode(wrapper, node);
 		}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/placeholder/DefaultEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/placeholder/DefaultEncoder.java
@@ -29,17 +29,18 @@ public class DefaultEncoder extends JsonOutputEncoder {
 
 		JsonWrapper childWrapper = new JsonWrapper();
 
-		for (String name : node.getKeys()) {
+		for (Node child : node.getChildNodes()) { // LIST encoding for this node
+			//childWrapper.put(child.getType().name(), childWrapper); // cyclic self reference
+			encode(childWrapper, child); // child LIST entry for this node
+		}
+		
+		for (String name : node.getKeys()) { // MAP encoding
 			String nameForEncode = name.replace("Decoder", "Encoder");
-			childWrapper.putString(nameForEncode, node.getValue(name));
+			childWrapper.put(nameForEncode, node.getValue(name));
 		}
 
-		wrapper.putObject(node.getType().name(), childWrapper);
+		wrapper.put(node.getType().name(), childWrapper);
 
-		for (Node child : node.getChildNodes()) {
-			childWrapper.putObject(child.getType().name(), childWrapper);
-			encode(childWrapper, child);
-		}
 	}
 
 	@Encoder(TemplateId.CONTINUOUS_VARIABLE_MEASURE_VALUE_CMS)

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -48,6 +48,19 @@ class QualityMeasureIdRoundTripTest {
 	}
 
 	@Test
+	void testMeasureCMS165DoesNotContainUnexpectedValue() {
+		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE));
+		JsonWrapper qpp = converter.transform();
+		List<String> containsUnwantedValueList = JsonHelper.readJsonAtJsonPath(qpp.toString(),
+			"$.measurementSets[?(@.category=='quality')].measurements[0].value.value", new TypeRef<List<String>>() { });
+		List<String> measureId = JsonHelper.readJsonAtJsonPath(qpp.toString(),
+			"$.measurementSets[?(@.category=='quality')].measurements[*].measureId", new TypeRef<List<String>>() { });
+
+		assertThat(measureId.get(0)).isEqualTo("236");
+		assertThat(containsUnwantedValueList).isEmpty();
+	}
+
+	@Test
 	void testMeasureCMS68v7PerformanceRateUuid() {
 		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE));
 		List<Detail> details = new ArrayList<>();

--- a/converter/src/test/java/gov/cms/qpp/acceptance/SubmissionIntegrationTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/SubmissionIntegrationTest.java
@@ -58,7 +58,7 @@ class SubmissionIntegrationTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	void testSubmissionApiPostFailure() throws IOException {
-		Map<String, Object> obj = (Map<String, Object>) qpp.getObject();
+		Map<String, Object> obj = (Map<String, Object>) qpp.toObject();
 		obj.remove("performanceYear");
 		HttpResponse httpResponse = servicePost(qpp);
 		Assumptions.assumeTrue(endpointIsUp(httpResponse), "Validation api is down");

--- a/converter/src/test/java/gov/cms/qpp/conversion/ScopedConversionTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/ScopedConversionTest.java
@@ -56,11 +56,14 @@ class ScopedConversionTest {
 		//when
 		QrdaScope testSection = QrdaScope.getInstanceByName(TemplateId.MEASURE_SECTION_V2.name());
 		Map<String, Object> content = scopedConversion(testSection);
+		Object cont = getScoped(content).get(0);
 
+		Object fixt = fixtures.get(testSection.name());
+		
 		//then
 		assertWithMessage("content should match valid %s fixture", testSection)
-				.that(fixtures.get(testSection.name()))
-				.isEqualTo(getScoped(content).get(0));
+				.that(cont) // this is the content under test
+				.isEqualTo(fixt); // this is the control
 	}
 
 	/**

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/PathCorrelatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/PathCorrelatorTest.java
@@ -66,7 +66,7 @@ class PathCorrelatorTest {
 		metadata.putMetadata(JsonWrapper.ENCODING_KEY, "mawp");
 
 		JsonWrapper wrapper = new JsonWrapper();
-		wrapper.addMetaMap(metadata);
+		wrapper.addMetadata(metadata);
 		wrapper.put("mop","mop"); // TODO asdf test list object. note that JSON require top level to be object not list
 		
 		String actual = PathCorrelator.prepPath("$.mawp", wrapper);
@@ -86,8 +86,8 @@ class PathCorrelatorTest {
 		// TODO asdf what about prepPath returning something other than empty?
 
 		JsonWrapper wrapper = new JsonWrapper();
-		wrapper.addMetaMap(metadata);
-		wrapper.addMetaMap(metadata2);
+		wrapper.addMetadata(metadata);
+		wrapper.addMetadata(metadata2);
 		wrapper.put("mop","mop");
 		
 		String actual = PathCorrelator.prepPath("$.mawp", wrapper);

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/PathCorrelatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/PathCorrelatorTest.java
@@ -1,21 +1,19 @@
 package gov.cms.qpp.conversion.correlation;
 
-import com.google.common.collect.Lists;
-import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
-import gov.cms.qpp.conversion.encode.JsonWrapper;
-import gov.cms.qpp.conversion.model.TemplateId;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
+import gov.cms.qpp.conversion.encode.JsonWrapper;
+import gov.cms.qpp.conversion.model.TemplateId;
 
 class PathCorrelatorTest {
 
@@ -63,12 +61,36 @@ class PathCorrelatorTest {
 
 	@Test
 	void unacknowledgedEncodedLabel() {
-		Map<String, String> map = new HashMap<>();
-		map.put("meep", "meep");
-		map.put("encodeLabel", "mawp");
-		JsonWrapper wrapper = new JsonWrapper();
-		wrapper.putObject("metadata_holder", Lists.newArrayList(map));
+		JsonWrapper metadata = new JsonWrapper();
+		metadata.putMetadata("meep", "meep");
+		metadata.putMetadata("encodeLabel", "mawp");
 
-		assertThat(PathCorrelator.prepPath("$.mawp", wrapper)).isEmpty();
+		JsonWrapper wrapper = new JsonWrapper();
+		wrapper.addMetaMap(metadata);
+		wrapper.put("mop","mop"); // TODO asdf test list object. note that JSON require top level to be object not list
+		
+		String actual = PathCorrelator.prepPath("$.mawp", wrapper);
+		assertThat(actual).isEmpty();
+	}
+
+	@Test
+	void unacknowledgedEncodedLabel_multipleMetadata() {
+		JsonWrapper metadata = new JsonWrapper();
+		metadata.putMetadata("meep", "meep");
+		metadata.putMetadata("encodeLabel", "mawp");
+		JsonWrapper metadata2 = new JsonWrapper();
+		metadata2.putMetadata("template", "mip");
+		metadata2.putMetadata("nsuri", "mip");
+		metadata2.putMetadata("encodeLabel", "mip");
+		// TODO asdf what about encodedLabel empty string?
+		// TODO asdf what about prepPath returning something other than empty?
+
+		JsonWrapper wrapper = new JsonWrapper();
+		wrapper.addMetaMap(metadata);
+		wrapper.addMetaMap(metadata2);
+		wrapper.put("mop","mop");
+		
+		String actual = PathCorrelator.prepPath("$.mawp", wrapper);
+		assertThat(actual).isEmpty();
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/PathCorrelatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/PathCorrelatorTest.java
@@ -63,7 +63,7 @@ class PathCorrelatorTest {
 	void unacknowledgedEncodedLabel() {
 		JsonWrapper metadata = new JsonWrapper();
 		metadata.putMetadata("meep", "meep");
-		metadata.putMetadata("encodeLabel", "mawp");
+		metadata.putMetadata(JsonWrapper.ENCODING_KEY, "mawp");
 
 		JsonWrapper wrapper = new JsonWrapper();
 		wrapper.addMetaMap(metadata);
@@ -77,11 +77,11 @@ class PathCorrelatorTest {
 	void unacknowledgedEncodedLabel_multipleMetadata() {
 		JsonWrapper metadata = new JsonWrapper();
 		metadata.putMetadata("meep", "meep");
-		metadata.putMetadata("encodeLabel", "mawp");
+		metadata.putMetadata(JsonWrapper.ENCODING_KEY, "mawp");
 		JsonWrapper metadata2 = new JsonWrapper();
 		metadata2.putMetadata("template", "mip");
 		metadata2.putMetadata("nsuri", "mip");
-		metadata2.putMetadata("encodeLabel", "mip");
+		metadata2.putMetadata(JsonWrapper.ENCODING_KEY, "mip");
 		// TODO asdf what about encodedLabel empty string?
 		// TODO asdf what about prepPath returning something other than empty?
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/QrdaQppAssociationTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/QrdaQppAssociationTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;
+import gov.cms.qpp.conversion.correlation.ValueOriginMapper.Association;
 import gov.cms.qpp.conversion.encode.JsonWrapper;
 
 class QrdaQppAssociationTest {
@@ -29,11 +31,13 @@ class QrdaQppAssociationTest {
 
 	@Test
 	void testAssociation() {
-		mapper.mapIt("$", qpp.getObject());
+		mapper.mapItJsW("$", qpp);
 		mapper.writeAssociations();
 
+		List<Association> associations = mapper.getAssociations();
+		
 		assertWithMessage("registered associations does not match expectation")
-				.that(mapper.getAssociations()).hasSize(60);
+				.that(associations).hasSize(60);
 	}
 
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/ValueOriginMapper.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/ValueOriginMapper.java
@@ -56,7 +56,7 @@ class ValueOriginMapper {
 				if (xPath != null) {
 					associations.add(new Association(xPath, newBase, entry.toObject().toString()));
 				}
-				if (entry.isKind(Kind.OBJECT)) {
+				if (entry.isKind(Kind.CONTAINER)) {
 					map(newBase, entry);
 				}
 			});
@@ -92,7 +92,7 @@ class ValueOriginMapper {
 			}
 			String newBase = base + "." + key;
 
-			if (entry.isKind(Kind.OBJECT)) {
+			if (entry.isKind(Kind.CONTAINER)) {
 				mapItJsW(newBase, entry);
 			} else {
 				JsonWrapper metadataSet = toAssociate.getMetadata();

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/ValueOriginMapper.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/ValueOriginMapper.java
@@ -25,7 +25,7 @@ class ValueOriginMapper {
 	}
 
 	void mapItJsW(String base, JsonWrapper holder) {
-		if (holder.isObject()) {
+		if (holder.isMap()) {
 			mapMapJsW(base, holder);
 		} else {
 			mapListJsW(base, holder);
@@ -48,7 +48,7 @@ class ValueOriginMapper {
 				map(newBase, child);
 			});
 		}
-		if (toAssociate.isObject()) {
+		if (toAssociate.isMap()) {
 			toAssociate.stream().forEach(entry -> {
 				String newBase = base + "." + entry.getKey();
 				JsonWrapper metadata = entry.getMetadata();

--- a/converter/src/test/java/gov/cms/qpp/conversion/correlation/ValueOriginMapper.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/correlation/ValueOriginMapper.java
@@ -111,7 +111,7 @@ class ValueOriginMapper {
 		JsonWrapper xPath = metadata.stream()
 			.reduce((JsonWrapper)null, 
 			(current, meta) -> {
-				String label = meta.getString("encodeLabel");
+				String label = meta.getString(JsonWrapper.ENCODING_KEY);
 				if (label.equals(key)) {
 					String relative = PathCorrelator.getXpath(meta.getString("template"), label, meta.getString("nsuri"));
 					String axPath = (relative == null) ? meta.getString("path") : meta.getString("path") + "/" + relative;
@@ -133,7 +133,7 @@ class ValueOriginMapper {
 			return xPath;
 		}
 		for (Map<String, String> metaMap : metadataSet) {
-			String label = metaMap.get("encodeLabel");
+			String label = metaMap.get(JsonWrapper.ENCODING_KEY);
 			if (label.equals(key)) {
 				String relative = PathCorrelator.getXpath(metaMap.get("template"), label, metaMap.get("nsuri"));
 				xPath = (relative == null) ? metaMap.get("path") : metaMap.get("path") + "/" + relative;
@@ -154,7 +154,7 @@ class ValueOriginMapper {
 		}
 		List<JsonWrapper> metadataSet = metadata.stream().collect(Collectors.toList());
 		for (JsonWrapper metaMap : metadataSet) {
-			String label = metaMap.getString("encodeLabel");
+			String label = metaMap.getString(JsonWrapper.ENCODING_KEY);
 			if (label.equals(key)) {
 				String relative = PathCorrelator.getXpath(metaMap.getString("template"), label, metaMap.getString("nsuri"));
 				xPath = (relative == null) ? metaMap.getString("path") : metaMap.getString("path") + "/" + relative;

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoderTest.java
@@ -10,7 +10,6 @@ import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -127,10 +126,9 @@ class ClinicalDocumentEncoderTest {
 		JsonWrapper testJsonWrapper = new JsonWrapper();
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
-		Object performanceYear = testJsonWrapper.getValue(ReportingParametersActDecoder.PERFORMANCE_YEAR);
+		Object performanceYear = testJsonWrapper.getInteger(ReportingParametersActDecoder.PERFORMANCE_YEAR);
 
-		assertThat(performanceYear)
-				.isEqualTo(2017);
+		assertThat(performanceYear).isEqualTo(2017);
 	}
 
 	@Test
@@ -140,13 +138,11 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
-
-		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.ENTITY_TYPE))
+		assertThat(testJsonWrapper.getString(ClinicalDocumentDecoder.ENTITY_TYPE))
 				.isEqualTo("individual");
-		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER))
+		assertThat(testJsonWrapper.getString(ClinicalDocumentDecoder.TAX_PAYER_IDENTIFICATION_NUMBER))
 				.isEqualTo("123456789");
-		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER))
+		assertThat(testJsonWrapper.getString(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER))
 				.isEqualTo("2567891421");
 	}
 
@@ -158,7 +154,7 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
+		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.toObject());
 
 		assertThat(clinicalDocMap.get(MEASUREMENT_SETS))
 				.isNull();
@@ -173,7 +169,7 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
+		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.toObject());
 
 		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.PRACTICE_ID))
 				.isNull();
@@ -188,7 +184,7 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
+		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.toObject());
 
 		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.PRACTICE_ID))
 				.isNull();
@@ -205,11 +201,10 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
-		List<LinkedHashMap<String, Object>> measurementSets = getMeasurementSets(clinicalDocMap);
-		String value = (String)measurementSets.get(0).get("category");
+		JsonWrapper measurementSets = getMeasurementSets(testJsonWrapper);
+		String value = measurementSets.get(0).getString("category");
 
-		assertThat(measurementSets).hasSize(1);
+		assertThat(measurementSets.size()).isEqualTo(1);
 		assertThat(value).isEqualTo(expectedSection);
 	}
 
@@ -222,10 +217,8 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
-
-		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.ENTITY_ID))
-			.isEqualTo("x12345");
+		assertThat(testJsonWrapper.getString(ClinicalDocumentDecoder.ENTITY_ID))
+			.isEqualTo("x12345"); // TODO asdf refactor equals to toObject maybe if not comparing to JsW
 	}
 
 	@Test
@@ -236,15 +229,14 @@ class ClinicalDocumentEncoderTest {
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
 
-		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.getObject());
+		Map<?, ?> clinicalDocMap = ((Map<?, ?>) testJsonWrapper.toObject());
 
 		assertThat(clinicalDocMap.get(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER))
 			.isNull();
 	}
 
 
-	@SuppressWarnings("unchecked")
-	private List<LinkedHashMap<String, Object>> getMeasurementSets(Map clinicalDocumentMap) {
-		return ((List<LinkedHashMap<String, Object>>) clinicalDocumentMap.get("measurementSets"));
+	private JsonWrapper getMeasurementSets(JsonWrapper clinicalDocument) {
+		return clinicalDocument.get("measurementSets");
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/EncoderNegativeConditionsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/EncoderNegativeConditionsTest.java
@@ -36,11 +36,11 @@ class EncoderNegativeConditionsTest {
 			Assertions.fail("Failure to encode: " + e.getMessage());
 		}
 
-		// NOTE: This test is only relevant in that it finds the deep value but
-		// it is not actually a result
-		String expected = "null";
-		assertThat(sw.toString())
-				.isEqualTo(expected);
+		// NOTE: This test is only relevant in that it finds 
+		// the deep value but it is not actually a result.
+		// QPPCT-1008: New null protection does not allow nulls in the wrapper 
+		String expected = "{ }";
+		assertThat(sw.toString()).isEqualTo(expected);
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -685,8 +685,8 @@ class JsonWrapperTest {
 		objectObjWrapper.putMetadata(meta1, meta1);
 		objectStrWrapper.putMetadata(meta2, meta2);
 		
-		listObjWrapper.addMetaMap(objectObjWrapper);
-		listObjWrapper.addMetaMap(objectStrWrapper);
+		listObjWrapper.addMetadata(objectObjWrapper);
+		listObjWrapper.addMetadata(objectStrWrapper);
 		
 		// test
 		String json = listObjWrapper.getMetadata().toString().replaceAll("\\s", "");

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -19,10 +19,20 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.truth.Truth;
 
 import gov.cms.qpp.conversion.encode.JsonWrapper.Kind;
 import gov.cms.qpp.conversion.encode.JsonWrapper.Type;
@@ -834,5 +844,656 @@ class JsonWrapperTest {
 		assertWithMessage("checkState should not accept unknown wrappers")
 			.that(actual).isFalse();
 	}
+
+//	when(gen.writeBoolean(any(Boolean.class)))
 	
+	@Test
+	void hasValue_true() throws Exception {
+		JsonWrapper value = new JsonWrapper(Boolean.TRUE);
+		boolean actual = Type.BOOLEAN.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+		
+		value = new JsonWrapper("01/01/2020");
+		actual = Type.DATE.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+		
+		value = new JsonWrapper(1);
+		actual = Type.INTEGER.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+		
+		value = new JsonWrapper(1.1f);
+		actual = Type.FLOAT.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+				
+		value = new JsonWrapper("value");
+		actual = Type.STRING.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+		
+		value = new JsonWrapper().put("name", "value");
+		actual = Type.MAP.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+				
+		value = new JsonWrapper().put("value");
+		actual = Type.LIST.hasValue(value);
+		assertWithMessage("Instance should have value")
+			.that(actual).isTrue();
+	}
+	
+	@Test
+	void hasValue_false() throws Exception {
+		JsonWrapper value = new JsonWrapper((String)null);
+		boolean actual = Type.STRING.hasValue(value);
+		assertWithMessage("Instance should NOT have value because of null")
+			.that(actual).isFalse();
+		
+		value = new JsonWrapper();
+		actual = Type.MAP.hasValue(value);
+		assertWithMessage("Instance should NOT have value because of UNKNOWN")
+			.that(actual).isFalse();
+	}		
+	
+	@Test
+	void enumTypeBoolean() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper(Boolean.TRUE);
+		
+		Type.BOOLEAN.json(value, gen);
+		
+		verify(gen, times(1)).writeBoolean(any(Boolean.class));
+	}
+	@Test
+	void enumTypeBoolean_empty() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper((String)null);
+		
+		Type.BOOLEAN.json(value, gen);
+		verify(gen, times(0)).writeBoolean(any(Boolean.class));
+		
+		Type.BOOLEAN.json(null, gen);
+		verify(gen, times(0)).writeBoolean(any(Boolean.class));
+	}
+	@Test
+	void enumTypeDate() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper("01/01/2020");
+		
+		Type.DATE.json(value, gen);
+		
+		verify(gen, times(1)).writeString(any(String.class));
+	}
+	@Test
+	void enumTypeDate_empty() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper((String)null);
+		
+		Type.DATE.json(value, gen);
+		verify(gen, times(0)).writeBoolean(any(Boolean.class));
+		
+		Type.DATE.json(null, gen);
+		verify(gen, times(0)).writeBoolean(any(Boolean.class));
+	}
+	@Test
+	void enumTypeInteger() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper(1);
+		
+		Type.INTEGER.json(value, gen);
+		
+		verify(gen, times(1)).writeNumber(any(Integer.class));
+	}
+	@Test
+	void enumTypeInteger_empty() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper((String)null);
+		
+		Type.INTEGER.json(value, gen);
+		verify(gen, times(0)).writeNumber(any(Integer.class));
+
+		Type.INTEGER.json(null, gen);
+		verify(gen, times(0)).writeNumber(any(Integer.class));
+	}
+	@Test
+	void enumTypeFloat() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper(1.1f);
+		
+		Type.FLOAT.json(value, gen);
+		
+		verify(gen, times(1)).writeNumber(any(Float.class));
+	}
+	@Test
+	void enumTypeFloat_empty() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper((String)null);
+		
+		Type.FLOAT.json(value, gen);
+		verify(gen, times(0)).writeNumber(any(Float.class));
+
+		Type.FLOAT.json(null, gen);
+		verify(gen, times(0)).writeNumber(any(Float.class));
+	}
+	@Test
+	void enumTypeMap() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper().put("name","value");
+		
+		Type.MAP.json(value, gen);
+		
+		verify(gen, times(1)).writeObject(any(Map.class));
+	}
+	@Test
+	void enumTypeMap_empty() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper((String)null);
+		
+		Type.MAP.json(value, gen);
+		verify(gen, times(0)).writeObject(any(Map.class));
+
+		Type.MAP.json(null, gen);
+		verify(gen, times(0)).writeObject(any(Map.class));
+		
+		value = new JsonWrapper();
+		Type.MAP.json(null, gen);
+		verify(gen, times(0)).writeObject(any(Map.class));
+	}
+	@Test
+	void enumTypeList() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper().put("value");
+		
+		Type.LIST.json(value, gen);
+		
+		verify(gen, times(1)).writeObject(any(List.class));
+	}
+	@Test
+	void enumTypeList_empty() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper((String)null);
+		
+		Type.LIST.json(value, gen);
+		verify(gen, times(0)).writeObject(any(List.class));
+
+		Type.LIST.json(null, gen);
+		verify(gen, times(0)).writeObject(any(List.class));
+		
+		value = new JsonWrapper();
+		Type.LIST.json(null, gen);
+		verify(gen, times(0)).writeObject(any(List.class));
+	}
+	
+	@Test
+	void enumTypeUnknow() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper value = new JsonWrapper("mock");
+		// this is odd coverage because only UNKNOWN calls the empty noop impls
+		Type.UNKNOWN.json(value, gen);
+		Type.UNKNOWN.metadata(value, gen);
+	}
+	
+	@Test
+	void metadataMap_noMetadata() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		InOrder order = Mockito.inOrder(gen);
+
+		// wrapper uses a LinkedHashMap to preserve order
+		JsonWrapper value = new JsonWrapper().put("name","value").put("other","data");
+		
+		Type.MAP.metadata(value, gen);
+
+		// cool, I tested taking these our of order - works like a charm
+		order.verify(gen, times(1)).writeStartObject();
+		order.verify(gen, times(1)).writeObjectField("name","value");
+		order.verify(gen, times(1)).writeObjectField("other","data");
+		order.verify(gen, times(1)).writeEndObject();
+	}
+	@Test
+	void metadataMap_withMetadata() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		InOrder order = Mockito.inOrder(gen);
+		
+		JsonWrapper value = new JsonWrapper().put("name","value").putMetadata("meta", "data");;
+		
+		Type.MAP.metadata(value, gen);
+
+		// cool, I tested taking these our of order - works like a charm
+		order.verify(gen, times(1)).writeStartObject();
+		order.verify(gen, times(1)).writeObjectField(JsonWrapper.METADATA_HOLDER, value.getMetadata());
+		// mock instance does not call inner actions - how could it if it is only a MOCK!
+//		order.verify(gen, times(1)).writeStartObject();
+//		order.verify(gen, times(1)).writeObjectField("meta","data");
+//		order.verify(gen, times(1)).writeEndObject();
+		order.verify(gen, times(1)).writeObjectField("name","value");
+		order.verify(gen, times(1)).writeEndObject();
+	}
+	@Test
+	void metadataMap_throwsIOE() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		Mockito.doThrow(IOException.class).when(gen).writeObjectField("name", "value");
+
+		// wrapper uses a LinkedHashMap to preserve order
+		JsonWrapper value = new JsonWrapper().put("name","value");
+		
+		assertThrows(RuntimeException.class, () -> {Type.MAP.metadata(value, gen);});
+	}
+
+	@Test
+	void metadataList_noMetadata() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		InOrder order = Mockito.inOrder(gen);
+
+		// wrapper uses a LinkedList to preserve order
+		JsonWrapper value = new JsonWrapper().put("value").put("data");
+		JsonWrapper item1 = value.get(0);
+		JsonWrapper item2 = value.get(1);
+		
+		Type.LIST.metadata(value, gen);
+
+		// cool, I tested taking these our of order - works like a charm
+		order.verify(gen, times(1)).writeStartArray();
+		order.verify(gen, times(1)).writeObject(item1);
+		order.verify(gen, times(1)).writeObject(item2);
+		order.verify(gen, times(1)).writeEndArray();
+	}
+	@Test
+	void metadataList_withMetadata() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		InOrder order = Mockito.inOrder(gen);
+		
+		JsonWrapper value = new JsonWrapper().put("value").putMetadata("meta", "data");;
+		
+		JsonWrapper item1 = value.get(0);
+		
+		Type.LIST.metadata(value, gen);
+
+		// cool, I tested taking these our of order - works like a charm
+		order.verify(gen, times(1)).writeStartArray();
+		order.verify(gen, times(1)).writeObject(value.getMetadata());
+		// mock instance does not call inner actions - how could it if it is only a MOCK!
+//		order.verify(gen, times(1)).writeStartObject();
+//		order.verify(gen, times(1)).writeObjectField("meta","data");
+//		order.verify(gen, times(1)).writeEndObject();
+		order.verify(gen, times(1)).writeObject(item1);
+		order.verify(gen, times(1)).writeEndArray();
+	}
+	@Test
+	void metadataList_throwsIOE() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+
+		// wrapper uses a LinkedList to preserve order
+		JsonWrapper value = new JsonWrapper().put("value");
+		JsonWrapper item1 = value.get(0);
+		
+		Mockito.doThrow(IOException.class).when(gen).writeObject(item1);
+		
+		assertThrows(RuntimeException.class, () -> {Type.LIST.metadata(value, gen);});
+	}
+
+	@Test
+	void test_JsonWrapperMetadataSerilizer_jsonContainer_noMetadata() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper.Type map = mock(JsonWrapper.Type.class);
+		JsonWrapper value = new JsonWrapper().put("value").setType(map);
+		
+		JsonWrapper.JsonWrapperMetadataSerilizer metaSer = new JsonWrapper.JsonWrapperMetadataSerilizer();
+		metaSer.jsonContainer(value, gen, null);
+		
+		// should call the super class handling if metadata is absent from the wrapper
+		verify(map, times(0)).metadata(value, gen);
+		verify(map, times(1)).json(value, gen);
+	}
+	@Test
+	void test_JsonWrapperMetadataSerilizer_jsonContainer_withMetadata() throws Exception {
+		JsonGenerator gen = mock(JsonGenerator.class);
+		JsonWrapper.Type map = mock(JsonWrapper.Type.class);
+		JsonWrapper value = new JsonWrapper().put("value").putMetadata("meta", "data");
+		value.setType(map);
+		
+		JsonWrapper.JsonWrapperMetadataSerilizer metaSer = new JsonWrapper.JsonWrapperMetadataSerilizer();
+		metaSer.jsonContainer(value, gen, null);
+
+		// should call the metadata method on the type instance if metadata is added to the wrapper
+		verify(map, times(1)).metadata(value, gen);
+		verify(map, times(0)).json(value, gen);
+	}
+	
+	@Test
+	void Constructor_throwsUnsupported() throws Exception {
+		assertThrows(UnsupportedOperationException.class, () -> {new JsonWrapper(Kind.VALUE);});
+	}
+	
+	@Test
+	void getKind() throws Exception {
+		assertWithMessage("getKind should return the wrapper Kind")
+			.that(new JsonWrapper().getKind())
+			.isEqualTo(Kind.CONTAINER);
+	}
+	
+	@Test
+	void clear_list() {
+		JsonWrapper list = new JsonWrapper().put("value").putMetadata("meta", "data");
+		assertWithMessage("Should have size 1 with a value added")
+			.that(list.size())
+			.isEqualTo(1);
+		assertWithMessage("Should have metadata")
+			.that(list.hasMetadata())
+			.isTrue();
+		list.clear();
+		assertWithMessage("Should have zero size after clear")
+			.that(list.size())
+			.isEqualTo(0);
+		assertWithMessage("Metadata should be cleared")
+			.that(list.hasMetadata())
+			.isFalse();
+	}
+	@Test
+	void clear_map() {
+		JsonWrapper map = new JsonWrapper().put("name","value").putMetadata("meta", "data");
+		assertWithMessage("Should have size 1 with a entry added")
+			.that(map.size())
+			.isEqualTo(1);
+		assertWithMessage("Should have metadata")
+			.that(map.hasMetadata())
+			.isTrue();
+		map.clear();
+		assertWithMessage("Should have zero size after clear")
+			.that(map.size())
+			.isEqualTo(0);
+		assertWithMessage("Metadata should be cleared")
+			.that(map.hasMetadata())
+			.isFalse();
+	}
+	@Test
+	void clear_value() {
+		JsonWrapper value = new JsonWrapper("value");
+		value.clear();
+		assertWithMessage("Clear should not clear immmutable values.")
+			.that(value.toObject()).isEqualTo("value");
+		assertWithMessage("Clear should not clear immmutable values.")
+			.that(value.getType()).isEqualTo(Type.STRING);
+	}
+	
+	@Test
+	void putDate_valid() {
+		String date = "2010/10/20";
+		JsonWrapper wrap = new JsonWrapper().putDate("date",date);
+		assertWithMessage("Should return entered date")
+			.that(wrap.getString("date"))
+			.isEqualTo(date.replaceAll("/","-"));
+		wrap = new JsonWrapper().putDate(date);
+		assertWithMessage("Should return entered date")
+			.that(wrap.get(0).toObject())
+			.isEqualTo(date.replaceAll("/","-"));
+	}
+	@Test
+	void putDate_invalid() {
+		assertThrows(EncodeException.class, () -> {
+			new JsonWrapper().putDate("date","not a date");
+		});
+	}
+	
+	@Test
+	void putInteger() {
+		JsonWrapper wrap = new JsonWrapper().put("int",1);
+		assertWithMessage("Should return entered integer")
+			.that(wrap.getInteger("int"))
+			.isEqualTo(1);
+		wrap = new JsonWrapper().put(1);
+		assertWithMessage("Should return entered integer")
+			.that(wrap.get(0).toObject())
+			.isEqualTo("1");
+	}
+
+	@Test
+	void putFloat() {
+		JsonWrapper wrap = new JsonWrapper().put("float",1.1f);
+		assertWithMessage("Should return entered float")
+			.that(wrap.getFloat("float"))
+			.isEqualTo(1.1f);
+		wrap = new JsonWrapper().put(1.1f);
+		assertWithMessage("Should return entered float")
+			.that(wrap.get(0).toObject())
+			.isEqualTo("1.1");
+	}
+	
+	@Test
+	void putBoolean() {
+		JsonWrapper wrap = new JsonWrapper().put("bool", true);
+		assertWithMessage("Should return entered boolean")
+			.that(wrap.getBoolean("bool"))
+			.isEqualTo(true);
+		wrap = new JsonWrapper().put(true);
+		assertWithMessage("Should return entered boolean")
+			.that(wrap.get(0).toObject())
+			.isEqualTo("true");
+	}
+	
+	@Test
+	void getString_valueNotFound() {
+		JsonWrapper wrap = new JsonWrapper().put("name", "value");
+		assertWithMessage("Should return null for unfound entry rather than NPE")
+			.that(wrap.getString("notEntered"))
+			.isNull();
+	}
+	
+	@Test
+	void getInteger_valueNotFound() {
+		JsonWrapper wrap = new JsonWrapper().put("int", 1);
+		assertWithMessage("Should return null for unfound entry rather than NPE")
+			.that(wrap.getInteger("notEntered"))
+			.isNull();
+	}
+	
+	@Test
+	void getFloat_valueNotFound() {
+		JsonWrapper wrap = new JsonWrapper().put("float", 1.1f);
+		assertWithMessage("Should return null for unfound entry rather than NPE")
+			.that(wrap.getFloat("notEntered"))
+			.isNull();
+	}
+	
+	@Test
+	void getBoolean_valueNotFound() {
+		JsonWrapper wrap = new JsonWrapper().put("bool", true);
+		assertWithMessage("Should return null for unfound entry rather than NPE")
+			.that(wrap.getBoolean("notEntered"))
+			.isNull();
+	}
+	
+	@Test
+	void getIndex_valueNotFound() {
+		JsonWrapper wrap = new JsonWrapper().put("value");
+		assertWithMessage("Should return null for unfound entry rather than NPE")
+			.that(wrap.get(10))
+			.isNull();
+		assertWithMessage("Should return null for unfound entry rather than NPE")
+			.that(wrap.get(-10))
+			.isNull();
+	}
+
+	@Test
+	void isDuplicateEntry_false() {
+		String value = "value";
+		JsonWrapper wrap = new JsonWrapper().put(value);
+		
+		boolean actual = wrap.isDuplicateEntry(new JsonWrapper(value));
+		assertWithMessage("Expect equal instance of unwrapped to be unique")
+			.that(actual).isFalse();
+	}
+
+	@Test
+	void isDuplicateEntry_self() {
+		JsonWrapper wrap = new JsonWrapper().put("value");
+		
+		assertThrows(UnsupportedOperationException.class,
+				()->{wrap.isDuplicateEntry(wrap);},
+				"Expect self to be considered duplicate");
+	}
+
+	@Test
+	void isDuplicateEntry_child() {
+		JsonWrapper child = new JsonWrapper().put("value");
+		JsonWrapper parentList = new JsonWrapper().put(child);
+		
+		assertThrows(UnsupportedOperationException.class,
+				()->{parentList.isDuplicateEntry(child);},
+				"Expect child to be detected duplicate");
+		
+		JsonWrapper parentMap = new JsonWrapper().put("name",child);
+		
+		assertThrows(UnsupportedOperationException.class,
+				()->{parentMap.isDuplicateEntry(child);},
+				"Expect child to be detected duplicate");
+	}
+	
+	@Test
+	void toStringWithMetadata() throws Exception {
+		JsonWrapper map = new JsonWrapper().put("name", "value");
+		map.putMetadata("meta", "data");
+
+		String json = map.toStringWithMetadata();
+
+		String expect = "{\n  \"metadata_holder\" : {\n    \"meta\" : \"data\"\n  },\n  \"name\" : \"value\"\n}";
+		assertWithMessage("expect a simple object of JSON")
+				.that(json)
+				.isEqualTo(expect);
+	}
+	
+	@Test
+	void stripWrapper_nonWrapper() {
+		String internal = "value";
+		Object actual = new JsonWrapper().stripWrapper(internal);
+		assertWithMessage("Internal Value of a nonWrapper is self")
+			.that(actual)
+			.isEqualTo(internal);
+	}
+	
+	@Test
+	void getMetadata_notNull() {
+		JsonWrapper map = new JsonWrapper().put("name", "value");
+		map.putMetadata("meta", "data");
+		
+		JsonWrapper metadata = map.getMetadata();
+		assertWithMessage("must return metadata instance")
+			.that(metadata)
+			.isInstanceOf(JsonWrapper.class);
+	}
+	
+	
+	@Test
+	void getMetadata_noMetadataOnMetadata() {
+		JsonWrapper map = new JsonWrapper().put("name", "value");
+		map.putMetadata("meta", "data");
+		
+		JsonWrapper metadata = map.getMetadata();
+		JsonWrapper metametadata = map.getMetadata().getMetadata();
+		assertWithMessage("must return self metadata instance")
+			.that(metametadata)
+			.isEqualTo(metadata);
+	}
+	
+	@Test
+	void addMetadata_notNull() {
+		JsonWrapper data = new JsonWrapper().put("name", "value").putMetadata("meta1", "data1");
+
+		assertWithMessage("expect metadata size to be 1")
+			.that(data.getMetadata().size()).isEqualTo(1);
+		
+		data.addMetadata(null);
+		
+		assertWithMessage("expect metadata size to be 1")
+			.that(data.getMetadata().size()).isEqualTo(1);
+	}
+	
+	@Test
+	void addMetadata() {
+		JsonWrapper data = new JsonWrapper().put("name", "value").putMetadata("meta1", "data1");
+		JsonWrapper metadata = new JsonWrapper().putMetadata("meta2", "data2");
+
+		assertWithMessage("expect metadata size to be 1")
+			.that(data.getMetadata().size()).isEqualTo(1);
+		
+		data.addMetadata(metadata);
+		
+		assertWithMessage("expect metadata size to be 2")
+			.that(data.getMetadata().size()).isEqualTo(2);
+	}
+	
+	@Test
+	void addMetadata_toMetadata() {
+		JsonWrapper data = new JsonWrapper().put("name", "value").putMetadata("meta1", "data1");
+		JsonWrapper metadata = new JsonWrapper().putMetadata("meta2", "data2");
+
+		assertWithMessage("expect metadata size to be 1")
+			.that(data.getMetadata().size()).isEqualTo(1);
+		
+		data.getMetadata().addMetadata(metadata);
+		
+		assertWithMessage("expect metadata size to be 2")
+			.that(data.getMetadata().size()).isEqualTo(2);
+	}
+	
+	@Test
+	void mergeMetadata() {
+		JsonWrapper data = new JsonWrapper().put("name", "value").putMetadata("meta1", "data1");
+		JsonWrapper metadata = new JsonWrapper().putMetadata("meta2", "data2");
+
+		assertWithMessage("expect metadata size to be 1")
+			.that(data.getMetadata().size()).isEqualTo(1);
+		
+		data.mergeMetadata(metadata, "merge label");
+ 		
+		int mergeSize = data.getMetadata().size();
+		assertWithMessage("expect metadata size to be 2")
+			.that(mergeSize).isEqualTo(2);
+		
+		String mergeLabel = data.getMetadata().get(1).getString(JsonWrapper.ENCODING_KEY);
+		assertWithMessage("expect encodeLabel to be set")
+			.that(mergeLabel).isEqualTo("merge label");
+	}
+	
+	@Test
+	void addMetadata_list() {
+		JsonWrapper otherWrapper = new JsonWrapper().putMetadata("meta1", "data1");
+		JsonWrapper metadata = new JsonWrapper().putMetadata("meta2", "data2");
+		otherWrapper.addMetadata(metadata); // this makes a metadata list on the wrapper
+
+		JsonWrapper dataWithMetadata = new JsonWrapper().put("name", "value").putMetadata("meta2", "data2");
+
+		dataWithMetadata.mergeMetadata(otherWrapper, "merge label");
+		
+		int mergeSize = dataWithMetadata.getMetadata().size();
+		assertWithMessage("expect metadata size to be 3")
+			.that(mergeSize).isEqualTo(3);
+		
+		String mergeLabel = dataWithMetadata.getMetadata().get(1).getString(JsonWrapper.ENCODING_KEY);
+		assertWithMessage("expect encodeLabel to be set")
+			.that(mergeLabel).isEqualTo("merge label");
+		
+		mergeLabel = dataWithMetadata.getMetadata().get(2).getString(JsonWrapper.ENCODING_KEY);
+		assertWithMessage("expect encodeLabel to be set")
+			.that(mergeLabel).isEqualTo("merge label");
+	}
+	
+	@Test
+	void size() {
+		JsonWrapper nullValue = new JsonWrapper((String)null);
+		JsonWrapper value = new JsonWrapper("value");
+		JsonWrapper map = new JsonWrapper().put("name", "value").put("name1", "value1");
+		JsonWrapper list = new JsonWrapper().put("value1").put("value2").put("value3");
+
+		assertWithMessage("expect metadata size to be 0")
+			.that(nullValue.size()).isEqualTo(0);
+		assertWithMessage("expect metadata size to be 1")
+			.that(value.size()).isEqualTo(1);
+		assertWithMessage("expect metadata size to be 2")
+			.that(map.size()).isEqualTo(2);
+		assertWithMessage("expect metadata size to be 3")
+			.that(list.size()).isEqualTo(3);
+	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -72,7 +72,7 @@ class JsonWrapperTest {
 	@Test
 	void testInitAsObject() {
 		assertWithMessage("Object should be null until the first put")
-				.that(objectStrWrapper.isObject()).isFalse();
+				.that(objectStrWrapper.isMap()).isFalse();
 		objectStrWrapper.put("name", "value");
 		Object obj1 = objectStrWrapper.toObject();
 		assertThat(obj1).isInstanceOf(Map.class);
@@ -117,7 +117,7 @@ class JsonWrapperTest {
 				.that(objectStrWrapper.isType(Type.MAP)).isFalse();
 		objectStrWrapper.put("name", "value");
 		assertWithMessage("should be an object container after first put")
-				.that(objectStrWrapper.isObject()).isTrue();
+				.that(objectStrWrapper.isMap()).isTrue();
 //		objectObjWrapper.put("name", new Object()); TODO asdf
 //		assertWithMessage("should be an object container after first map put")
 //				.that(objectObjWrapper.isObject()).isTrue();
@@ -126,15 +126,15 @@ class JsonWrapperTest {
 	@Test
 	void testIsObject_false() {
 		assertWithMessage("should not be an object container")
-				.that(listStrWrapper.isObject())
+				.that(listStrWrapper.isMap())
 				.isFalse();
 		listStrWrapper.put("name");
 		assertWithMessage("should not be an object container after first list put")
-				.that(listStrWrapper.isObject())
+				.that(listStrWrapper.isMap())
 				.isFalse();
 
 		assertWithMessage("should not be an object container")
-				.that(listStrWrapper.isObject())
+				.that(listStrWrapper.isMap())
 				.isFalse();
 //		listObjWrapper.put(new Object()); TODO asdf
 //		assertWithMessage("should not be an object container after first list put")

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/JsonWrapperTest.java
@@ -827,7 +827,7 @@ class JsonWrapperTest {
 	@Test
 	void checkState_addUnknown() {
 		JsonWrapper wrapper = new JsonWrapper();
-		JsonWrapper unknown = new JsonWrapper(Kind.OBJECT);
+		JsonWrapper unknown = new JsonWrapper(Kind.CONTAINER);
 		
 		boolean actual = wrapper.checkState(unknown);
 		

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/PiNumeratorDenominatorEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/PiNumeratorDenominatorEncoderTest.java
@@ -84,11 +84,11 @@ class PiNumeratorDenominatorEncoderTest {
 		//assert
 		assertThat(jsonWrapper.getString("measureId"))
 				.isEqualTo(MEASURE_ID);
-		assertThat(jsonWrapper.getObject())
+		assertThat(jsonWrapper.toObject())
 				.isNotNull();
-		assertThat(jsonWrapper.getObject())
+		assertThat(jsonWrapper.toObject())
 				.isInstanceOf(Map.class);
-		assertThat(((Map<?, ?>)jsonWrapper.getObject()).get("value"))
+		assertThat(((Map<?, ?>)jsonWrapper.toObject()).get("value"))
 				.isNotNull();
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/PiProportionDenominatorEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/PiProportionDenominatorEncoderTest.java
@@ -57,9 +57,10 @@ class PiProportionDenominatorEncoderTest {
 	void testEncoderWithoutValue() {
 		numeratorDenominatorValueNode.putValue("aggregateCount", null);
 		runEncoder();
-
+		
+		// QPPCT-1008 wrappers are protected from null
 		assertThat(json.toString())
-				.isEqualTo("null");
+				.isEqualTo("{ }");
 	}
 
 	private void runEncoder() {

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/PiSectionEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/PiSectionEncoderTest.java
@@ -75,13 +75,11 @@ class PiSectionEncoderTest {
 		PiSectionEncoder piSectionEncoder = new PiSectionEncoder(new Context());
 		piSectionEncoder.internalEncode(jsonWrapper, piSectionNode);
 
-		Map<?, ?> testMapObject = (Map<?, ?>) jsonWrapper.getObject();
-
-		assertWithMessage("Must have a child node").that(testMapObject).isNotNull();
-		assertWithMessage("Must be category ACI").that(testMapObject.get(CATEGORY)).isEqualTo(PI);
-		assertWithMessage("Must have measurements").that(testMapObject.get(MEASUREMENTS)).isNotNull();
+		assertWithMessage("Must have a child node").that(jsonWrapper).isNotNull();
+		assertWithMessage("Must be category ACI").that(jsonWrapper.getString(CATEGORY)).isEqualTo(PI);
+		assertWithMessage("Must have measurements").that(jsonWrapper.get(MEASUREMENTS)).isNotNull();
 		assertWithMessage("Must have submissionMethod")
-				.that(testMapObject.get(SUBMISSION_METHOD)).isEqualTo(ELECTRONIC_HEALTH_RECORD);
+				.that(jsonWrapper.getString(SUBMISSION_METHOD)).isEqualTo(ELECTRONIC_HEALTH_RECORD);
 	}
 
 	@Test
@@ -90,10 +88,9 @@ class PiSectionEncoderTest {
 		PiSectionEncoder piSectionEncoder = new PiSectionEncoder(new Context());
 		piSectionEncoder.internalEncode(jsonWrapper, piSectionNode);
 
-		Map<?, ?> testMapObject = (Map<?, ?>) jsonWrapper.getObject();
-		Stream failed = ((Set) testMapObject.get("metadata_holder")).stream()
-			.filter(entry -> ((Map) entry).get("template").equals(TemplateId.REPORTING_PARAMETERS_ACT.name()))
-			.filter(entry -> ((Map) entry).get("encodeLabel").equals(""));
+		Stream<JsonWrapper> failed = jsonWrapper.getMetadata().stream() // TODO asdf
+			.filter(entry -> entry.getString("template").equals(TemplateId.REPORTING_PARAMETERS_ACT.name()))
+			.filter(entry -> entry.getString("encodeLabel").equals(""));
 
 		assertThat(failed.count()).isEqualTo(0);
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/PiSectionEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/PiSectionEncoderTest.java
@@ -90,7 +90,7 @@ class PiSectionEncoderTest {
 
 		Stream<JsonWrapper> failed = jsonWrapper.getMetadata().stream() // TODO asdf
 			.filter(entry -> entry.getString("template").equals(TemplateId.REPORTING_PARAMETERS_ACT.name()))
-			.filter(entry -> entry.getString("encodeLabel").equals(""));
+			.filter(entry -> entry.getString(JsonWrapper.ENCODING_KEY).equals(""));
 
 		assertThat(failed.count()).isEqualTo(0);
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QedEncoder.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QedEncoder.java
@@ -29,7 +29,7 @@ public class QedEncoder extends QppOutputEncoder {
 		Set<String> keys = node.getKeys();
 
 		for (String key : keys) {
-			wrapper.putString(key, node.getValue(key));
+			wrapper.put(key, node.getValue(key));
 		}
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -1,16 +1,15 @@
 package gov.cms.qpp.conversion.encode;
 
-import gov.cms.qpp.conversion.Context;
-import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.model.TemplateId;
-import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashMap;
-
-import static com.google.common.truth.Truth.assertThat;
+import gov.cms.qpp.conversion.Context;
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.model.TemplateId;
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 
 class QualityMeasureIdEncoderTest {
 
@@ -69,19 +68,19 @@ class QualityMeasureIdEncoderTest {
 	@Test
 	void testEndToEndReportedIsEncoded() {
 		executeInternalEncode();
-		LinkedHashMap<String, Object> childValues = getChildValues();
+		JsonWrapper childValues = getChildValues();
 
-		assertThat((Boolean)childValues.get("isEndToEndReported"))
+		assertThat(childValues.getBoolean("isEndToEndReported"))
 				.isTrue();
 	}
 
 	@Test
 	void testPopulationTotalIsEncoded() {
 		executeInternalEncode();
-		LinkedHashMap<String, Object> childValues = getChildValues();
+		JsonWrapper childValues = getChildValues();
 
 
-		assertThat(childValues.get(ELIGIBLE_POPULATION))
+		assertThat(childValues.getInteger(ELIGIBLE_POPULATION))
 				.isEqualTo(600);
 	}
 
@@ -91,35 +90,35 @@ class QualityMeasureIdEncoderTest {
 		populationNode.putValue(type, "IPP");
 		populationNode.addChildNode(aggregateCountNode);
 		executeInternalEncode();
-		LinkedHashMap<String, Object> childValues = getChildValues();
+		JsonWrapper childValues = getChildValues();
 
-		assertThat(childValues.get(ELIGIBLE_POPULATION))
+		assertThat(childValues.getInteger(ELIGIBLE_POPULATION))
 				.isEqualTo(600);
 	}
 
 	@Test
 	void testPerformanceMetIsEncoded() {
 		executeInternalEncode();
-		LinkedHashMap<String, Object> childValues = getChildValues();
-		assertThat(childValues.get("performanceMet"))
+		JsonWrapper childValues = getChildValues();
+		assertThat(childValues.getInteger("performanceMet"))
 				.isEqualTo(600);
 	}
 
 	@Test
 	void testPerformanceExclusionIsEncoded() {
 		executeInternalEncode();
-		LinkedHashMap<String, Object> childValues = getChildValues();
+		JsonWrapper childValues = getChildValues();
 
-		assertThat(childValues.get("eligiblePopulationExclusion"))
+		assertThat(childValues.getInteger("eligiblePopulationExclusion"))
 				.isEqualTo(600);
 	}
 
 	@Test
 	void testPerformanceNotMetIsEncoded() {
 		executeInternalEncode();
-		LinkedHashMap<String, Object> childValues = getChildValues();
+		JsonWrapper childValues = getChildValues();
 
-		assertThat(childValues.get("performanceNotMet"))
+		assertThat(childValues.getInteger("performanceNotMet"))
 				.isEqualTo(-600);
 	}
 
@@ -132,8 +131,7 @@ class QualityMeasureIdEncoderTest {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	private LinkedHashMap<String, Object> getChildValues() {
-		return (LinkedHashMap<String, Object>)((LinkedHashMap<String, Object>) wrapper.getObject()).get("value");
+	private JsonWrapper getChildValues() {
+		return wrapper.get("value");
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -122,6 +122,15 @@ class QualityMeasureIdEncoderTest {
 				.isEqualTo(-600);
 	}
 
+	@Test
+	void testIgnoresNonMeasureDataNodes() {
+		qualityMeasureId.addChildNode(aggregateCountNode);
+		executeInternalEncode();
+		JsonWrapper childValues = getChildValues();
+
+		assertThat(childValues.getInteger("aggregateCount")).isNull();
+	}
+
 	private void executeInternalEncode() {
 		qualityMeasureId.addChildNodes(populationNode, denomExclusionNode, numeratorNode, denominatorNode);
 		try {

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdMultiEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdMultiEncoderTest.java
@@ -129,10 +129,8 @@ class QualityMeasureIdMultiEncoderTest {
 
 		encoder.internalEncode(wrapper, qualityMeasureId);
 
-		LinkedHashMap<String, Object> childValues = getChildValues();
-		@SuppressWarnings("unchecked")
-		List<LinkedHashMap<String, ?>> subPopulations =
-				(List<LinkedHashMap<String, ?>>)childValues.get("strata");
+		JsonWrapper childValues = getChildValues();
+		JsonWrapper subPopulations = childValues.get("strata");
 		assertFirstSubPopulation(subPopulations);
 		assertSecondSubPopulation(subPopulations);
 	}
@@ -146,36 +144,52 @@ class QualityMeasureIdMultiEncoderTest {
 
 		encoder.internalEncode(wrapper, qualityMeasureId);
 
-		LinkedHashMap<String, Object> childValues = getChildValues();
-		@SuppressWarnings("unchecked")
-		List<LinkedHashMap<String, ?>> subPopulations =
-				(List<LinkedHashMap<String, ?>>)childValues.get("strata");
+		JsonWrapper subPopulations = getChildValues().get("strata");
 
-		assertThat(subPopulations).isEmpty();
+		assertThat(subPopulations).isNull();
 	}
 
-	@SuppressWarnings("unchecked")
-	private LinkedHashMap<String, Object> getChildValues() {
-		return (LinkedHashMap<String, Object>)((LinkedHashMap<String, Object>) wrapper.getObject()).get("value");
+	private JsonWrapper getChildValues() {
+		return wrapper.get("value");
 	}
 
-	private void assertFirstSubPopulation(List<LinkedHashMap<String, ?>> strata) {
-		LinkedHashMap<String, ?> firstSubPopulation = strata.get(0);
+	private void assertFirstSubPopulation(JsonWrapper strata) {
+		JsonWrapper firstSubPopulation = strata.get(0);
 
-		assertWithMessage(REQUIRE_POPULATION_TOTAL).that(firstSubPopulation.get(ELIGIBLE_POPULATION)).isEqualTo(600);
-		assertWithMessage(REQUIRE_PERFORMANCE_MET).that(firstSubPopulation.get(PERFORMANCE_MET)).isEqualTo(600);
-		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCEP).that(firstSubPopulation.get(ELIGIBLE_POPULATION_EXCEPTION)).isEqualTo(600);
-		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCLUS).that(firstSubPopulation.get(ELIGIBLE_POPULATION_EXCLUSION)).isEqualTo(600);
-		assertWithMessage(REQUIRE_STRATUM).that(firstSubPopulation.get(STRATUM)).isEqualTo("test1strata1");
+		assertWithMessage(REQUIRE_POPULATION_TOTAL)
+			.that(firstSubPopulation.getInteger(ELIGIBLE_POPULATION))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_PERFORMANCE_MET)
+			.that(firstSubPopulation.getInteger(PERFORMANCE_MET))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCEP)
+			.that(firstSubPopulation.getInteger(ELIGIBLE_POPULATION_EXCEPTION))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCLUS)
+			.that(firstSubPopulation.getInteger(ELIGIBLE_POPULATION_EXCLUSION))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_STRATUM)
+			.that(firstSubPopulation.getString(STRATUM))
+			.isEqualTo("test1strata1");
 	}
 
-	private void assertSecondSubPopulation(List<LinkedHashMap<String, ?>> strata) {
-		LinkedHashMap<String, ?> secondSubPopulation = strata.get(1);
+	private void assertSecondSubPopulation(JsonWrapper strata) {
+		JsonWrapper secondSubPopulation = strata.get(1);
 
-		assertWithMessage(REQUIRE_POPULATION_TOTAL).that(secondSubPopulation.get(ELIGIBLE_POPULATION)).isEqualTo(600);
-		assertWithMessage(REQUIRE_PERFORMANCE_MET).that(secondSubPopulation.get(PERFORMANCE_MET)).isEqualTo(600);
-		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCEP).that(secondSubPopulation.get(ELIGIBLE_POPULATION_EXCEPTION)).isEqualTo(600);
-		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCLUS).that(secondSubPopulation.get(ELIGIBLE_POPULATION_EXCLUSION)).isEqualTo(600);
-		assertWithMessage(REQUIRE_STRATUM).that(secondSubPopulation.get(STRATUM)).isEqualTo("test1strata2");
+		assertWithMessage(REQUIRE_POPULATION_TOTAL)
+			.that(secondSubPopulation.getInteger(ELIGIBLE_POPULATION))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_PERFORMANCE_MET)
+			.that(secondSubPopulation.getInteger(PERFORMANCE_MET))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCEP)
+			.that(secondSubPopulation.getInteger(ELIGIBLE_POPULATION_EXCEPTION))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_ELIGIBLE_POPULATION_EXCLUS)
+			.that(secondSubPopulation.getInteger(ELIGIBLE_POPULATION_EXCLUSION))
+			.isEqualTo(600);
+		assertWithMessage(REQUIRE_STRATUM)
+			.that(secondSubPopulation.getString(STRATUM))
+			.isEqualTo("test1strata2");
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/placeholder/DefaultEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/placeholder/DefaultEncoderTest.java
@@ -44,4 +44,22 @@ class DefaultEncoderTest {
 		new DefaultEncoder("Default Encode test").internalEncode(wrapper, root);
 		assertThat(wrapper.toString()).hasLength(3);
 	}
+
+	@Test
+	void encodeNodes() throws EncodeException {
+		Node root = new Node(TemplateId.DEFAULT);
+		Node placeHolder = new Node(TemplateId.PLACEHOLDER, root);
+		root.addChildNode(placeHolder);
+		placeHolder.putValue("name1", "value1");
+		Node qed = new Node(TemplateId.QED, root);
+		root.addChildNode(qed);
+		qed.putValue("name2", "value2");
+		JsonWrapper wrapper = new JsonWrapper();
+		new DefaultEncoder("Default Encode test").internalEncode(wrapper, root);
+		String json = wrapper.toString();
+		String acutal = json.replaceAll("\\s", "");
+//		String expect = "{\"DEFAULT\":[\"PLACEHOLDER\":{\"name\":\"value\"}]}"; // TODO maybe the children should be a list and data should be a map
+		String expect = "{\"DEFAULT\":{\"PLACEHOLDER\":{\"name1\":\"value1\"},\"QED\":{\"name2\":\"value2\"}}}";
+		assertThat(acutal).isEqualTo(expect);
+	}
 }

--- a/converter/src/test/resources/negative/junk_in_quality_measure.xml
+++ b/converter/src/test/resources/negative/junk_in_quality_measure.xml
@@ -15,9 +15,10 @@
    THIS SAMPLE FILE IS INFORMATIVE ONLY.
 -->
 <ClinicalDocument
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
-	xmlns="urn:hl7-org:v3"
-	xmlns:voc="urn:hl7-org:v3/voc">
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+		xmlns="urn:hl7-org:v3"
+		xmlns:voc="urn:hl7-org:v3/voc">
 	<!--
 ********************************************************
 CDA Header
@@ -35,9 +36,10 @@ CDA Header
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).
 			 This code SHALL contain exactly one [1..1] @code="55184-6" " Quality Reporting Document Architecture Calculated Summary Report (CodeSystem: LOINC 2.16.840.1.113883.6.1) (CONF:19549). -->
-	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
 	<!-- SHALL contain exactly one [1..1] title (CONF:17211). -->
-	<title>Eligible Clinicians (EC) Meaningful Use Group Sample QRDA-III		(Informative)</title>
+	<title>Eligible Clinicians (EC) Meaningful Use Group Sample QRDA-III (Informative)</title>
 	<!-- SHALL contain exactly one [1..1] effectiveTime (CONF:17237).  a. The content SHALL be a conformant US Realm Date and Time (DTM.US.FIELDED) (2.16.840.1.113883.10.20.22.5.4) (CONF:18189). -->
 	<effectiveTime value="20170311061231"/>
 	<!-- SHALL contain exactly one [1..1] confidentialityCode="N" Normal (CodeSystem: ConfidentialityCode 2.16.840.1.113883.5.25 STATIC) (CONF:711174).
@@ -185,7 +187,8 @@ CDA Header
 					1.	SHALL contain exactly one [1..1] @root="2.16.840.1.113883.3.2074.1" CMS EHR Certification ID (CONF:18305). Note: This value specifies that the id is the CMS EHR Certification ID. .-->
 			<id root="2.16.840.1.113883.3.2074.1"/>
 			<!-- This associatedEntity SHALL contain exactly one [1..1] code (CONF:18308).  This code SHALL contain exactly one [1..1] @code="129465004" medical record, device (CodeSystem: SNOMED CT 2.16.840.1.113883.6.96 STATIC) (CONF:18309). -->
-			<code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
 		</associatedEntity>
 	</participant>
 	<!-- ** 1.1.8	documentationOf ** -->
@@ -240,7 +243,8 @@ CDA Header
 			<id root="84613250-e75e-11e1-aff1-0800200c9a66"/>
 			<!-- This consent SHALL contain exactly one [1..1] code (CodeSystem: SNOMED CT 2.16.840.1.113883.6.96 STATIC) (CONF:18363).
 						This code SHALL contain exactly one [1..1] @code="425691002" Consent given for electronic record sharing (CodeSystem: SNOMED CT 2.16.840.1.113883.6.96) (CONF:19550). -->
-			<code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
 			<!-- This consent SHALL contain exactly one [1..1] statusCode (CONF:18364) that SHALL contain exactly one [1..1] @code="completed" Completed (CodeSystem: ActStatus 2.16.840.1.113883.5.14) (CONF:19551). -->
 			<statusCode code="completed"/>
 		</consent>
@@ -264,4073 +268,1927 @@ CDA Header
 					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01"/>
 					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1" displayName="measure section"/>
 					<title>Measure Section</title>
-					<text>
-						<!--NQF 0018/ CMS165-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Controlling High Blood Pressure</td>
-									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
-									<td>40280381-51f0-825b-0152-22b98cff181a</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0028/ CMS138-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Preventive Care and Screening: Tobacco Use: Screening and										Cessation Intervention</td>
-									<td>e35791df-5b25-41bb-b260-673337bc44a8</td>
-									<td>40280381-503f-a1fc-0150-d33f5b0a1b8c</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0031/ CMS125-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Breast Cancer Screening</td>
-									<td>19783c1b-4fd1-46c1-8a96-a2f192b97ee0</td>
-									<td>40280381-51f0-825b-0152-229c4ea3170c</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0034/ CMS130-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Colorectal Cancer Screening</td>
-									<td>aa2a4bbc-864f-45ee-b17a-7ebcc62e6aac</td>
-									<td>40280381-51f0-825b-0152-22a1e7e81737</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0041/ CMS147-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Preventive Care and Screening: Influenza Immunization</td>
-									<td>a244aa29-7d11-4616-888a-86e376bfcc6f</td>
-									<td>40280381-52fc-3a32-0153-395ce63513af</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0043/ CMS127-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Pneumonia Vaccination Status for Older Adults</td>
-									<td>59657b9b-01bf-4979-a090-8534da1d0516</td>
-									<td>40280381-52fc-3a32-0153-1a646a2a0bfa</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0059/ CMS122-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Diabetes: Hemoglobin A1c Poor Control</td>
-									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
-									<td>40280381-51f0-825b-0152-229afff616ee</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0064/ CMS163-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Diabetes: Low Density Lipoprotein (LDL) Management</td>
-									<td>0dac1dec-e011-493b-a281-7c28964872dd</td>
-									<td>40280381-52fc-3a32-0153-1dfb2f2c0c48</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0075/ CMS182-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Ischemic Vascular Disease (IVD): Complete Lipid Panel and										LDL Control</td>
-									<td>500e4792-7f94-4e34-8546-ee71c56fe463</td>
-									<td>40280381-51f0-825b-0152-22bd8ee41875</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842								0.789
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:750
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>450
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0083/ CMS144-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Heart Failure (HF): Beta-Blocker Therapy for Left										Ventricular Systolic Dysfunction (LVSD)</td>
-									<td>8439f671-2932-4d4c-88ca-ea5faeacc89a</td>
-									<td>40280381-52fc-3a32-0153-1a3981870b45</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0101/ CMS139-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Falls: Screening for Future Fall Risk</td>
-									<td>bc5b4a57-b964-4399-9d40-667c896f31ea</td>
-									<td>40280381-51f0-825b-0152-22aae8a21778</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0418/ CMS2-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Preventive Care and Screening: Screening for Clinical										Depression and Follow-Up Plan</td>
-									<td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
-									<td>40280381-537c-f767-0153-c378bd7207a5</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.89
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0419/ CMS68-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Documentation of Current Medications in the Medical										Record</td>
-									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
-									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-					</text>
 					<!--Measure Entry for NQF 0018/ CMS165-->
 					<entry>
-            <organizer classCode="CLUSTER" moodCode="EVN">
-              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01" />
-              <id root="D5E68474-5760-11E7-1256-09173F13E4C5" />
-              <statusCode code="completed" />
-              <!--Measure Reference and Results-->
-              <reference typeCode="REFR">
-                <externalDocument classCode="DOC" moodCode="EVN">
-                  <id root="2.16.840.1.113883.4.738" extension="40280382-5abd-fa46-015b-49abb28d38b2" />
-                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
-                  <text>Controlling High Blood Pressure</text>
-                </externalDocument>
-              </reference>
-              <!--Performance Rate-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01" />
-                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Performance Rate" />
-                  <statusCode code="completed" />
-                  <value xsi:type="REAL" value=".888889" />
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="709D84FA-637D-42CD-8934-43C3FBAD0979" />
-                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Numerator" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--IPOP Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--IPOP Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68475-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68476-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68477-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68478-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68479-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6847D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6847E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6847F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68480-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--IPOP Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="5C206C23-4CF9-4390-9E76-0F243FE59DCF" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENOM Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENOM Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68481-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68482-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68483-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68484-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68485-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68486-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68487-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68488-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68489-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6848A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6848B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6848C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENOM Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="1D456B20-71F7-4477-BD23-D39600D5A095" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENEX Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENEX Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="100" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6848F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68490-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68491-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68492-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68493-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68494-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68495-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68496-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68497-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68498-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENEX Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="9805BC7D-274C-4CCF-916A-B5BA34D62A31" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--NUMER Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--NUMER Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="800" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68499-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6849A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E684A0-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A1-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A2-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A3-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A4-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--NUMER Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="709D84FA-637D-42CD-8934-43C3FBAD0979" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-            </organizer>
-          </entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="40280382-5abd-fa46-015b-49abb28d38b2"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="709D84FA-637D-42CD-8934-43C3FBAD0979"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--Invalid Measure Performed Node-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.27" extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="5C206C23-4CF9-4390-9E76-0F243FE59DCF"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="1D456B20-71F7-4477-BD23-D39600D5A095"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9805BC7D-274C-4CCF-916A-B5BA34D62A31"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="709D84FA-637D-42CD-8934-43C3FBAD0979"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
 					<!-- Reporting Parameters Act -->
 					<entry typeCode="DRIV">
 						<act classCode="ACT" moodCode="EVN">

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1Test.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/QrdaControllerV1Test.java
@@ -80,7 +80,7 @@ class QrdaControllerV1Test {
 	@BeforeEach
 	void initialization() throws IOException {
 		JsonWrapper wrapper = new JsonWrapper();
-		wrapper.putString("key", "Good Qpp");
+		wrapper.put("key", "Good Qpp");
 
 		validationInputStream = Files.newInputStream(validationJsonFilePath);
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/AuditServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/AuditServiceImplTest.java
@@ -183,7 +183,7 @@ public class AuditServiceImplTest {
 	private void successfulEncodingPrep() {
 		prepOverlap();
 		JsonWrapper wrapper = new JsonWrapper();
-		wrapper.putString("meep", "mawp");
+		wrapper.put("meep", "mawp");
 
 		when(report.getQppSource()).thenReturn(wrapper.toSource());
 	}

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/QrdaServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/QrdaServiceImplTest.java
@@ -87,7 +87,7 @@ class QrdaServiceImplTest {
 		Converter mockConverter = mock(Converter.class);
 
 		JsonWrapper qpp = new JsonWrapper();
-		qpp.putString(KEY, MOCK_SUCCESS_QPP_STRING);
+		qpp.put(KEY, MOCK_SUCCESS_QPP_STRING);
 
 		ConversionReport report = mock(ConversionReport.class);
 


### PR DESCRIPTION
### Information
- JIRA story QPPCT-1008.

### Changes proposed in this PR:
- Refactors Metadata out of the JsonWrapper named string map.
- Uses the JsonWrapper recursively to hold object rather than Object type.
-

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
