### PR TITLE
QPPSF-6618: Added slack notifications for GitHub Actions

### DIFF
--- a/.github/workflows/ecr-publish.yml
+++ b/.github/workflows/ecr-publish.yml
@@ -8,6 +8,9 @@ on:
       - release/*
       - master
 
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
 jobs:
   deploy:
     name: Build Docker image and deploy to AWS ECR
@@ -28,7 +31,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Temp - Build and deploy to Amazon ECR #remove me after rollout
+      - name: Temp - Build and deploy to Amazon ECR #Reminder to remove this block after the project is completed
         if: github.ref == 'refs/heads/ecr-deploy'
         id: build-image
         env:
@@ -39,6 +42,22 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Notify slack success
+        if: success()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools - Successful Docker build and AWS ECR deployment (Temp)
+          color: good
+
+      - name: Notify slack fail
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools - Failed Docker build or AWS ECR deployment (Temp)
+          color: danger             
       
       - name: Dev - Build and deploy to Amazon ECR
         if: github.ref == 'refs/heads/develop'
@@ -50,6 +69,22 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Notify slack success
+        if: success()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools - Successful Docker build and AWS ECR deployment (develop)
+          color: good
+
+      - name: Notify slack fail
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools - Failed Docker build or AWS ECR deployment (develop)
+          color: danger 
 
       - name: Impl - Build and deploy to Amazon ECR 
         if: github.ref == 'refs/heads/release/'

--- a/.github/workflows/ecr-publish.yml
+++ b/.github/workflows/ecr-publish.yml
@@ -48,7 +48,7 @@ jobs:
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: p-qpp-sub-alerts
-          status: Conversion tools - Successful Docker build and AWS ECR deployment (Temp)
+          status: Conversion tools (env:temp) - Successful Docker build and AWS ECR deployment  
           color: good
 
       - name: Notify slack fail
@@ -56,7 +56,7 @@ jobs:
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: p-qpp-sub-alerts
-          status: Conversion tools - Failed Docker build or AWS ECR deployment (Temp)
+          status: Conversion tools (env:temp) - Failed Docker build or AWS ECR deployment
           color: danger             
       
       - name: Dev - Build and deploy to Amazon ECR
@@ -75,7 +75,7 @@ jobs:
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: p-qpp-sub-alerts
-          status: Conversion tools - Successful Docker build and AWS ECR deployment (develop)
+          status: Conversion tools (env:dev) - Successful Docker build and AWS ECR deployment
           color: good
 
       - name: Notify slack fail
@@ -83,7 +83,7 @@ jobs:
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: p-qpp-sub-alerts
-          status: Conversion tools - Failed Docker build or AWS ECR deployment (develop)
+          status: Conversion tools (env:dev) - Failed Docker build or AWS ECR deployment
           color: danger 
 
       - name: Impl - Build and deploy to Amazon ECR 
@@ -96,7 +96,23 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-    
+
+      - name: Notify slack success
+        if: success()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools (env:impl) - Successful Docker build and AWS ECR deployment
+          color: good
+
+      - name: Notify slack fail
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools (env:impl) - Failed Docker build or AWS ECR deployment
+          color: danger 
+
       - name: Prod - Build and deploy to Amazon ECR
         if: github.ref == 'refs/heads/master'
         env:
@@ -107,6 +123,22 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Notify slack success
+        if: success()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools (env:prod) - Successful Docker build and AWS ECR deployment
+          color: good
+
+      - name: Notify slack fail
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: p-qpp-sub-alerts
+          status: Conversion tools (env:prod) - Failed Docker build or AWS ECR deployment
+          color: danger 
 
       - name: Logout of Amazon ECR
         if: always()


### PR DESCRIPTION
### Information
- JIRA story QPPSF-6618.

Integrate the [slack-notify-build](https://github.com/marketplace/actions/slack-notify-build) GitHub Action to print the build or deploy status to Slack (p-qpp-sub-alerts).
