### PR TITLE
Update CPC Unprocessed list filtering

### DIFF
--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImpl.java
@@ -81,19 +81,17 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 			return IntStream.range(0, Constants.CPC_DYNAMO_PARTITIONS).mapToObj(partition -> {
 				Map<String, AttributeValue> valueMap = new HashMap<>();
 				valueMap.put(":cpcValue", new AttributeValue().withS(Constants.CPC_DYNAMO_PARTITION_START + partition));
-				valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false"));
-				valueMap.put(":createDate", new AttributeValue().withS(cpcConversionStartDate));
+				valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false#" + cpcConversionStartDate));
 
 				DynamoDBQueryExpression<Metadata> metadataQuery = new DynamoDBQueryExpression<Metadata>()
 					.withIndexName("Cpc-CpcProcessed_CreateDate-index")
 					.withKeyConditionExpression(Constants.DYNAMO_CPC_ATTRIBUTE + " = :cpcValue and begins_with("
 							+ Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE + ", :cpcProcessedValue)")
-					.withFilterExpression(Constants.DYNAMO_CREATE_DATE_ATTRIBUTE + " > :createDate")
 					.withExpressionAttributeValues(valueMap)
 					.withConsistentRead(false)
 					.withLimit(LIMIT);
 
-				return mapper.get().query(Metadata.class, metadataQuery).stream();
+				return mapper.get().queryPage(Metadata.class, metadataQuery).getResults().stream();
 			}).flatMap(Function.identity()).collect(Collectors.toList());
 		} else {
 			API_LOG.warn("Could not get unprocessed CPC+ metadata because the dynamodb mapper is absent");


### PR DESCRIPTION
### Information
- QPPSF_5592

### Changes proposed in this PR:
- Changes sorting to use queryPage again but instead filter with the GSI's sort key date. This solves the issue of limitations being ignored and applies filtering for year 2020. The only issue is the filtering will start for every date in 2020 rather than January 02, 2020. This should not be a problem as the conversion tool isn't accessible until January 02, 2020 regardless.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [n/a] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
