### PR TITLE
Enabling Sonar Properties

### DIFF
--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -34,3 +34,10 @@ jobs:
 
       - name: Run Integration Tests  
         run: mvn --batch-mode test -P integration
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@c35654669e40ece974c8835211c2e8ad9c802df0 # pin@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=gov.cms.qpp.conversion:qpp-conversion
+sonar.projectName=QPP Conversion
+sonar.projectVersion=0.1
+
+sonar.sources=**/src/main/java
+
+sonar.exclusions=node_modules,**/test/**,**/frontend/**,**/*.yaml,**/tools/**,**/sample-files/**,**/*.xml
+sonar.coverage.exclusions=**/*
+
+sonar.sourceEncoding=UTF-8
+
+sonar.organization=cmsgov
+sonar.github.repository=CMSgov/qpp-conversion-tool


### PR DESCRIPTION
Even though Sonar integration is enabled on this repo, it is not scanning properly the repo. Currently the last scan happened on  **_September 17, 2018 ie. 2 years ago_**
I presume it is due to the lack of a sonar properties file. In this PR I am adding sonar-project.properties. Let's see if that fixes the issue: https://sonarcloud.io/dashboard?id=gov.cms.qpp.conversion%3Aqpp-conversion (note to change the branch)