### PR TITLE
QPPSF-6654: RTI API Processing updates.

### DIFF
--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/SecurityConfig.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package gov.cms.qpp.conversion.api.config;
 
 import gov.cms.qpp.conversion.api.security.JwtAuthorizationFilter;
 
+import com.google.common.collect.ImmutableSet;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -21,6 +22,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	@Value("${ORG_NAME:" + JwtAuthorizationFilter.DEFAULT_ORG_NAME + "}")
 	protected String orgName;
 
+	@Value("${RTI_ORG_NAME:" + JwtAuthorizationFilter.DEFAULT_ORG_NAME + "}")
+	protected String rtiOrgName;
+
 	/**
 	 * Configures the path to be authorized by the JWT token
 	 *
@@ -32,7 +36,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		http.antMatcher(CPC_WILDCARD).authorizeRequests()
 				.anyRequest().authenticated()
 				.and()
-				.addFilter(new JwtAuthorizationFilter(authenticationManager(), orgName))
+				.addFilter(new JwtAuthorizationFilter(authenticationManager(), ImmutableSet.of(orgName, rtiOrgName)))
 				.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				.and().cors()
 				.and().csrf().disable();

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
@@ -1,11 +1,5 @@
 package gov.cms.qpp.conversion.api.controllers.v1;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +24,9 @@ import gov.cms.qpp.conversion.api.model.Status;
 import gov.cms.qpp.conversion.api.model.UnprocessedCpcFileData;
 import gov.cms.qpp.conversion.api.services.CpcFileService;
 import gov.cms.qpp.conversion.util.EnvironmentHelper;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Controller to handle cpc file data

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
@@ -1,6 +1,9 @@
 package gov.cms.qpp.conversion.api.controllers.v1;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -10,6 +13,7 @@ import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +40,7 @@ import gov.cms.qpp.conversion.util.EnvironmentHelper;
 public class CpcFileControllerV1 {
 
 	private static final String BLOCKED_BY_FEATURE_FLAG =
-			"CPC+ unprocessed files request blocked by feature flag";
+			"CPC+ request blocked by feature flag or that have an invalid organization";
 	private static final Logger API_LOG = LoggerFactory.getLogger(CpcFileControllerV1.class);
 
 	private CpcFileService cpcFileService;
@@ -62,9 +66,11 @@ public class CpcFileControllerV1 {
 
 		String orgAttribute = Constants.ORG_ATTRIBUTE_MAP.get(organization);
 
-		if (blockCpcPlusApi()) {
+		if (blockCpcPlusApi() || StringUtils.isEmpty(orgAttribute)) {
 			API_LOG.info(BLOCKED_BY_FEATURE_FLAG);
-			return new ResponseEntity<>(null, null, HttpStatus.FORBIDDEN);
+			return ResponseEntity
+				.status(HttpStatus.FORBIDDEN)
+				.body(null);
 		}
 
 		List<UnprocessedCpcFileData> unprocessedCpcFileDataList =
@@ -89,7 +95,7 @@ public class CpcFileControllerV1 {
 		API_LOG.info("CPC+ file retrieval request received for fileId {}", fileId);
 
 		if (blockCpcPlusApi()) {
-			API_LOG.info("CPC+ file request blocked by feature flag");
+			API_LOG.info(BLOCKED_BY_FEATURE_FLAG);
 			return new ResponseEntity<>(null, null, HttpStatus.FORBIDDEN);
 		}
 
@@ -114,7 +120,7 @@ public class CpcFileControllerV1 {
 		API_LOG.info("CPC+ QPP retrieval request received for fileId {}", fileId);
 
 		if (blockCpcPlusApi()) {
-			API_LOG.info("CPC+ QPP request blocked by feature flag");
+			API_LOG.info(BLOCKED_BY_FEATURE_FLAG);
 			return new ResponseEntity<>(null, null, HttpStatus.FORBIDDEN);
 		}
 

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1.java
@@ -55,17 +55,20 @@ public class CpcFileControllerV1 {
 	 *
 	 * @return Valid json or error json content
 	 */
