### PR TITLE
Fix CMS347v1

### DIFF
--- a/commandline/src/test/resources/measures-data.json
+++ b/commandline/src/test/resources/measures-data.json
@@ -44044,7 +44044,39 @@
 			"electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/measures/cms347v1"
 		},
 		"cpcPlusGroup": "Other_Measure",
-		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7"
+		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
+		"strata": [
+			{
+				"description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
+					"denominatorUuid": "CC35FC48-FA75-4E8C-8949-BC2B4D152F72",
+					"numeratorUuid": "53656F0F-97C7-4537-907E-4C8D836A5853",
+					"denominatorExclusionUuid": "6C1F017F-F0C4-4346-B823-0BC24E3BFA9C",
+					"denominatorExceptionUuid": "F13A488B-6F7F-45E3-8216-1A7A679ADBFD"
+				}
+			},
+			{
+				"description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
+					"denominatorUuid": "C44EA250-22FE-4FF1-835B-BD718A9E71FA",
+					"numeratorUuid": "632ECBD0-8C77-40E9-AE21-795891D5CD64",
+					"denominatorExclusionUuid": "C5AA9EF4-FC68-4844-A45A-4985E81DA8A1",
+					"denominatorExceptionUuid": "B55F6B97-ABF6-4F44-90C5-D02D99DE55DA"
+				}
+			},
+			{
+				"description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",
+					"denominatorUuid": "01B3E154-5F42-4905-BDDD-E2A34B8C1DB2",
+					"numeratorUuid": "5E64B1E4-1F1A-4B3B-B148-5044F6B30760",
+					"denominatorExclusionUuid": "1354D37B-998F-434E-8039-99F6CCC987FD",
+					"denominatorExceptionUuid": "3D0BD8CB-CB77-407A-A367-080F53D880DD"
+				}
+			}
+		]
 	},
 	{
 		"title": "Age Appropriate Screening Colonoscopy",

--- a/commandline/src/test/resources/measures-data.json
+++ b/commandline/src/test/resources/measures-data.json
@@ -44047,6 +44047,7 @@
 		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
 		"strata": [
 			{
+				"name" : "clinicalASCVD",
 				"description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
@@ -44057,6 +44058,7 @@
 				}
 			},
 			{
+				"name" : ">21Familial",
 				"description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
@@ -44067,6 +44069,7 @@
 				}
 			},
 			{
+				"name" : "between40And75",
 				"description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",

--- a/commons/src/main/resources/measures-data.json
+++ b/commons/src/main/resources/measures-data.json
@@ -44044,7 +44044,39 @@
 			"electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/measures/cms347v1"
 		},
 		"cpcPlusGroup": "Other_Measure",
-		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7"
+		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
+		"strata": [
+			{
+				"description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
+					"denominatorUuid": "CC35FC48-FA75-4E8C-8949-BC2B4D152F72",
+					"numeratorUuid": "53656F0F-97C7-4537-907E-4C8D836A5853",
+					"denominatorExclusionUuid": "6C1F017F-F0C4-4346-B823-0BC24E3BFA9C",
+					"denominatorExceptionUuid": "F13A488B-6F7F-45E3-8216-1A7A679ADBFD"
+				}
+			},
+			{
+				"description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
+					"denominatorUuid": "C44EA250-22FE-4FF1-835B-BD718A9E71FA",
+					"numeratorUuid": "632ECBD0-8C77-40E9-AE21-795891D5CD64",
+					"denominatorExclusionUuid": "C5AA9EF4-FC68-4844-A45A-4985E81DA8A1",
+					"denominatorExceptionUuid": "B55F6B97-ABF6-4F44-90C5-D02D99DE55DA"
+				}
+			},
+			{
+				"description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",
+					"denominatorUuid": "01B3E154-5F42-4905-BDDD-E2A34B8C1DB2",
+					"numeratorUuid": "5E64B1E4-1F1A-4B3B-B148-5044F6B30760",
+					"denominatorExclusionUuid": "1354D37B-998F-434E-8039-99F6CCC987FD",
+					"denominatorExceptionUuid": "3D0BD8CB-CB77-407A-A367-080F53D880DD"
+				}
+			}
+		]
 	},
 	{
 		"title": "Age Appropriate Screening Colonoscopy",

--- a/commons/src/main/resources/measures-data.json
+++ b/commons/src/main/resources/measures-data.json
@@ -44047,6 +44047,7 @@
 		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
 		"strata": [
 			{
+				"name" : "clinicalASCVD",
 				"description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
@@ -44057,6 +44058,7 @@
 				}
 			},
 			{
+				"name" : ">21Familial",
 				"description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
@@ -44067,6 +44069,7 @@
 				}
 			},
 			{
+				"name" : "between40And75",
 				"description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
@@ -5,6 +5,7 @@ import gov.cms.qpp.conversion.model.Encoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+import gov.cms.qpp.conversion.util.SubPopulationHelper;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -32,28 +33,12 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
 		if (!SubPopulationLabel.IPOP.hasAlias(node.getValue(MEASURE_TYPE))) {
-			Map<SubPopulationLabel, String> measureTypeMapper = initializeMeasureTypeMap();
 			String measureType = node.getValue(MEASURE_TYPE);
 			Node aggCount = node.findFirstNode(TemplateId.PI_AGGREGATE_COUNT);
 
-			String encodeLabel = measureTypeMapper.get(SubPopulationLabel.findPopulation(measureType));
+			String encodeLabel = SubPopulationHelper.measureTypeMap.get(SubPopulationLabel.findPopulation(measureType));
 			wrapper.putInteger(encodeLabel, aggCount.getValue(AGGREGATE_COUNT));
 			maintainContinuity(wrapper, aggCount, encodeLabel);
 		}
 	}
