### PR TITLE
QPPSF-5592: Optimize sort filter of dynamo Query.

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -2,7 +2,6 @@
 Current list of all error messages being output by the converter.
 Any text in the following format `(Example)` are considered variables to be filled in.
 
-
 ### Format - Error Code : Error Message
 * 1 : CT - Failed to find an encoder
 * 2 : CT - The file is not a valid XML document. The file you are submitting is not a properly formatted XML document. Please check your document to ensure proper formatting.

--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -2,6 +2,7 @@
 Current list of all error messages being output by the converter.
 Any text in the following format `(Example)` are considered variables to be filled in.
 
+
 ### Format - Error Code : Error Message
 * 1 : CT - Failed to find an encoder
 * 2 : CT - The file is not a valid XML document. The file you are submitting is not a properly formatted XML document. Please check your document to ensure proper formatting.

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImpl.java
@@ -90,8 +90,7 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 							+ Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE + ", :cpcProcessedValue)")
 					.withFilterExpression(Constants.DYNAMO_CREATE_DATE_ATTRIBUTE + " > :createDate")
 					.withExpressionAttributeValues(valueMap)
-					.withConsistentRead(false)
-					.withLimit(LIMIT);
+					.withConsistentRead(false);
 
 				return mapper.get().query(Metadata.class, metadataQuery).stream();
 			}).flatMap(Function.identity()).collect(Collectors.toList());

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImpl.java
@@ -76,12 +76,15 @@ public class DbServiceImpl extends AnyOrderActionService<Metadata, Metadata>
 	public List<Metadata> getUnprocessedCpcPlusMetaData() {
 		if (mapper.isPresent()) {
 			API_LOG.info("Getting list of unprocessed CPC+ metadata...");
-			String cpcConversionStartDate = environment.getProperty(Constants.CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE);
+			String cpcConversionStartDate = Optional.of(
+				environment.getProperty(Constants.CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE))
+				.orElse("");
+			String year = cpcConversionStartDate.substring(0, 4);
 
 			return IntStream.range(0, Constants.CPC_DYNAMO_PARTITIONS).mapToObj(partition -> {
 				Map<String, AttributeValue> valueMap = new HashMap<>();
 				valueMap.put(":cpcValue", new AttributeValue().withS(Constants.CPC_DYNAMO_PARTITION_START + partition));
-				valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false"));
+				valueMap.put(":cpcProcessedValue", new AttributeValue().withS("false#"+year));
 				valueMap.put(":createDate", new AttributeValue().withS(cpcConversionStartDate));
 
 				DynamoDBQueryExpression<Metadata> metadataQuery = new DynamoDBQueryExpression<Metadata>()


### PR DESCRIPTION
### Information
- Optimizes Query search by filtering more with the Sort key.
- In the future, I would want find a way to actually limit the query as DynamoDbMapper.DynamoDBQueryExpression.withLimit doesn't actually limit in a Query. The optimization works in Dev and Imp. Before proceeding on adding features that completely change how we gather data from Dynamo, I would like to ensure this optimization reaches Prod and close the current bug ticket.

### Checklist 
- [X] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [X] Added and updated JavaDocs for non-test classes and methods.
- [X] No local design debt. Do you feel that something is "ugly" after your changes?
- [n/a] Updated documentation (`README.md`, etc.) depending if the changes require it.