-	@GetMapping(value = "/unprocessed-files",
+	@GetMapping(value = "/unprocessed-files/{org}",
 			headers = {"Accept=" + Constants.V1_API_ACCEPT})
-	public ResponseEntity<List<UnprocessedCpcFileData>> getUnprocessedCpcPlusFiles() {
+	public ResponseEntity<List<UnprocessedCpcFileData>> getUnprocessedCpcPlusFiles(@PathVariable("org") String organization) {
 		API_LOG.info("CPC+ unprocessed files request received");
+
+		String orgAttribute = Constants.ORG_ATTRIBUTE_MAP.get(organization);
 
 		if (blockCpcPlusApi()) {
 			API_LOG.info(BLOCKED_BY_FEATURE_FLAG);
 			return new ResponseEntity<>(null, null, HttpStatus.FORBIDDEN);
 		}
 
-		List<UnprocessedCpcFileData> unprocessedCpcFileDataList = cpcFileService.getUnprocessedCpcPlusFiles();
+		List<UnprocessedCpcFileData> unprocessedCpcFileDataList =
+			cpcFileService.getUnprocessedCpcPlusFiles(orgAttribute);
 
 		API_LOG.info("CPC+ unprocessed files request succeeded");
 
@@ -129,9 +132,9 @@ public class CpcFileControllerV1 {
 	 * @param request The new state of the file being updated
 	 * @return Message if the file was updated or not
 	 */
-	@PutMapping(value = "/file/{fileId}",
+	@PutMapping(value = "/file/{fileId}/{org}",
 			headers = {"Accept=" + Constants.V1_API_ACCEPT})
-	public ResponseEntity<String> updateFile(@PathVariable("fileId") String fileId,
+	public ResponseEntity<String> updateFile(@PathVariable("fileId") String fileId, @PathVariable("org") String org,
 			@RequestBody(required = false) CpcFileStatusUpdateRequest request) {
 		if (blockCpcPlusApi()) {
 			API_LOG.info(BLOCKED_BY_FEATURE_FLAG);
@@ -142,9 +145,9 @@ public class CpcFileControllerV1 {
 
 		String message;
 		if (request != null && request.getProcessed() != null && !request.getProcessed()) {
-			message = cpcFileService.unprocessFileById(fileId);
+			message = cpcFileService.unprocessFileById(fileId, org);
 		} else {
-			message = cpcFileService.processFileById(fileId);
+			message = cpcFileService.processFileById(fileId, org);
 		}
 
 		API_LOG.info("CPC+ update file request succeeded for fileId {} with message: {}", fileId, message);

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/helper/MetadataHelper.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/helper/MetadataHelper.java
@@ -46,6 +46,7 @@ public class MetadataHelper {
 			metadata.setProgramName(findProgramName(node));
 			metadata.setCpc(deriveCpcHash(node));
 			metadata.setCpcProcessed(false);
+			metadata.setRtiProcessed(false);
 		}
 
 		outcome.setStatus(metadata);

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp.conversion.api.model;
 
+import java.util.HashMap;
+
 /**
  * Constants library for use within the ReST API.
  */
@@ -22,6 +24,16 @@ public class Constants {
 	public static final String CPC_PLUS_BUCKET_NAME_VARIABLE = "CPC_PLUS_BUCKET_NAME";
 	public static final String CPC_PLUS_FILENAME_VARIABLE = "CPC_PLUS_VALIDATION_FILE";
 	public static final String CPC_PLUS_UNPROCESSED_FILE_SEARCH_DATE_VARIABLE = "CPC_PLUS_UNPROCESSED_FILTER_START_DATE";
+	public static final HashMap<String, String> ORG_ATTRIBUTE_MAP;
+	public static final String CPC_ORG = "cpcplus";
+	public static final String RTI_ORG = "rti";
+
+	static {
+		HashMap<String, String> mapBuilder = new HashMap<>();
+		mapBuilder.put(CPC_ORG, DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE);
+		mapBuilder.put(RTI_ORG,DYNAMO_RTI_PROCESSED_CREATE_DATE_ATTRIBUTE);
+		ORG_ATTRIBUTE_MAP = mapBuilder;
+	}
 
 	/**
 	 * Library utility class so the constructor is private and empty.

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
@@ -17,6 +17,7 @@ public class Constants {
 	public static final String CPC_DYNAMO_PARTITION_START = "CPC_";
 	public static final String DYNAMO_CPC_ATTRIBUTE = "Cpc";
 	public static final String DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE = "CpcProcessed_CreateDate";
+	public static final String DYNAMO_RTI_PROCESSED_CREATE_DATE_ATTRIBUTE = "RtiProcessed_CreateDate";
 	public static final String DYNAMO_CREATE_DATE_ATTRIBUTE = "CreateDate";
 	public static final String CPC_PLUS_BUCKET_NAME_VARIABLE = "CPC_PLUS_BUCKET_NAME";
 	public static final String CPC_PLUS_FILENAME_VARIABLE = "CPC_PLUS_VALIDATION_FILE";

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/security/JwtAuthorizationFilter.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/security/JwtAuthorizationFilter.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.api.security;
 
+import com.google.common.collect.ImmutableSet;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -13,17 +14,20 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Filter for checking the Json Web Token (JWT) for the correct Authorization
  */
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 	public static final String DEFAULT_ORG_NAME = "cpc-test";
+	public static final Set<String> DEFAULT_ORG_SET = ImmutableSet.of(DEFAULT_ORG_NAME);
 	private static final String HEADER_STRING = "Authorization";
 	private static final String TOKEN_PREFIX = "Bearer ";
 
-	protected final String orgName;
+	protected final Set<String> orgName;
 
 	/**
 	 * JWT Constructor with Authentication manager
@@ -31,7 +35,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 	 * @param authManager Object to be passed to it's parent constructor
 	 */
 	public JwtAuthorizationFilter(AuthenticationManager authManager) {
-		this(authManager, DEFAULT_ORG_NAME);
+		this(authManager, DEFAULT_ORG_SET);
 	}
 
 	/**
@@ -40,7 +44,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 	 * @param authManager Object to be passed to it's parent constructor
 	 * @param orgName The organization name
 	 */
-	public JwtAuthorizationFilter(AuthenticationManager authManager, String orgName) {
+	public JwtAuthorizationFilter(AuthenticationManager authManager, Set<String> orgName) {
 		super(authManager);
 		this.orgName = orgName;
 	}
@@ -109,6 +113,6 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 	 */
 	private boolean isValidCpcPlusOrg(Map<String, String> payloadMap) {
 		String payloadOrgName = payloadMap.get("name");
-		return (payloadOrgName != null && payloadMap.containsKey("orgType") && orgName.equals(payloadOrgName));
+		return (payloadOrgName != null && payloadMap.containsKey("orgType") && orgName.contains(payloadOrgName));
 	}
 }

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/security/JwtAuthorizationFilter.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/security/JwtAuthorizationFilter.java
@@ -14,7 +14,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/CpcFileService.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/CpcFileService.java
@@ -15,7 +15,7 @@ public interface CpcFileService {
 	 *
 	 * @return {@link Metadata} extracted as {@link UnprocessedCpcFileData}.
 	 */
-	List<UnprocessedCpcFileData> getUnprocessedCpcPlusFiles();
+	List<UnprocessedCpcFileData> getUnprocessedCpcPlusFiles(String orgAttribute);
 
 	Metadata getMetadataById(String fileId);
 
@@ -43,7 +43,7 @@ public interface CpcFileService {
 	 * @param fileId Identifier of the CPC+ file
 	 * @return Success or failure message
 	 */
-	String processFileById(String fileId);
+	String processFileById(String fileId, String orgName);
 
 	/**
 	 * Marks a CPC File as unprocessed by id
@@ -51,5 +51,5 @@ public interface CpcFileService {
 	 * @param fileId Identifier of the CPC+ file
 	 * @return Success or failure message
 	 */
-	String unprocessFileById(String fileId);
+	String unprocessFileById(String fileId, String orgName);
 }

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbService.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/DbService.java
@@ -17,7 +17,7 @@ public interface DbService {
 	 */
 	CompletableFuture<Metadata> write(Metadata meta);
 
-	List<Metadata> getUnprocessedCpcPlusMetaData();
+	List<Metadata> getUnprocessedCpcPlusMetaData(String orgAttribute);
 
 	/**
 	 * Retrieves the metadata from the database by uuid

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1Test.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1Test.java
@@ -160,6 +160,14 @@ class CpcFileControllerV1Test {
 	}
 
 	@Test
+	void testEndpoint1WithInvalidOrganization() {
+		ResponseEntity<List<UnprocessedCpcFileData>> cpcResponse = cpcFileControllerV1.getUnprocessedCpcPlusFiles("meep");
+
+		assertThat(cpcResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(cpcResponse.getBody()).isNull();
+	}
+
+	@Test
 	void testEndpoint2WithFeatureFlagDisabled() throws IOException {
 		System.setProperty(Constants.NO_CPC_PLUS_API_ENV_VARIABLE, "trueOrWhatever");
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1Test.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/CpcFileControllerV1Test.java
@@ -58,17 +58,17 @@ class CpcFileControllerV1Test {
 
 	@Test
 	void testUpdateFileWithNullBodyMarksAsProcessed() {
-		cpcFileControllerV1.updateFile("mock", null);
-		verify(cpcFileService).processFileById("mock");
+		cpcFileControllerV1.updateFile("mock", Constants.CPC_ORG,null);
+		verify(cpcFileService).processFileById("mock", Constants.CPC_ORG);
 	}
 
 	@Test
 	void testGetUnprocessedFileList() {
-		when(cpcFileService.getUnprocessedCpcPlusFiles()).thenReturn(expectedUnprocessedCpcFileDataList);
+		when(cpcFileService.getUnprocessedCpcPlusFiles(anyString())).thenReturn(expectedUnprocessedCpcFileDataList);
 
-		ResponseEntity<List<UnprocessedCpcFileData>> qppResponse = cpcFileControllerV1.getUnprocessedCpcPlusFiles();
+		ResponseEntity<List<UnprocessedCpcFileData>> qppResponse = cpcFileControllerV1.getUnprocessedCpcPlusFiles(Constants.CPC_ORG);
 
-		verify(cpcFileService).getUnprocessedCpcPlusFiles();
+		verify(cpcFileService).getUnprocessedCpcPlusFiles(Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE);
 
 		assertThat(qppResponse.getBody()).isEqualTo(expectedUnprocessedCpcFileDataList);
 	}
@@ -107,44 +107,44 @@ class CpcFileControllerV1Test {
 
 	@Test
 	void testMarkFileAsProcessedReturnsSuccess() {
-		when(cpcFileService.processFileById(anyString())).thenReturn("success!");
+		when(cpcFileService.processFileById(anyString(), anyString())).thenReturn("success!");
 
 		ResponseEntity<String> response = markProcessed();
 
-		verify(cpcFileService, times(1)).processFileById("meep");
+		verify(cpcFileService, times(1)).processFileById("meep", Constants.CPC_ORG);
 
 		assertThat(response.getBody()).isEqualTo("success!");
 	}
 
 	@Test
 	void testMarkFileAsProcessedHttpStatusOk() {
-		when(cpcFileService.processFileById(anyString())).thenReturn("success!");
+		when(cpcFileService.processFileById(anyString(), anyString())).thenReturn("success!");
 
 		ResponseEntity<String> response = markProcessed();
 
-		verify(cpcFileService, times(1)).processFileById("meep");
+		verify(cpcFileService, times(1)).processFileById("meep", Constants.CPC_ORG);
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
 
 	@Test
 	void testMarkFileAsUnprocessedReturnsSuccess() {
-		when(cpcFileService.unprocessFileById(anyString())).thenReturn("success!");
+		when(cpcFileService.unprocessFileById(anyString(), anyString())).thenReturn("success!");
 
 		ResponseEntity<String> response = markUnprocessed();
 
-		verify(cpcFileService, times(1)).unprocessFileById("meep");
+		verify(cpcFileService, times(1)).unprocessFileById("meep", Constants.RTI_ORG);
 
 		assertThat(response.getBody()).isEqualTo("success!");
 	}
 
 	@Test
 	void testMarkFileAsUnprocessedHttpStatusOk() {
-		when(cpcFileService.unprocessFileById(anyString())).thenReturn("success!");
+		when(cpcFileService.unprocessFileById(anyString(), anyString())).thenReturn("success!");
 
 		ResponseEntity<String> response = markUnprocessed();
 
-		verify(cpcFileService, times(1)).unprocessFileById("meep");
+		verify(cpcFileService, times(1)).unprocessFileById("meep", Constants.RTI_ORG);
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
@@ -153,7 +153,7 @@ class CpcFileControllerV1Test {
 	void testEndpoint1WithFeatureFlagDisabled() {
 		System.setProperty(Constants.NO_CPC_PLUS_API_ENV_VARIABLE, "trueOrWhatever");
 
-		ResponseEntity<List<UnprocessedCpcFileData>> cpcResponse = cpcFileControllerV1.getUnprocessedCpcPlusFiles();
+		ResponseEntity<List<UnprocessedCpcFileData>> cpcResponse = cpcFileControllerV1.getUnprocessedCpcPlusFiles(Constants.CPC_ORG);
 
 		assertThat(cpcResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 		assertThat(cpcResponse.getBody()).isNull();
@@ -263,13 +263,13 @@ class CpcFileControllerV1Test {
 	private ResponseEntity<String> markProcessed() {
 		CpcFileStatusUpdateRequest request = new CpcFileStatusUpdateRequest();
 		request.setProcessed(true);
-		return cpcFileControllerV1.updateFile("meep", request);
+		return cpcFileControllerV1.updateFile("meep", Constants.CPC_ORG, request);
 	}
 
 	private ResponseEntity<String> markUnprocessed() {
 		CpcFileStatusUpdateRequest request = new CpcFileStatusUpdateRequest();
 		request.setProcessed(false);
-		return cpcFileControllerV1.updateFile("meep", request);
+		return cpcFileControllerV1.updateFile("meep", Constants.RTI_ORG, request);
 	}
 
 	List<UnprocessedCpcFileData> createMockedUnprocessedDataList() {

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/ExceptionHandlerControllerV1Test.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v1/ExceptionHandlerControllerV1Test.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -223,8 +224,8 @@ class ExceptionHandlerControllerV1Test implements LoggerContract {
 				.build();
 		AmazonServiceException exception = new AmazonServiceException("some message");
 		exception.setStatusCode(404);
-		Mockito.when(mock.getUnprocessedCpcPlusFiles()).thenThrow(exception);
-		MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/cpc/unprocessed-files")).andReturn();
+		Mockito.when(mock.getUnprocessedCpcPlusFiles(anyString())).thenThrow(exception);
+		MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/cpc/unprocessed-files/cpcplus")).andReturn();
 		Truth.assertThat(result.getResponse().getStatus()).isEqualTo(404);
 		//mvc.perform(RequestBuilder("/cpc/unprocessed-files"));
 	}

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/model/ConstantsTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/model/ConstantsTest.java
@@ -4,11 +4,21 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 
+import static com.google.common.truth.Truth.assertThat;
+
 class ConstantsTest {
 	@Test
 	void testPrivateConstructor() throws Exception {
 		Constructor<Constants> constructor = Constants.class.getDeclaredConstructor();
 		constructor.setAccessible(true);
 		constructor.newInstance();
+	}
+
+	@Test
+	void testMapConstruction() {
+		assertThat(Constants.ORG_ATTRIBUTE_MAP.get(Constants.RTI_ORG))
+			.isEqualTo(Constants.DYNAMO_RTI_PROCESSED_CREATE_DATE_ATTRIBUTE);
+		assertThat(Constants.ORG_ATTRIBUTE_MAP.get(Constants.CPC_ORG))
+			.isEqualTo(Constants.DYNAMO_CPC_PROCESSED_CREATE_DATE_ATTRIBUTE);
 	}
 }

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/model/MetadataTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/model/MetadataTest.java
@@ -20,6 +20,7 @@ class MetadataTest {
 	@Test
 	void equalsContract() {
 		EqualsVerifier.forClass(Metadata.class)
+				.withIgnoredFields("rtiProcessed")
 				.usingGetClass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.verify();

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/security/JwtAuthorizationFilterTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/security/JwtAuthorizationFilterTest.java
@@ -2,6 +2,8 @@ package gov.cms.qpp.conversion.api.security;
 
 import gov.cms.qpp.conversion.api.helper.JwtPayloadHelper;
 import gov.cms.qpp.conversion.api.helper.JwtTestHelper;
+
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,6 +22,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -148,13 +151,13 @@ public class JwtAuthorizationFilterTest {
 
 	@Test
 	public void testDefaultOrgName() {
-		JwtAuthorizationFilter testJwtAuthFilter = new JwtAuthorizationFilter(authenticationManager, JwtAuthorizationFilter.DEFAULT_ORG_NAME);
-		Truth.assertThat(testJwtAuthFilter.orgName).isEqualTo(JwtAuthorizationFilter.DEFAULT_ORG_NAME);
+		JwtAuthorizationFilter testJwtAuthFilter = new JwtAuthorizationFilter(authenticationManager, JwtAuthorizationFilter.DEFAULT_ORG_SET);
+		Truth.assertThat(testJwtAuthFilter.orgName).contains(JwtAuthorizationFilter.DEFAULT_ORG_NAME);
 	}
 
 	@Test
 	public void testGivenOrgName() {
-		String expected = "some org name";
+		Set<String> expected = ImmutableSet.of("some org name");
 		JwtAuthorizationFilter testJwtAuthFilter = new JwtAuthorizationFilter(authenticationManager, expected);
 		Truth.assertThat(testJwtAuthFilter.orgName).isEqualTo(expected);
 	}

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/CpcFileServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/CpcFileServiceImplTest.java
@@ -2,6 +2,7 @@ package gov.cms.qpp.conversion.api.services.internal;
 
 import gov.cms.qpp.conversion.api.exceptions.InvalidFileTypeException;
 import gov.cms.qpp.conversion.api.exceptions.NoFileInDatabaseException;
+import gov.cms.qpp.conversion.api.model.Constants;
 import gov.cms.qpp.conversion.api.model.Metadata;
 import gov.cms.qpp.conversion.api.services.DbService;
 import gov.cms.qpp.conversion.api.services.StorageService;
@@ -21,12 +22,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.springframework.core.io.InputStreamResource;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,9 +58,9 @@ class CpcFileServiceImplTest {
 
 		List<Metadata> metadataList = Stream.generate(Metadata::new).limit(numberOfMetadata).collect(Collectors.toList());
 
-		when(dbService.getUnprocessedCpcPlusMetaData()).thenReturn(metadataList);
+		when(dbService.getUnprocessedCpcPlusMetaData(anyString())).thenReturn(metadataList);
 
-		assertThat(objectUnderTest.getUnprocessedCpcPlusFiles()).hasSize(numberOfMetadata);
+		assertThat(objectUnderTest.getUnprocessedCpcPlusFiles(Constants.CPC_ORG)).hasSize(numberOfMetadata);
 	}
 
 	@Test
@@ -174,7 +177,7 @@ class CpcFileServiceImplTest {
 		when(dbService.getMetadataById(anyString())).thenReturn(returnedData);
 		when(dbService.write(any(Metadata.class))).thenReturn(CompletableFuture.completedFuture(returnedData));
 
-		String message = objectUnderTest.processFileById(MEEP);
+		String message = objectUnderTest.processFileById(MEEP, Constants.CPC_ORG);
 
 		verify(dbService, times(1)).getMetadataById(MEEP);
 		verify(dbService, times(1)).write(returnedData);
@@ -187,7 +190,7 @@ class CpcFileServiceImplTest {
 		when(dbService.getMetadataById(anyString())).thenReturn(null);
 
 		NoFileInDatabaseException expectedException = assertThrows(NoFileInDatabaseException.class, ()
-				-> objectUnderTest.processFileById("test"));
+				-> objectUnderTest.processFileById("test", Constants.CPC_ORG));
 
 		verify(dbService, times(1)).getMetadataById(anyString());
 
@@ -199,7 +202,7 @@ class CpcFileServiceImplTest {
 		when(dbService.getMetadataById(anyString())).thenReturn(buildFakeMetadata(false, false));
 
 		InvalidFileTypeException expectedException = assertThrows(InvalidFileTypeException.class, ()
-				-> objectUnderTest.processFileById("test"));
+				-> objectUnderTest.processFileById("test", Constants.CPC_ORG));
 
 		verify(dbService, times(1)).getMetadataById(anyString());
 
@@ -209,8 +212,10 @@ class CpcFileServiceImplTest {
 	@Test
 	void testProcessFileByIdWithProcessedFile() {
 		when(dbService.getMetadataById(anyString())).thenReturn(buildFakeMetadata(true, true));
+		when(dbService.write(any())).thenReturn(CompletableFuture.completedFuture(
+			buildFakeMetadata(true, true)));
 
-		String response = objectUnderTest.processFileById("test");
+		String response = objectUnderTest.processFileById("test", Constants.CPC_ORG);
 
 		verify(dbService, times(1)).getMetadataById(anyString());
 
@@ -223,7 +228,7 @@ class CpcFileServiceImplTest {
 		when(dbService.getMetadataById(anyString())).thenReturn(returnedData);
 		when(dbService.write(any(Metadata.class))).thenReturn(CompletableFuture.completedFuture(returnedData));
 
-		String message = objectUnderTest.unprocessFileById(MEEP);
+		String message = objectUnderTest.unprocessFileById(MEEP, Constants.CPC_ORG);
 
 		verify(dbService, times(1)).getMetadataById(MEEP);
 		verify(dbService, times(1)).write(returnedData);
@@ -236,7 +241,7 @@ class CpcFileServiceImplTest {
 		when(dbService.getMetadataById(anyString())).thenReturn(null);
 
 		NoFileInDatabaseException expectedException = assertThrows(NoFileInDatabaseException.class, ()
-				-> objectUnderTest.unprocessFileById("test"));
+				-> objectUnderTest.unprocessFileById("test", "meep"));
 
 		verify(dbService, times(1)).getMetadataById(anyString());
 
@@ -248,7 +253,7 @@ class CpcFileServiceImplTest {
 		when(dbService.getMetadataById(anyString())).thenReturn(buildFakeMetadata(false, false));
 
 		InvalidFileTypeException expectedException = assertThrows(InvalidFileTypeException.class, ()
-				-> objectUnderTest.unprocessFileById("test"));
+				-> objectUnderTest.unprocessFileById("test", Constants.CPC_ORG));
 
 		verify(dbService, times(1)).getMetadataById(anyString());
 
@@ -258,8 +263,10 @@ class CpcFileServiceImplTest {
 	@Test
 	void testUnprocessFileByIdWithProcessedFile() {
 		when(dbService.getMetadataById(anyString())).thenReturn(buildFakeMetadata(true, false));
+		when(dbService.write(any())).thenReturn(CompletableFuture.completedFuture(
+			buildFakeMetadata(true, false)));
 
-		String response = objectUnderTest.unprocessFileById("test");
+		String response = objectUnderTest.unprocessFileById("test", Constants.CPC_ORG);
 
 		verify(dbService, times(1)).getMetadataById(anyString());
 
@@ -270,6 +277,7 @@ class CpcFileServiceImplTest {
 		Metadata metadata = Metadata.create();
 		metadata.setCpc(isCpc ? "CPC_26" : null);
 		metadata.setCpcProcessed(isCpcProcessed);
+		metadata.setRtiProcessed(isCpcProcessed);
 		metadata.setSubmissionLocator("test");
 		metadata.setQppLocator("test");
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/DbServiceImplTest.java
@@ -62,7 +62,7 @@ class DbServiceImplTest {
 	@Test
 	void testGetUnprocessedCpcPlusMetaDataWithMissingDynamoDbMapper() {
 		underTest = new DbServiceImpl(taskExecutor, Optional.empty(), environment);
-		assertThat(underTest.getUnprocessedCpcPlusMetaData()).isEmpty();
+		assertThat(underTest.getUnprocessedCpcPlusMetaData(Constants.CPC_ORG)).isEmpty();
 	}
 
 	@Test
@@ -119,7 +119,7 @@ class DbServiceImplTest {
 		when(dbMapper.query(eq(Metadata.class), any(DynamoDBQueryExpression.class)))
 			.thenReturn(mockMetadataPage);
 
-		List<Metadata> metaDataList = underTest.getUnprocessedCpcPlusMetaData();
+		List<Metadata> metaDataList = underTest.getUnprocessedCpcPlusMetaData(Constants.CPC_ORG);
 
 		verify(dbMapper, times(Constants.CPC_DYNAMO_PARTITIONS)).query(eq(Metadata.class), any(DynamoDBQueryExpression.class));
 		assertThat(metaDataList).hasSize(itemsPerPartition * Constants.CPC_DYNAMO_PARTITIONS);


### PR DESCRIPTION
### Information
- https://jira.cms.gov/browse/QPPSF-6654

### Changes proposed in this PR:
- Adds new metadata field `RtiProcessed_CreateDate` to allow data storage and filtering for the RTI team.
- New security configuration stored as an ENV called `RTI_ORG_NAME` to allow any organization with proper JWT organization access. Using an environment variable to allow security around the name and being able to change and deploy easily (The tokens have not been requested yet however,  we can test with any token for now until proper tokens are made)
- Updated CPC+ APIs
    - Retrieve Unprocessed files now takes an organization i.e. `rti` or `cpcplus` to decide which team is pulling the list.
    - Retreive QRDA-III and QPP-json is the same.
    - Processing/Unprocessing api now takes an org name as well to filter which team has processed a file.
- Unit tests to ensure the API side is working properly.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
