### PR TITLE
CPC+ Cehrt ID Warning Removal

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -69,7 +69,6 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 80 : CT - The given National Provider Identifier `(npi)`, Taxpayer Identification Number `(tin)`, and Alternative Payment Model `(apm)` are not a valid combination
 * 81 : CT - At least one measure is required in a measure section
 * 82 : CT - There are too many errors associated with this QRDA-III file. Showing 100 out of `(Error amount)` errors. Please fix the given errors and re-submit
-* 83 : CT - CPC+ submissions should contain a CEHRT. Please refer to the `(Submission year's)` IG for more details https://ecqi.healthit.gov/system/files/2019_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG-508.pdf#page=15 regarding practice CEHRTs.
 * 84 : CT - CPC+ QRDA-III Submissions require at least one TIN to be present.
 * 85 : CT - CPC+ QRDA-III Submission TINs require a 9 digit numerical value
 * 86 : CT - This CPC+ QRDA-III submission is missing a TIN. Please ensure there is a TIN associated with every NPI submitted

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ErrorCode.java
@@ -162,9 +162,6 @@ public enum ErrorCode implements LocalizedError {
 	MEASURE_SECTION_MISSING_MEASURE(81, "At least one measure is required in a measure section"),
 	TOO_MANY_ERRORS(82, "There are too many errors associated with this QRDA-III file. Showing 100 out of `(Error amount)` errors."
 		+ " Please fix the given errors and re-submit", true),
-	MISSING_CEHRT(83, "CPC+ submissions should contain a CEHRT."
-		+ " Please refer to the `(Submission year's)` IG for more details " + DocumentationReference.CEHRT
-	    + " regarding practice CEHRTs.", true),
 	CPC_PLUS_TIN_REQUIRED(84, "CPC+ QRDA-III Submissions require at least one TIN to be present."),
 	CPC_PLUS_INVALID_TIN(85, "CPC+ QRDA-III Submission TINs require a 9 digit numerical value"),
 	CPC_PLUS_MISSING_TIN(86, "This CPC+ QRDA-III submission is missing a TIN. Please ensure there is a TIN associated with every "

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidator.java
@@ -78,7 +78,6 @@ public class CpcClinicalDocumentValidator extends NodeValidator {
 					1, TemplateId.MEASURE_SECTION_V3);
 
 		checkWarnings(node)
-			.valueIsNotEmpty(ErrorCode.MISSING_CEHRT.format(Context.REPORTING_YEAR), ClinicalDocumentDecoder.CEHRT)
 			.doesNotHaveChildren(ErrorCode.CPC_PLUS_NO_IA_OR_PI, TemplateId.IA_SECTION, TemplateId.PI_SECTION);
 
 		validateApmEntityId(node);

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -72,6 +72,7 @@ class CpcPlusAcceptanceTest {
 	@MethodSource("successData")
 	void testCpcPlusFileSuccesses(Path entry) {
 		AllErrors errors = null;
+		List<Detail> warnings = null;
 
 		Converter converter = new Converter(new PathSource(entry));
 
@@ -79,9 +80,11 @@ class CpcPlusAcceptanceTest {
 			converter.transform();
 		} catch (TransformException failure) {
 			errors = failure.getDetails();
+			warnings = failure.getConversionReport().getWarnings();
 		}
 
 		assertThat(errors).isNull();
+		assertThat(warnings).isNull();
 	}
 
 	@ParameterizedTest

--- a/converter/src/test/resources/cpc_plus/success/ComprehensivePrimaryCareSampleQRDA-III_SDE.xml
+++ b/converter/src/test/resources/cpc_plus/success/ComprehensivePrimaryCareSampleQRDA-III_SDE.xml
@@ -73,12 +73,7 @@
       </representedOrganization>
     </assignedEntity>
   </legalAuthenticator>
-  <participant typeCode="DEV">
-    <associatedEntity classCode="RGPR">
-      <id root="2.16.840.1.113883.3.2074.1" extension="CMS_EHR_Certification_Identification_Number_Goes_Here" />
-      <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
-    </associatedEntity>
-  </participant>
+  <!--Remove cehrt id-->
   <!--Practice Site-->
   <participant typeCode="LOC">
     <associatedEntity classCode="SDLOC">

--- a/sample-files/2019/cpcPlusMultiValidApmCombo.xml
+++ b/sample-files/2019/cpcPlusMultiValidApmCombo.xml
@@ -73,12 +73,7 @@
       </representedOrganization>
     </assignedEntity>
   </legalAuthenticator>
-  <participant typeCode="DEV">
-    <associatedEntity classCode="RGPR">
-      <id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX" />
-      <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
-    </associatedEntity>
-  </participant>
+
   <!--Practice Site-->
   <participant typeCode="LOC">
     <associatedEntity classCode="SDLOC">


### PR DESCRIPTION
### Information
- QPPSF-5650

### Changes proposed in this PR:
- Removes the warning for missing cehrt id's in CPC+ submissions
- Adds tests and sample file to ensure warnings do not appear for submissions without cehrt id's

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
