### PR TITLE
CPC Plus Filter Start Date

### DIFF
--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
@@ -20,6 +20,7 @@ public class Constants {
 	public static final String DYNAMO_CREATE_DATE_ATTRIBUTE = "CreateDate";
 	public static final String CPC_PLUS_BUCKET_NAME_VARIABLE = "CPC_PLUS_BUCKET_NAME";
 	public static final String CPC_PLUS_FILENAME_VARIABLE = "CPC_PLUS_VALIDATION_FILE";
+	public static final String CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE = "CPC_PLUS_UNPROCESSED_FILE_SEARCH_START_DATE";
 
 	/**
 	 * Library utility class so the constructor is private and empty.

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
@@ -20,7 +20,7 @@ public class Constants {
 	public static final String DYNAMO_CREATE_DATE_ATTRIBUTE = "CreateDate";
 	public static final String CPC_PLUS_BUCKET_NAME_VARIABLE = "CPC_PLUS_BUCKET_NAME";
 	public static final String CPC_PLUS_FILENAME_VARIABLE = "CPC_PLUS_VALIDATION_FILE";
-	public static final String CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE = "CPC_PLUS_UNPROCESSED_FILE_SEARCH_START_DATE";
+	public static final String CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE = "CPC_PLUS_UNPROCESSED_FILTER_START_DATE";
 
 	/**
 	 * Library utility class so the constructor is private and empty.

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbServiceImpl.java
@@ -32,7 +32,6 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 
 	private static final Logger API_LOG = LoggerFactory.getLogger(DbServiceImpl.class);
 	private static final int LIMIT = 3;
-	public static final String START_OF_UNALLOWED_CONVERSION_TIME = "2018-01-02T04:59:59.999Z";
 
 	private final Optional<DynamoDBMapper> mapper;
 	private final Environment environment;
@@ -76,12 +75,13 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 	public List<Metadata> getUnprocessedCpcPlusMetaData() {
 		if (mapper.isPresent()) {
 			API_LOG.info("Getting list of unprocessed CPC+ metadata");
+			String cpcConversionStartDate = environment.getProperty(Constants.CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE);
 
 			return IntStream.range(0, Constants.CPC_DYNAMO_PARTITIONS).mapToObj(partition -> {
 				Map<String, AttributeValue> valueMap = new HashMap<>();
 				valueMap.put(":cpcValue", new AttributeValue().withS(Constants.CPC_DYNAMO_PARTITION_START + partition));
 				valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false"));
-				valueMap.put(":createDate", new AttributeValue().withS(START_OF_UNALLOWED_CONVERSION_TIME));
+				valueMap.put(":createDate", new AttributeValue().withS(cpcConversionStartDate));
 
 				DynamoDBQueryExpression<Metadata> metadataQuery = new DynamoDBQueryExpression<Metadata>()
 					.withIndexName("Cpc-CpcProcessed_CreateDate-index")

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/CpcApiAcceptance.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/acceptance/CpcApiAcceptance.java
@@ -91,7 +91,7 @@ class CpcApiAcceptance {
 	@AcceptanceTest
 	void testUnprocessedFilesDates() {
 		Metadata afterJanuarySecondMetadata = createDatedCpcMetadata("2018-01-02T05:00:00.000Z");
-		Metadata beforeJanuarySecondMetadata = createDatedCpcMetadata(DbServiceImpl.START_OF_UNALLOWED_CONVERSION_TIME);
+		Metadata beforeJanuarySecondMetadata = createDatedCpcMetadata("2018-01-02T04:59:59.999Z");
 		Metadata anotherAllowedMetadata = createDatedCpcMetadata("2018-02-26T14:36:43.723Z");
 		Metadata anotherUnallowedMetadata = createDatedCpcMetadata("2017-12-25T00:00:00.000Z");
 
@@ -101,7 +101,7 @@ class CpcApiAcceptance {
 
 		responseBody.stream().forEach(map ->
 			assertThat(Instant.parse((String)map.get("conversionDate")))
-				.isGreaterThan(Instant.parse(DbServiceImpl.START_OF_UNALLOWED_CONVERSION_TIME)));
+				.isGreaterThan(Instant.parse("2018-01-02T04:59:59.999Z")));
 	}
 
 	@AcceptanceTest


### PR DESCRIPTION
### Information
- Changes the CPC+ filter date for unprocessed CPC+ conversion from static to an environment variable. This will allow us to deploy a proper date filter without having to deploy new code.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
