### PR TITLE
Measure Reference and Results Bug

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -181,7 +181,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		this.encodePerformanceNotMet(childWrapper, parentNode);
 
 		for (Node childNode : parentNode.getChildNodes()) {
-			if (TemplateId.MEASURE_DATA_CMS_V2.equals(childNode.getType())) {
+			if (TemplateId.MEASURE_DATA_CMS_V2 == childNode.getType()) {
 				JsonOutputEncoder measureDataEncoder = encoders.get(childNode.getType());
 				measureDataEncoder.encode(childWrapper, childNode);
 			}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -181,8 +181,8 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		this.encodePerformanceNotMet(childWrapper, parentNode);
 
 		for (Node childNode : parentNode.getChildNodes()) {
-			JsonOutputEncoder measureDataEncoder = encoders.get(childNode.getType());
-			if (null != measureDataEncoder) {
+			if (TemplateId.MEASURE_DATA_CMS_V2.equals(childNode.getType())) {
+				JsonOutputEncoder measureDataEncoder = encoders.get(childNode.getType());
 				measureDataEncoder.encode(childWrapper, childNode);
 			}
 		}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -48,6 +48,19 @@ class QualityMeasureIdRoundTripTest {
 	}
 
 	@Test
+	void testMeasureCMS165DoesNotContainUnexpectedValue() {
+		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE));
+		JsonWrapper qpp = converter.transform();
+		List<String> containsUnwantedValueList = JsonHelper.readJsonAtJsonPath(qpp.toString(),
+			"$.measurementSets[?(@.category=='quality')].measurements[0].value.value", new TypeRef<List<String>>() { });
+		List<String> measureId = JsonHelper.readJsonAtJsonPath(qpp.toString(),
+			"$.measurementSets[?(@.category=='quality')].measurements[*].measureId", new TypeRef<List<String>>() { });
+
+		assertThat(measureId.get(0)).isEqualTo("236");
+		assertThat(containsUnwantedValueList).isEmpty();
+	}
+
+	@Test
 	void testMeasureCMS68v7PerformanceRateUuid() {
 		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE));
 		List<Detail> details = new ArrayList<>();

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -123,6 +123,15 @@ class QualityMeasureIdEncoderTest {
 				.isEqualTo(-600);
 	}
 