-
-	/**
-	 * Initializes the measure type map with specific values.
-	 *
-	 * @return intialized measure type map
-	 */
-	private Map<SubPopulationLabel, String> initializeMeasureTypeMap() {
-		Map<SubPopulationLabel, String> measureTypeMapper = new EnumMap<>(SubPopulationLabel.class);
-		measureTypeMapper.put(SubPopulationLabel.NUMER, "performanceMet");
-		measureTypeMapper.put(SubPopulationLabel.DENOM, "eligiblePopulation");
-		measureTypeMapper.put(SubPopulationLabel.DENEX, "eligiblePopulationExclusion");
-		measureTypeMapper.put(SubPopulationLabel.DENEXCEP, "eligiblePopulationException");
-		return measureTypeMapper;
-	}
-
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -84,25 +84,45 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		wrapper.putObject(VALUE, childWrapper);
 	}
 
-	private void encodeSubPopulationSum(SubPopulationLabel label, Node parentNode, JsonWrapper childWrapper) {
-		int currentPopulationSum = calculateSubPopulationSum(parentNode, label);
-		maintainContinuity(childWrapper, parentNode, SubPopulationHelper.measureTypeMap.get(label));
+	/**
+	 *
+	 *
+	 * @param label current Sub-Population type
+	 * @param measureReferenceNode holder of measure data nodes
+	 * @param childWrapper wrapper to hold encoded measure data
+	 */
+	private void encodeSubPopulationSum(SubPopulationLabel label, Node measureReferenceNode, JsonWrapper childWrapper) {
+		int currentPopulationSum = calculateSubPopulationSum(measureReferenceNode, label);
+		maintainContinuity(childWrapper, measureReferenceNode, SubPopulationHelper.measureTypeMap.get(label));
 		childWrapper.putInteger(SubPopulationHelper.measureTypeMap.get(label), String.valueOf(currentPopulationSum));
 	}
 
-	private void encodePerformanceNotMetSubPopulationSum(JsonWrapper childWrapper, Node parentNode) {
-		int numeratorSum = calculateSubPopulationSum(parentNode, SubPopulationLabel.NUMER);
-		int denominatorSum = calculateSubPopulationSum(parentNode, SubPopulationLabel.DENOM);
-		int denexSum = calculateSubPopulationSum(parentNode, SubPopulationLabel.DENEX);
-		int denexcepSum = calculateSubPopulationSum(parentNode, SubPopulationLabel.DENEXCEP);
+	/**
+	 *
+	 *
+	 * @param childWrapper wrapper to hold encoded measure data
+	 * @param measureReferenceNode holder of measure data nodes
+	 */
+	private void encodePerformanceNotMetSubPopulationSum(JsonWrapper childWrapper, Node measureReferenceNode) {
+		int numeratorSum = calculateSubPopulationSum(measureReferenceNode, SubPopulationLabel.NUMER);
+		int denominatorSum = calculateSubPopulationSum(measureReferenceNode, SubPopulationLabel.DENOM);
+		int denexSum = calculateSubPopulationSum(measureReferenceNode, SubPopulationLabel.DENEX);
+		int denexcepSum = calculateSubPopulationSum(measureReferenceNode, SubPopulationLabel.DENEXCEP);
 		int performanceNotMet = denominatorSum - numeratorSum - denexSum - denexcepSum;
 
-		maintainContinuity(childWrapper, parentNode, PERFORMANCE_NOT_MET);
+		maintainContinuity(childWrapper, measureReferenceNode, PERFORMANCE_NOT_MET);
 		childWrapper.putInteger(PERFORMANCE_NOT_MET, String.valueOf(performanceNotMet));
 	}
 
-	private int calculateSubPopulationSum(Node separateSubpopulationNode, SubPopulationLabel label) {
-		return separateSubpopulationNode.getChildNodes(TemplateId.MEASURE_DATA_CMS_V2)
+	/**
+	 *
+	 *
+	 * @param measureReferenceNode holder of measure data nodes
+	 * @param label current Sub-Population type
+	 * @return
+	 */
+	private int calculateSubPopulationSum(Node measureReferenceNode, SubPopulationLabel label) {
+		return measureReferenceNode.getChildNodes(TemplateId.MEASURE_DATA_CMS_V2)
 			.filter(childNode ->
 				label.hasAlias(childNode.getValue(MeasureDataDecoder.MEASURE_TYPE)))
 			.mapToInt(ipopNode ->

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -36,7 +36,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	private static final String SINGLE_PERFORMANCE_RATE = "singlePerformanceRate";
 	public static final String IS_END_TO_END_REPORTED = "isEndToEndReported";
 	private static final String TRUE = "true";
-	private static final String MEASURE_438= "438";
+	private static final String MEASURE_438 = "438";
 	private static final String PERFORMANCE_NOT_MET = "performanceNotMet";
 
 	public QualityMeasureIdEncoder(Context context) {
@@ -57,11 +57,9 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		wrapper.putString(MEASURE_ID, measureId);
 		if (MEASURE_438.equals(measureId)) {
 			encodeAllSubPopulationSums(wrapper, node);
-		}
-		else if (isASinglePerformanceRate(measureConfig) && !MEASURE_438.equals(measureId)) {
+		} else if (isASinglePerformanceRate(measureConfig) && !MEASURE_438.equals(measureId)) {
 			encodeChildren(wrapper, node, measureConfig);
-		}
- 		else {
+		} else {
 			encodeMultiPerformanceRate(wrapper, node, measureConfig);
 		}
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoder.java
@@ -13,8 +13,6 @@ import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
 import gov.cms.qpp.conversion.util.MeasureConfigHelper;
 import gov.cms.qpp.conversion.util.SubPopulationHelper;
 
-import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -36,7 +34,7 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 	private static final String SINGLE_PERFORMANCE_RATE = "singlePerformanceRate";
 	public static final String IS_END_TO_END_REPORTED = "isEndToEndReported";
 	private static final String TRUE = "true";
-	private static final String MEASURE_438 = "438";
+	private static final String CMS347_MEASURE_ID = "438";
 	private static final String PERFORMANCE_NOT_MET = "performanceNotMet";
 
 	public QualityMeasureIdEncoder(Context context) {
@@ -55,9 +53,9 @@ public class QualityMeasureIdEncoder extends QppOutputEncoder {
 		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node);
 		String measureId = measureConfig.getMeasureId();
 		wrapper.putString(MEASURE_ID, measureId);
-		if (MEASURE_438.equals(measureId)) {
+		if (CMS347_MEASURE_ID.equals(measureId)) {
 			encodeAllSubPopulationSums(wrapper, node);
-		} else if (isASinglePerformanceRate(measureConfig) && !MEASURE_438.equals(measureId)) {
+		} else if (isASinglePerformanceRate(measureConfig)) {
 			encodeChildren(wrapper, node, measureConfig);
 		} else {
 			encodeMultiPerformanceRate(wrapper, node, measureConfig);

--- a/converter/src/main/java/gov/cms/qpp/conversion/util/SubPopulationHelper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/util/SubPopulationHelper.java
@@ -1,0 +1,22 @@
+package gov.cms.qpp.conversion.util;
+
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+
+public class SubPopulationHelper {
+
+	public static final Map<SubPopulationLabel, String> measureTypeMap;
+
+	static {
+		Map<SubPopulationLabel, String> measureTypeMapper = new EnumMap<>(SubPopulationLabel.class);
+		measureTypeMapper.put(SubPopulationLabel.NUMER, "performanceMet");
+		measureTypeMapper.put(SubPopulationLabel.DENOM, "eligiblePopulation");
+		measureTypeMapper.put(SubPopulationLabel.DENEX, "eligiblePopulationExclusion");
+		measureTypeMapper.put(SubPopulationLabel.DENEXCEP, "eligiblePopulationException");
+		measureTypeMap = Collections.unmodifiableMap(measureTypeMapper);
+	}
+}

--- a/converter/src/main/java/gov/cms/qpp/conversion/util/SubPopulationHelper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/util/SubPopulationHelper.java
@@ -6,11 +6,16 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 
-
+/**
+ * Helper for Sub population mapping data
+ */
 public class SubPopulationHelper {
 
 	public static final Map<SubPopulationLabel, String> measureTypeMap;
 
+	/**
+	 * Mapper that translates the Metric type to encoding name
+	 */
 	static {
 		Map<SubPopulationLabel, String> measureTypeMapper = new EnumMap<>(SubPopulationLabel.class);
 		measureTypeMapper.put(SubPopulationLabel.NUMER, "performanceMet");

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -37,7 +37,7 @@ import static gov.cms.qpp.conversion.decode.MeasureDataDecoder.MEASURE_TYPE;
 abstract class QualityMeasureIdValidator extends NodeValidator {
 	Set<SubPopulationLabel> subPopulationExclusions = Collections.emptySet();
 	protected static final String NOT_AVAILABLE = "(not provided)";
-	protected static final Set<String> IPOP = Stream.of("IPP", "IPOP")
+	public static final Set<String> IPOP = Stream.of("IPP", "IPOP")
 			.collect(Collectors.toSet());
 	private static final Logger DEV_LOG = LoggerFactory.getLogger(QualityMeasureIdValidator.class);
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -46,7 +46,7 @@ class QualityMeasureIdEncoderTest {
 		denomExclusionNode.addChildNode(aggregateCountNode);
 
 		denominatorExceptionNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
-		denominatorExceptionNode.putValue(type, SubPopulationLabel.DENEX.name());
+		denominatorExceptionNode.putValue(type, SubPopulationLabel.DENEXCEP.name());
 		denominatorExceptionNode.addChildNode(aggregateCountNode);
 
 		numeratorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
@@ -125,20 +125,73 @@ class QualityMeasureIdEncoderTest {
 		LinkedHashMap<String, Object> childValues = getChildValues();
 
 		assertThat(childValues.get("performanceNotMet"))
-				.isEqualTo(-600);
+				.isEqualTo(-1200);
 	}
 
 	@Test
-	void testMeasure438Encoding()
+	void testMeasure438EncodingEndToEndEncoded()
 	{
 		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
 		executeInternalEncode();
 		LinkedHashMap<String, Object> childValues = getChildValues();
-		System.out.println(childValues);
 
+		assertThat((Boolean)childValues.get("isEndToEndReported"))
+			.isTrue();
 	}
+
+	@Test
+	void testMeasure438EncodingEligiblePopulation() {
+		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+
+		assertThat(childValues.get(ELIGIBLE_POPULATION))
+			.isEqualTo(600);
+	}
+
+	@Test
+	void testMeasure438EncodingPerformanceMet() {
+		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+
+		assertThat(childValues.get("performanceMet"))
+			.isEqualTo(600);
+	}
+
+	@Test
+	void testMeasure438EncodingEligiblePopulationExclusion() {
+		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+
+		assertThat(childValues.get("eligiblePopulationExclusion"))
+			.isEqualTo(600);
+	}
+
+	@Test
+	void testMeasure438EncodingEligiblePopulationException() {
+		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+
+		assertThat(childValues.get("eligiblePopulationException"))
+			.isEqualTo(600);
+	}
+
+	@Test
+	void testMeasure438EncodingPerformanceNotMet() {
+		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+
+		assertThat(childValues.get("performanceNotMet"))
+			.isEqualTo(-1200);
+	}
+
 	private void executeInternalEncode() {
-		qualityMeasureId.addChildNodes(populationNode, denomExclusionNode, numeratorNode, denominatorNode, denomExclusionNode);
+		qualityMeasureId.addChildNodes(populationNode, denomExclusionNode, numeratorNode, denominatorNode,
+			denominatorExceptionNode);
 		try {
 			encoder.internalEncode(wrapper, qualityMeasureId);
 		} catch (EncodeException e) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -17,6 +17,7 @@ class QualityMeasureIdEncoderTest {
 	private Node qualityMeasureId;
 	private Node populationNode;
 	private Node denomExclusionNode;
+	private Node denominatorExceptionNode;
 	private Node numeratorNode;
 	private Node denominatorNode;
 	private Node aggregateCountNode;
@@ -43,6 +44,10 @@ class QualityMeasureIdEncoderTest {
 		denomExclusionNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
 		denomExclusionNode.putValue(type, SubPopulationLabel.DENEX.name());
 		denomExclusionNode.addChildNode(aggregateCountNode);
+
+		denominatorExceptionNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
+		denominatorExceptionNode.putValue(type, SubPopulationLabel.DENEX.name());
+		denominatorExceptionNode.addChildNode(aggregateCountNode);
 
 		numeratorNode = new Node(TemplateId.MEASURE_DATA_CMS_V2);
 		numeratorNode.putValue(type, SubPopulationLabel.NUMER.name());
@@ -123,8 +128,17 @@ class QualityMeasureIdEncoderTest {
 				.isEqualTo(-600);
 	}
 
+	@Test
+	void testMeasure438Encoding()
+	{
+		qualityMeasureId.putValue("measureId", "40280382-5b4d-eebc-015b-8245e0fa06b7");
+		executeInternalEncode();
+		LinkedHashMap<String, Object> childValues = getChildValues();
+		System.out.println(childValues);
+
+	}
 	private void executeInternalEncode() {
-		qualityMeasureId.addChildNodes(populationNode, denomExclusionNode, numeratorNode, denominatorNode);
+		qualityMeasureId.addChildNodes(populationNode, denomExclusionNode, numeratorNode, denominatorNode, denomExclusionNode);
 		try {
 			encoder.internalEncode(wrapper, qualityMeasureId);
 		} catch (EncodeException e) {

--- a/converter/src/test/java/gov/cms/qpp/conversion/util/SubPopulationHelperTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/util/SubPopulationHelperTest.java
@@ -1,0 +1,45 @@
+package gov.cms.qpp.conversion.util;
+
+import org.junit.jupiter.api.Test;
+
+import gov.cms.qpp.conversion.model.validation.SubPopulationLabel;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class SubPopulationHelperTest {
+
+	@Test
+	void testMapperWithNumeratorLabel() {
+		String label = SubPopulationHelper.measureTypeMap.get(SubPopulationLabel.NUMER);
+
+		assertThat(label).isEqualTo("performanceMet");
+	}
+
+	@Test
+	void testMapperWithDenominatorLabel() {
+		String label = SubPopulationHelper.measureTypeMap.get(SubPopulationLabel.DENOM);
+
+		assertThat(label).isEqualTo("eligiblePopulation");
+	}
+
+	@Test
+	void testMapperDenominatorExclusionLabel() {
+		String label = SubPopulationHelper.measureTypeMap.get(SubPopulationLabel.DENEX);
+
+		assertThat(label).isEqualTo("eligiblePopulationExclusion");
+	}
+
+	@Test
+	void testMapperDenominatorExceptionLabel() {
+		String label = SubPopulationHelper.measureTypeMap.get(SubPopulationLabel.DENEXCEP);
+
+		assertThat(label).isEqualTo("eligiblePopulationException");
+	}
+
+	@Test
+	void testMapperWithNonExistentLabel() {
+		String label = SubPopulationHelper.measureTypeMap.get(SubPopulationLabel.IPOP);
+
+		assertThat(label).isNull();
+	}
+}

--- a/sample-files/2018/mipsCms347v1SampleFile.xml
+++ b/sample-files/2018/mipsCms347v1SampleFile.xml
@@ -1,0 +1,5060 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type='text/xsl' href='CDA.xsl'?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:voc="urn:hl7-org:v3/voc" xmlns="urn:hl7-org:v3">
+  <realmCode code="US" />
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2017-07-01" />
+  <id root="26a42253-99f5-48e7-9274-b467c6c7f623" />
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
+  <title>QRDA Calculated Summary Report for CMS 347</title>
+  <effectiveTime value="20190117" />
+  <confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N" />
+  <languageCode code="en" />
+  <versionNumber value="1" />
+  <recordTarget typeCode="RCT" contextControlCode="OP">
+    <patientRole>
+      <id nullFlavor="NA" />
+    </patientRole>
+  </recordTarget>
+  <author typeCode="AUT" contextControlCode="OP">
+    <time value="20190117" />
+    <assignedAuthor classCode="ASSIGNED">
+      <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+      <addr>
+        <streetAddressLine nullFlavor="UNK" />
+        <city nullFlavor="UNK" />
+        <state nullFlavor="UNK" />
+        <postalCode nullFlavor="UNK" />
+        <country nullFlavor="UNK" />
+      </addr>
+      <telecom use="WP" value="tel:tel:(123)456-7890" />
+      <assignedPerson>
+        <name>
+          <given>DFDFD</given>
+          <family>YRUDD</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <name>DJHFDJER</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <custodian typeCode="CST">
+    <assignedCustodian classCode="ASSIGNED">
+      <representedCustodianOrganization classCode="ORG" determinerCode="INSTANCE">
+        <id root="2.16.840.1.113883.4.336" extension="1234567890" />
+        <name>FGFGFGFE</name>
+        <telecom use="WP" value="tel:tel:(123)456-7890" />
+        <addr>
+          <streetAddressLine nullFlavor="UNK" />
+          <city nullFlavor="UNK" />
+          <state nullFlavor="UNK" />
+          <postalCode nullFlavor="UNK" />
+          <country nullFlavor="UNK" />
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <informationRecipient>
+    <intendedRecipient>
+      <id root="2.16.840.1.113883.3.249.7" extension="MIPS_GROUP" />
+    </intendedRecipient>
+  </informationRecipient>
+  <legalAuthenticator>
+    <time value="20190117" />
+    <signatureCode code="S" />
+    <assignedEntity>
+      <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+    </assignedEntity>
+  </legalAuthenticator>
+  <documentationOf>
+    <serviceEvent classCode="PCPR">
+      <effectiveTime>
+        <low value="20180222103000" />
+        <high value="20180222122057" />
+      </effectiveTime>
+      <performer typeCode="PRF">
+        <functionCode nullFlavor="UNK" />
+        <assignedEntity>
+          <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+          <code code="207V00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+          <assignedPerson>
+            <name>REWLSDFDJHDF </name>
+          </assignedPerson>
+          <representedOrganization>
+            <id extension="561771748" root="2.16.840.1.113883.4.2" />
+            <name>VNNDKJF</name>
+            <telecom use="WP" value="tel:(123)456-7890" />
+            <addr>
+				<streetAddressLine nullFlavor="UNK" />
+				<city nullFlavor="UNK" />
+				<state nullFlavor="UNK" />
+				<postalCode nullFlavor="UNK" />
+				<country nullFlavor="UNK" />
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+      <performer typeCode="PRF">
+        <functionCode nullFlavor="UNK" />
+        <assignedEntity>
+          <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+          <code code="56-1771748" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+          <assignedPerson>
+            <name>VNJD DJKFDKFJD EWE </name>
+          </assignedPerson>
+          <representedOrganization>
+            <id extension="561771748" root="2.16.840.1.113883.4.2" />
+            <name>TDJCVK</name>
+            <telecom use="WP" value="tel:(123)456-7890" />
+            <addr>
+				<streetAddressLine nullFlavor="UNK" />
+				<city nullFlavor="UNK" />
+				<state nullFlavor="UNK" />
+				<postalCode nullFlavor="UNK" />
+				<country nullFlavor="UNK" />
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+      <performer typeCode="PRF">
+        <functionCode nullFlavor="UNK" />
+        <assignedEntity>
+          <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+          <code code="207V00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+          <assignedPerson>
+            <name>SDFHJKHFJ </name>
+          </assignedPerson>
+          <representedOrganization>
+            <id extension="561771748" root="2.16.840.1.113883.4.2" />
+            <name>DFJKDFJDK</name>
+            <telecom use="WP" value="tel:(123)456-7890" />
+            <addr>
+				<streetAddressLine nullFlavor="UNK" />
+				<city nullFlavor="UNK" />
+				<state nullFlavor="UNK" />
+				<postalCode nullFlavor="UNK" />
+				<country nullFlavor="UNK" />
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+      <performer typeCode="PRF">
+        <functionCode nullFlavor="UNK" />
+        <assignedEntity>
+          <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+          <code code="207V00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+          <assignedPerson>
+            <name>VBDFJERT </name>
+          </assignedPerson>
+          <representedOrganization>
+            <id extension="561771748" root="2.16.840.1.113883.4.2" />
+            <name>DUIFUCNV</name>
+            <telecom use="WP" value="tel:(123)456-7890" />
+            <addr>
+				<streetAddressLine nullFlavor="UNK" />
+				<city nullFlavor="UNK" />
+				<state nullFlavor="UNK" />
+				<postalCode nullFlavor="UNK" />
+				<country nullFlavor="UNK" />
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+      <performer typeCode="PRF">
+        <functionCode nullFlavor="UNK" />
+        <assignedEntity>
+          <id root="2.16.840.1.113883.4.6" extension="1234567890" />
+          <assignedPerson>
+            <name>BIDKHJGDFK </name>
+          </assignedPerson>
+          <representedOrganization>
+            <id extension="561771748" root="2.16.840.1.113883.4.2" />
+            <name>IOWEIODFFD</name>
+            <telecom use="WP" value="tel:(123)456-7890" />
+            <addr>
+				<streetAddressLine nullFlavor="UNK" />
+				<city nullFlavor="UNK" />
+				<state nullFlavor="UNK" />
+				<postalCode nullFlavor="UNK" />
+				<country nullFlavor="UNK" />
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <component>
+    <structuredBody>
+      <!--******************************************************** Measure Section ********************************************************-->
+      <component>
+        <section>
+          <!--Measure Section template ID-->
+          <templateId root="2.16.840.1.113883.10.20.24.2.2" />
+          <!--QRDA Category III Measure Section template ID-->
+          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01" />
+          <!--CMS IG - QRDA Category III Measure Section - CMS (V3) template ID-->
+          <templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01" />
+          <code code="55186-1" displayName="Measure Section" codeSystem="2.16.840.1.113883.6.1" />
+          <title>Measure Section</title>
+          <text>
+            <table border="1" width="100%">
+              <thead>
+                <tr>
+                  <th>eMeasure Title</th>
+                  <th>Version neutral identifier</th>
+                  <th>eMeasure Version Number</th>
+                  <th>NQF eMeasure Number</th>
+                  <th>eMeasure Identifier (MAT)</th>
+                  <th>Version specific identifier</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Statin Therapy for the Prevention and Treatment of Cardiovascular Disease</td>
+                  <td>5375d6a9-203b-4fff-b851-afa9b68d2ac2</td>
+                  <td>1</td>
+                  <td>Not Applicable</td>
+                  <td>347</td>
+                  <td>40280382-5b4d-eebc-015b-8245e0fa06b7</td>
+                </tr>
+              </tbody>
+            </table>
+            <content styleCode="Bold">Member of Measure Set: </content>
+            <list>
+              <item>
+                <content styleCode="Bold">Performance Rate</content>: 0.0  (Predicted = 0.00)</item>
+              <item>
+                <content styleCode="Bold">Reporting Rate</content>: 0.0</item>
+              <item>
+                <content styleCode="Bold">Initial Patient Population</content>: 0<list><item><content styleCode="Bold">Male</content>: 0</item><item><content styleCode="Bold">Female</content>: 0</item><item><content styleCode="Bold">Not Hispanic or Latino</content>: 0</item><item><content styleCode="Bold">Hispanic or Latino</content>: : 0</item><item><content styleCode="Bold">American Indian or Alaska Native</content>: 0</item><item><content styleCode="Bold">Asian</content>: 0</item><item><content styleCode="Bold">Black or African American</content>: 0</item><item><content styleCode="Bold">Native Hawaiian or Other Pacific Islander</content>: 0</item><item><content styleCode="Bold">White</content>: 0</item><item><content styleCode="Bold">Other Race</content>: 0</item><item><content styleCode="Bold">Payer - Other</content>: 0</item></list></item>
+              <item>
+                <content styleCode="Bold">Denominator</content>: 0<list><item><content styleCode="Bold">Male</content>: 0</item><item><content styleCode="Bold">Female</content>: 0</item><item><content styleCode="Bold">Not Hispanic or Latino</content>: 0</item><item><content styleCode="Bold">Hispanic or Latino</content>: : 0</item><item><content styleCode="Bold">American Indian or Alaska Native</content>: 0</item><item><content styleCode="Bold">Asian</content>: 0</item><item><content styleCode="Bold">Black or African American</content>: 0</item><item><content styleCode="Bold">Native Hawaiian or Other Pacific Islander</content>: 0</item><item><content styleCode="Bold">White</content>: 0</item><item><content styleCode="Bold">Other Race</content>: 0</item><item><content styleCode="Bold">Payer - Other</content>: 0</item></list></item>
+              <item>
+                <content styleCode="Bold">Denominator Exceptions</content>: 0<list><item><content styleCode="Bold">Male</content>: 0</item><item><content styleCode="Bold">Female</content>: 0</item><item><content styleCode="Bold">Not Hispanic or Latino</content>: 0</item><item><content styleCode="Bold">Hispanic or Latino</content>: : 0</item><item><content styleCode="Bold">American Indian or Alaska Native</content>: 0</item><item><content styleCode="Bold">Asian</content>: 0</item><item><content styleCode="Bold">Black or African American</content>: 0</item><item><content styleCode="Bold">Native Hawaiian or Other Pacific Islander</content>: 0</item><item><content styleCode="Bold">White</content>: 0</item><item><content styleCode="Bold">Other Race</content>: 0</item><item><content styleCode="Bold">Payer - Other</content>: 0</item></list></item>
+              <item>
+                <content styleCode="Bold">Numerator</content>: 0<list><item><content styleCode="Bold">Male</content>: 0</item><item><content styleCode="Bold">Female</content>: 0</item><item><content styleCode="Bold">Not Hispanic or Latino</content>: 0</item><item><content styleCode="Bold">Hispanic or Latino</content>: : 0</item><item><content styleCode="Bold">American Indian or Alaska Native</content>: 0</item><item><content styleCode="Bold">Asian</content>: 0</item><item><content styleCode="Bold">Black or African American</content>: 0</item><item><content styleCode="Bold">Native Hawaiian or Other Pacific Islander</content>: 0</item><item><content styleCode="Bold">White</content>: 0</item><item><content styleCode="Bold">Other Race</content>: 0</item><item><content styleCode="Bold">Payer - Other</content>: 0</item></list></item>
+            </list>
+          </text>
+         <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!--CMS IG - Measure Reference and Results - CMS (V3) template ID-->
+              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01" />
+              <!--Measure Reference template ID-->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
+              <!--Conforms to Measure Reference and Results (V3) template ID-->
+              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
+              <id root="9ab424ee-7e19-4776-a7a6-a6599d43e431" />
+              <statusCode code="completed" />
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <id root="2.16.840.1.113883.4.738" extension="40280382-5b4d-eebc-015b-8245e0fa06b7" />
+                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
+                  <text>Statin Therapy for the Prevention and Treatment of Cardiovascular Disease</text>
+                  <setId root="5375d6a9-203b-4fff-b851-afa9b68d2ac2" />
+                  <versionNumber value="1" />
+                </externalDocument>
+              </reference>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.14" />
+                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" displayName="Performance Rate 1" codeSystemName="2.16.840.1.113883.6.1" />
+                  <statusCode code="completed" />
+                  <value xsi:type="REAL" value="0.0" />
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="53656F0F-97C7-4537-907E-4C8D836A5853" />
+                      <code code="NUMER" displayName="Numerator" codeSystem="2.16.840.1.113883.5.1063" codeSystemName="ObservationValue" />
+                    </externalObservation>
+                  </reference>
+                  <referenceRange>
+                    <observationRange>
+                      <value xsi:type="REAL" value="0.00" />
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.15" />
+                  <code code="72509-3" codeSystem="2.16.840.1.113883.6.1" displayName="Reporting Rate 3" codeSystemName="2.16.840.1.113883.6.1" />
+                  <statusCode code="completed" />
+                  <value xsi:type="REAL" value="0.5" />
+                </observation>
+              </component>
+              <!--IPOP 1: MeasureSection 5576-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.1063" displayName="Initial Patient Population" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="5576" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1039" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="143" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="47" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="654" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="8" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="4048" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="21" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5576" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="564" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" displayName="Medicaid" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="212" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="39" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="3" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1645" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2300" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="813" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="B5249FB8-86D2-4633-BCF8-705EAAA35F04" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENOM 1: MeasureSection 56-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="56" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="9" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="8" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="35" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="56" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="19" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" displayName="Medicaid" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="15" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="9" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="7" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="CC35FC48-FA75-4E8C-8949-BC2B4D152F72" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEX 1: MeasureSection 0-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator Exclusions" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="0" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="6C1F017F-F0C4-4346-B823-0BC24E3BFA9C" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEXCEP 1: MeasureSection 1-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEXCEP" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator Exceptions" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="F13A488B-6F7F-45E3-8216-1A7A679ADBFD" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--NUMER 1: MeasureSection 0-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.1063" displayName="Numerator" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="0" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="53656F0F-97C7-4537-907E-4C8D836A5853" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--IPOP 2: MeasureSection 5576-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.1063" displayName="Initial Patient Population" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="5576" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1039" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="143" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="47" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="654" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="8" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="4048" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="21" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5576" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="564" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" displayName="Medicaid" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="212" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="39" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="3" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1645" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2300" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="813" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="F1948A70-E9EE-427F-9D1F-9489B902DFAB" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENOM 2: MeasureSection 151-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="151" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="151" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="30" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="3" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="98" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="805" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1071" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" displayName="Medicaid" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="33" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="7" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="342" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="336" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="103" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="C44EA250-22FE-4FF1-835B-BD718A9E71FA" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEX 2: MeasureSection 1-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator Exclusions" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="C5AA9EF4-FC68-4844-A45A-4985E81DA8A1" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEXCEP 2 MeasureSection 4-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEXCEP" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator Exceptions" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="4" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="3" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="4" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="4" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="B55F6B97-ABF6-4F44-90C5-D02D99DE55DA" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--NUMER MeasureSection 8-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.1063" displayName="Numerator" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="8" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="6" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="8" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="6" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="632ECBD0-8C77-40E9-AE21-795891D5CD64" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--IPOP 3: MeasureSection 5576-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.1063" displayName="Initial Patient Population" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="5576" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1039" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="143" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="47" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="654" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="8" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="4048" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="21" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="5576" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" displayName="Medicare" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="564" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" displayName="Medicaid" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="212" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="39" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="3" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1645" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2300" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="813" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="E44CE0A2-A08E-48CC-B022-5B54F808FB61" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENOM 3 MeasureSection 2-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="2" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="2" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="01B3E154-5F42-4905-BDDD-E2A34B8C1DB2" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEX 3 MeasureSection 0-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator Exclusions" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="0" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="1354D37B-998F-434E-8039-99F6CCC987FD" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEXCEP 3 MeasureSection 0-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEXCEP" codeSystem="2.16.840.1.113883.5.1063" displayName="Denominator Exceptions" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="0" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" displayName="Other" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="3D0BD8CB-CB77-407A-A367-080F53D880DD" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--NUMER 3 MeasureSection 1-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!--Conforms to Measure Data template-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <!--CMS IG - Measure Data (CMS EP) template ID-->
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01" />
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.1063" displayName="Numerator" codeSystemName="ObservationValue" />
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1" />
+                      <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Ethnicity Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <code code="69490-1" displayName="Ethnic" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2135-2" displayName="Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="1002-5" displayName="American Indian or Alaska Native" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2028-9" displayName="Asian" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2054-5" displayName="Black or African American" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <code code="72826-1" displayName="Race" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="2131-1" displayName="Other Race" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Sex Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Sex Supplemental Data Element template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <code code="76689-9" displayName="Sex assigned at birth" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7AdministrativeGenderCode" />
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!--Payer Supplemental Data Element ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <!--CMG IG - Payer Supplemental Data Element - CMS template ID-->
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2016-11-01" />
+                      <id nullFlavor="NA" />
+                      <code code="48768-6" displayName="Payment source" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED-CT" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20180101" />
+                        <high value="20181231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" displayName="Private Health Insurance" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" />
+                      </value>
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" displayName="rate aggregation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="1" />
+                          <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--MeasureObservationSubSection-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="5E64B1E4-1F1A-4B3B-B148-5044F6B30760" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+            </organizer>
+		     </entry>
+		 <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.17.3.8" />
+              <templateId root="2.16.840.1.113883.10.20.27.3.23" />
+              <id root="c3e15b3c-d7f1-4d10-9779-c22c10bc4856" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters" />
+              <effectiveTime>
+                <low value="20180101" />
+                <high value="20181231" />
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>


### PR DESCRIPTION
### Information
- QPPCT-1043
   - Creates a new way for encoding CMS347v1. 
   - The new encoding takes the sum of all subpopulations for each metric type. The reason it was added into the encoding process is because decoding cannot be changed. CMS347v1 requires submission with 3 Subpopulation strata and then to be converted into one with the sum of each subpopulations of same metric type be summed.
   - Adds guids into `measures-data.json` for CMS347v1
-
### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.