### PR TITLE
Remove overall checker

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -57,7 +57,6 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 62 : CT - The Alternative Payment Model (APM) Entity Identifier must not be empty. Here is a link to the IG section on identifiers: https://ecqi.healthit.gov/system/files/2019_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG-508.pdf#page=15
 * 63 : CT - The Alternative Payment Model (APM) Entity Identifier is not valid.  Here is a link to the IG section on identifiers: https://ecqi.healthit.gov/system/files/2019_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG-508.pdf#page=15
 * 64 : CT - CPC+ Submissions must have at least `(CPC+ measure group minimum)` of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`
-* 65 : CT - CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of the following measures: `(Listing of all CPC+ measure ids)`.
 * 66 : CT - Missing the `(Supplemental Type)` - `(Type Qualification)` supplemental data for code `(Supplemental Data Code)` for the measure id `(Measure Id)`'s Sub-population `(Sub Population)`
 * 67 : CT - Must have one count for Supplemental Data `(Supplemental Data Code)` on Sub-population `(Sub Population)` for the measure id `(Measure Id)`
 * 68 : CT - Your CPC+ submission was made after the CPC+ Measure section submission deadline of `(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at `(CPC+ contact email)` for assistance.

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -135,8 +135,6 @@ public enum ErrorCode implements LocalizedError {
 			+ " Here is a link to the IG section on identifiers: " + DocumentationReference.IDENTIFIERS),
 	CPC_PLUS_TOO_FEW_QUALITY_MEASURE_CATEGORY(64, "CPC+ Submissions must have at least `(CPC+ measure group minimum)` "
 			+ "of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`", true),
-	CPC_PLUS_TOO_FEW_QUALITY_MEASURES(65, "CPC+ Submissions must have at least `(Overall CPC+ measure minimum)` of "
-		+ "the following measures: `(Listing of all CPC+ measure ids)`.", true),
 	CPC_PLUS_MISSING_SUPPLEMENTAL_CODE(66, "Missing the `(Supplemental Type)` - `(Type Qualification)` supplemental data for code "
 		+ "`(Supplemental Data Code)` for the measure id `(Measure Id)`'s Sub-population `(Sub Population)`", true),
 	CPC_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT(67, "Must have one count for Supplemental Data `(Supplemental Data Code)` "

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureSectionValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureSectionValidator.java
@@ -78,11 +78,6 @@ public class CpcQualityMeasureSectionValidator extends NodeValidator {
 			return mapName;
 		}
 
-		static LocalizedError makeOverallError(String... measureIds) {
-			return ErrorCode.CPC_PLUS_TOO_FEW_QUALITY_MEASURES
-					.format(CpcGroupMinimum.NUMBER_OF_MEASURES_REQUIRED, String.join(",", measureIds));
-		}
-
 		LocalizedError makeError(String... measureIds) {
 			return ErrorCode.CPC_PLUS_TOO_FEW_QUALITY_MEASURE_CATEGORY
 					.format(minimum, label, String.join(",", measureIds));

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureSectionValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureSectionValidator.java
@@ -30,7 +30,6 @@ public class CpcQualityMeasureSectionValidator extends NodeValidator {
 
 		Arrays.stream(CpcGroupMinimum.values())
 				.forEach(group -> checkGroupMinimum(checker, group));
-		verifyOverallCount(checker);
 	}
 
 	/**
@@ -55,21 +54,6 @@ public class CpcQualityMeasureSectionValidator extends NodeValidator {
 		return cpcPlusGroups.get(groupMinimum.getMapName()).stream()
 				.map(MeasureConfig::getElectronicMeasureVerUuid)
 				.toArray(String[]::new);
-	}
-
-	/**
-	 * Verify minimum across all groups.
-	 * @param checker node validator helper
-	 */
-	private void verifyOverallCount(Checker checker) {
-		String[] measureIds = MeasureConfigs.getCpcPlusGroups()
-				.values().stream()
-				.flatMap(List::stream)
-				.map(MeasureConfig::getElectronicMeasureVerUuid)
-				.toArray(String[]::new);
-
-		checker.hasMeasures(
-				CpcGroupMinimum.makeOverallError(measureIds), CpcGroupMinimum.NUMBER_OF_MEASURES_REQUIRED, measureIds);
 	}
 
 	/**


### PR DESCRIPTION
### Information
- QPPSF-5066

### Changes proposed in this PR:
- Slight change to remove error code 65 as it is no longer required.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [n/a] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