+	@Test
+	void testIgnoresNonMeasureDataNodes() {
+		qualityMeasureId.addChildNode(aggregateCountNode);
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+
+		assertThat(childValues.get("aggregateCount")).isNull();
+	}
+
 	private void executeInternalEncode() {
 		qualityMeasureId.addChildNodes(populationNode, denomExclusionNode, numeratorNode, denominatorNode);
 		try {

--- a/converter/src/test/resources/negative/junk_in_quality_measure.xml
+++ b/converter/src/test/resources/negative/junk_in_quality_measure.xml
@@ -15,9 +15,10 @@
    THIS SAMPLE FILE IS INFORMATIVE ONLY.
 -->
 <ClinicalDocument
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
-	xmlns="urn:hl7-org:v3"
-	xmlns:voc="urn:hl7-org:v3/voc">
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+		xmlns="urn:hl7-org:v3"
+		xmlns:voc="urn:hl7-org:v3/voc">
 	<!--
 ********************************************************
 CDA Header
@@ -35,9 +36,10 @@ CDA Header
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).
 			 This code SHALL contain exactly one [1..1] @code="55184-6" " Quality Reporting Document Architecture Calculated Summary Report (CodeSystem: LOINC 2.16.840.1.113883.6.1) (CONF:19549). -->
-	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
 	<!-- SHALL contain exactly one [1..1] title (CONF:17211). -->
-	<title>Eligible Clinicians (EC) Meaningful Use Group Sample QRDA-III		(Informative)</title>
+	<title>Eligible Clinicians (EC) Meaningful Use Group Sample QRDA-III (Informative)</title>
 	<!-- SHALL contain exactly one [1..1] effectiveTime (CONF:17237).  a. The content SHALL be a conformant US Realm Date and Time (DTM.US.FIELDED) (2.16.840.1.113883.10.20.22.5.4) (CONF:18189). -->
 	<effectiveTime value="20170311061231"/>
 	<!-- SHALL contain exactly one [1..1] confidentialityCode="N" Normal (CodeSystem: ConfidentialityCode 2.16.840.1.113883.5.25 STATIC) (CONF:711174).
@@ -185,7 +187,8 @@ CDA Header
 					1.	SHALL contain exactly one [1..1] @root="2.16.840.1.113883.3.2074.1" CMS EHR Certification ID (CONF:18305). Note: This value specifies that the id is the CMS EHR Certification ID. .-->
 			<id root="2.16.840.1.113883.3.2074.1"/>
 			<!-- This associatedEntity SHALL contain exactly one [1..1] code (CONF:18308).  This code SHALL contain exactly one [1..1] @code="129465004" medical record, device (CodeSystem: SNOMED CT 2.16.840.1.113883.6.96 STATIC) (CONF:18309). -->
-			<code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
 		</associatedEntity>
 	</participant>
 	<!-- ** 1.1.8	documentationOf ** -->
@@ -240,7 +243,8 @@ CDA Header
 			<id root="84613250-e75e-11e1-aff1-0800200c9a66"/>
 			<!-- This consent SHALL contain exactly one [1..1] code (CodeSystem: SNOMED CT 2.16.840.1.113883.6.96 STATIC) (CONF:18363).
 						This code SHALL contain exactly one [1..1] @code="425691002" Consent given for electronic record sharing (CodeSystem: SNOMED CT 2.16.840.1.113883.6.96) (CONF:19550). -->
-			<code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
 			<!-- This consent SHALL contain exactly one [1..1] statusCode (CONF:18364) that SHALL contain exactly one [1..1] @code="completed" Completed (CodeSystem: ActStatus 2.16.840.1.113883.5.14) (CONF:19551). -->
 			<statusCode code="completed"/>
 		</consent>
@@ -264,4073 +268,1927 @@ CDA Header
 					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01"/>
 					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1" displayName="measure section"/>
 					<title>Measure Section</title>
-					<text>
-						<!--NQF 0018/ CMS165-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Controlling High Blood Pressure</td>
-									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
-									<td>40280381-51f0-825b-0152-22b98cff181a</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0028/ CMS138-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Preventive Care and Screening: Tobacco Use: Screening and										Cessation Intervention</td>
-									<td>e35791df-5b25-41bb-b260-673337bc44a8</td>
-									<td>40280381-503f-a1fc-0150-d33f5b0a1b8c</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0031/ CMS125-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Breast Cancer Screening</td>
-									<td>19783c1b-4fd1-46c1-8a96-a2f192b97ee0</td>
-									<td>40280381-51f0-825b-0152-229c4ea3170c</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0034/ CMS130-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Colorectal Cancer Screening</td>
-									<td>aa2a4bbc-864f-45ee-b17a-7ebcc62e6aac</td>
-									<td>40280381-51f0-825b-0152-22a1e7e81737</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0041/ CMS147-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Preventive Care and Screening: Influenza Immunization</td>
-									<td>a244aa29-7d11-4616-888a-86e376bfcc6f</td>
-									<td>40280381-52fc-3a32-0153-395ce63513af</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0043/ CMS127-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Pneumonia Vaccination Status for Older Adults</td>
-									<td>59657b9b-01bf-4979-a090-8534da1d0516</td>
-									<td>40280381-52fc-3a32-0153-1a646a2a0bfa</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0059/ CMS122-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Diabetes: Hemoglobin A1c Poor Control</td>
-									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
-									<td>40280381-51f0-825b-0152-229afff616ee</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0064/ CMS163-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Diabetes: Low Density Lipoprotein (LDL) Management</td>
-									<td>0dac1dec-e011-493b-a281-7c28964872dd</td>
-									<td>40280381-52fc-3a32-0153-1dfb2f2c0c48</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0075/ CMS182-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Ischemic Vascular Disease (IVD): Complete Lipid Panel and										LDL Control</td>
-									<td>500e4792-7f94-4e34-8546-ee71c56fe463</td>
-									<td>40280381-51f0-825b-0152-22bd8ee41875</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842								0.789
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:750
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>450
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0083/ CMS144-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Heart Failure (HF): Beta-Blocker Therapy for Left										Ventricular Systolic Dysfunction (LVSD)</td>
-									<td>8439f671-2932-4d4c-88ca-ea5faeacc89a</td>
-									<td>40280381-52fc-3a32-0153-1a3981870b45</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0101/ CMS139-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Falls: Screening for Future Fall Risk</td>
-									<td>bc5b4a57-b964-4399-9d40-667c896f31ea</td>
-									<td>40280381-51f0-825b-0152-22aae8a21778</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0418/ CMS2-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Preventive Care and Screening: Screening for Clinical										Depression and Follow-Up Plan</td>
-									<td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
-									<td>40280381-537c-f767-0153-c378bd7207a5</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.89
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-						<!--NQF 0419/ CMS68-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Documentation of Current Medications in the Medical										Record</td>
-									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
-									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.842
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Patient Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -										Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -										Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-					</text>
 					<!--Measure Entry for NQF 0018/ CMS165-->
 					<entry>
-            <organizer classCode="CLUSTER" moodCode="EVN">
-              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01" />
-              <id root="D5E68474-5760-11E7-1256-09173F13E4C5" />
-              <statusCode code="completed" />
-              <!--Measure Reference and Results-->
-              <reference typeCode="REFR">
-                <externalDocument classCode="DOC" moodCode="EVN">
-                  <id root="2.16.840.1.113883.4.738" extension="40280382-5abd-fa46-015b-49abb28d38b2" />
-                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
-                  <text>Controlling High Blood Pressure</text>
-                </externalDocument>
-              </reference>
-              <!--Performance Rate-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01" />
-                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Performance Rate" />
-                  <statusCode code="completed" />
-                  <value xsi:type="REAL" value=".888889" />
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="709D84FA-637D-42CD-8934-43C3FBAD0979" />
-                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Numerator" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--IPOP Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--IPOP Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68475-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68476-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68477-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68478-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68479-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6847D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6847E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6847F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68480-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--IPOP Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="5C206C23-4CF9-4390-9E76-0F243FE59DCF" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENOM Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENOM Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68481-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68482-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68483-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68484-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68485-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68486-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68487-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68488-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68489-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6848A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6848B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E6848C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENOM Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="1D456B20-71F7-4477-BD23-D39600D5A095" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENEX Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENEX Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="100" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6848F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68490-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68491-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68492-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68493-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68494-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68495-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68496-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68497-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E68498-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENEX Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="9805BC7D-274C-4CCF-916A-B5BA34D62A31" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--NUMER Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--NUMER Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="800" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68499-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6849A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E684A0-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A1-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A2-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A3-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
-                      <id root="D5E684A4-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--NUMER Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="709D84FA-637D-42CD-8934-43C3FBAD0979" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-            </organizer>
-          </entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="40280382-5abd-fa46-015b-49abb28d38b2"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="709D84FA-637D-42CD-8934-43C3FBAD0979"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--Invalid Measure Performed Node-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.27" extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="5C206C23-4CF9-4390-9E76-0F243FE59DCF"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="1D456B20-71F7-4477-BD23-D39600D5A095"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9805BC7D-274C-4CCF-916A-B5BA34D62A31"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="709D84FA-637D-42CD-8934-43C3FBAD0979"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
 					<!-- Reporting Parameters Act -->
 					<entry typeCode="DRIV">
 						<act classCode="ACT" moodCode="EVN">


### PR DESCRIPTION
### Information
- Fix for the `value:true` encoding bug in the measure section reference and results node.
- Forces a whitelist in the measure section v2 encoder as it does not need any other template id's encoded. If other template id's need to be encoded here in the future, they can be added.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
