### PR TITLE
QPPSF-6546: APM validation file

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/Context.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/Context.java
@@ -37,7 +37,7 @@ public class Context {
 	 * @param apmEntityIds
 	 */
 	public Context(ApmEntityIds apmEntityIds) {
-		apmEntityIds = apmEntityIds;
+		this.apmEntityIds = apmEntityIds;
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/Context.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/Context.java
@@ -1,11 +1,13 @@
 package gov.cms.qpp.conversion;
 
+import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
 import gov.cms.qpp.conversion.model.Program;
 import gov.cms.qpp.conversion.model.Registry;
+import gov.cms.qpp.conversion.model.validation.ApmEntityIds;
 import gov.cms.qpp.conversion.validate.pii.MissingPiiValidator;
 import gov.cms.qpp.conversion.validate.pii.PiiValidator;
 
@@ -20,6 +22,23 @@ public class Context {
 	private boolean historical;
 	private boolean doValidation = true;
 	private PiiValidator piiValidator = MissingPiiValidator.INSTANCE;
+	private ApmEntityIds apmEntityIds;
+
+	/**
+	 * Initialize a context with the default APM entity id file
+	 */
+	public Context() {
+		apmEntityIds = new ApmEntityIds(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
+	}
+
+	/**
+	 * Initialize a context with a pre-set APM entity id file
+	 *
+	 * @param apmEntityIds
+	 */
+	public Context(ApmEntityIds apmEntityIds) {
+		apmEntityIds = apmEntityIds;
+	}
 
 	/**
 	 * Gets the current contextual {@link Program}
@@ -81,6 +100,14 @@ public class Context {
 
 	public void setPiiValidator(PiiValidator piiValidator) {
 		this.piiValidator = piiValidator;
+	}
+
+	public ApmEntityIds getApmEntityIds() {
+		return apmEntityIds;
+	}
+
+	public void setApmEntityIds(final ApmEntityIds apmEntityIds) {
+		this.apmEntityIds = apmEntityIds;
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
@@ -10,46 +10,21 @@ import java.util.Set;
 /**
  * Represents all the valid APM Entity IDs
  */
-public final class ApmEntityIds {
+public class ApmEntityIds {
 
 	public static final String DEFAULT_APM_ENTITY_FILE_NAME = "apm_entity_ids.json";
 
-	private static String apmEntityIdsFileName = DEFAULT_APM_ENTITY_FILE_NAME;
-	private static Set<String> validApmEntityIds;
+	private Set<String> validApmEntityIds;
 
-	/**
-	 * Static initialization
-	 */
-	static {
-		initApmEntityIds();
-	}
-
-	/**
-	 * Empty private constructor for singleton
-	 */
-	private ApmEntityIds() {
-		//empty and private constructor because this is a singleton
-	}
-
-	/**
-	 * Populates the set of APM Entity IDs.
-	 */
-	private static void initApmEntityIds() {
-		validApmEntityIds = grabConfiguration(apmEntityIdsFileName);
-	}
-
-	/**
-	 * Given the file name, returns a {@link Set} of {@link String}s from the file.
-	 *
-	 * @param fileName The file to parse.
-	 * @return Set of Strings.
-	 */
-	private static Set<String> grabConfiguration(String fileName) {
+	public ApmEntityIds(InputStream fileStream) {
 		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
+		validApmEntityIds = JsonHelper.readJson(fileStream, setOfStringsType);
+	}
 
+	public ApmEntityIds(String fileName) {
+		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
 		InputStream apmEntityIdsInput = ClasspathHelper.contextClassLoader().getResourceAsStream(fileName);
-
-		return JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
+		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
 	}
 
 	/**
@@ -57,9 +32,10 @@ public final class ApmEntityIds {
 	 *
 	 * @param fileName The file name to use.
 	 */
-	public static void setApmDataFile(String fileName) {
-		apmEntityIdsFileName = fileName;
-		initApmEntityIds();
+	public void setApmDataFile(String fileName) {
+		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
+		InputStream apmEntityIdsInput = ClasspathHelper.contextClassLoader().getResourceAsStream(fileName);
+		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
 	}
 
 	/**
@@ -68,7 +44,7 @@ public final class ApmEntityIds {
 	 * @param apmEntityId The APM Entity ID to check.
 	 * @return Whether or not the APM Entity ID exists.
 	 */
-	public static boolean idExists(String apmEntityId) {
+	public boolean idExists(String apmEntityId) {
 		return validApmEntityIds.contains(apmEntityId);
 	}
 }

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
@@ -14,23 +14,22 @@ public class ApmEntityIds {
 
 	public static final String DEFAULT_APM_ENTITY_FILE_NAME = "apm_entity_ids.json";
 
+	private static TypeReference<Set<String>> SET_OF_STRINGS_TYPE = new TypeReference<Set<String>>() {};
+
 	private Set<String> validApmEntityIds;
 
 	public ApmEntityIds(InputStream fileStream) {
-		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
-		validApmEntityIds = JsonHelper.readJson(fileStream, setOfStringsType);
+		validApmEntityIds = JsonHelper.readJson(fileStream, SET_OF_STRINGS_TYPE);
 	}
 
 	public ApmEntityIds(String fileName) {
-		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
 		InputStream apmEntityIdsInput = ClasspathHelper.contextClassLoader().getResourceAsStream(fileName);
-		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
+		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, SET_OF_STRINGS_TYPE);
 	}
 
 	public ApmEntityIds() {
-		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
 		InputStream apmEntityIdsInput = ClasspathHelper.contextClassLoader().getResourceAsStream(DEFAULT_APM_ENTITY_FILE_NAME);
-		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
+		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, SET_OF_STRINGS_TYPE);
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
@@ -27,6 +27,12 @@ public class ApmEntityIds {
 		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
 	}
 
+	public ApmEntityIds() {
+		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
+		InputStream apmEntityIdsInput = ClasspathHelper.contextClassLoader().getResourceAsStream(DEFAULT_APM_ENTITY_FILE_NAME);
+		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
+	}
+
 	/**
 	 * Returns a boolean for whether the provided APM Entity ID exists in the set of valid APM Entity IDs.
 	 *

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/validation/ApmEntityIds.java
@@ -28,17 +28,6 @@ public class ApmEntityIds {
 	}
 
 	/**
-	 * Sets the file to use as a data source for the set of valid APM Entity IDs.
-	 *
-	 * @param fileName The file name to use.
-	 */
-	public void setApmDataFile(String fileName) {
-		TypeReference<Set<String>> setOfStringsType = new TypeReference<Set<String>>() {};
-		InputStream apmEntityIdsInput = ClasspathHelper.contextClassLoader().getResourceAsStream(fileName);
-		validApmEntityIds = JsonHelper.readJson(apmEntityIdsInput, setOfStringsType);
-	}
-
-	/**
 	 * Returns a boolean for whether the provided APM Entity ID exists in the set of valid APM Entity IDs.
 	 *
 	 * @param apmEntityId The APM Entity ID to check.

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidator.java
@@ -113,7 +113,7 @@ public class CpcClinicalDocumentValidator extends NodeValidator {
 			return;
 		}
 
-		if (!ApmEntityIds.idExists(apmEntityId)) {
+		if (!context.getApmEntityIds().idExists(apmEntityId)) {
 			addError(Detail.forProblemAndNode(ProblemCode.CPC_CLINICAL_DOCUMENT_INVALID_APM, node));
 		}
 	}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentExtensionTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentExtensionTest.java
@@ -1,6 +1,7 @@
 package gov.cms.qpp.acceptance;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,12 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ProblemCode;
 import gov.cms.qpp.conversion.model.error.TransformException;
 import gov.cms.qpp.conversion.model.validation.ApmEntityIds;
+import gov.cms.qpp.conversion.model.validation.MeasureConfig;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -30,13 +34,11 @@ class ClinicalDocumentExtensionTest {
 
 	@BeforeAll
 	static void initMockApmIds() throws IOException {
-		ApmEntityIds.setApmDataFile("test_apm_entity_ids.json");
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.TEST_MEASURE_DATA);
 	}
 
 	@AfterAll
 	static void teardown() {
-		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
 	}
 
@@ -51,7 +53,7 @@ class ClinicalDocumentExtensionTest {
 	}
 
 	@Test
-	void invalidMessage() {
+	void invalidMessage() throws IOException {
 		try {
 			convert(INVALID);
 		} catch (TransformException ex) {
@@ -61,8 +63,9 @@ class ClinicalDocumentExtensionTest {
 		}
 	}
 
-	private JsonWrapper convert(Path location) {
-		Converter converter = new Converter(new PathSource(location));
+	private JsonWrapper convert(Path location) throws IOException {
+		ApmEntityIds apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
+		Converter converter = new Converter(new PathSource(location), new Context(apmEntityIds));
 		return converter.transform();
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/acceptance/CpcPlusRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/CpcPlusRoundTripTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import gov.cms.qpp.acceptance.helper.JsonPathToXpathHelper;
+import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
 import gov.cms.qpp.conversion.encode.JsonWrapper;
 import gov.cms.qpp.conversion.model.validation.ApmEntityIds;
@@ -31,17 +32,12 @@ class CpcPlusRoundTripTest {
 	@SuppressWarnings("unchecked")
 	@BeforeAll
 	static void setup() throws URISyntaxException, IOException {
-		ApmEntityIds.setApmDataFile("test_apm_entity_ids.json");
+		ApmEntityIds apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
 		URL sample = CpcPlusRoundTripTest.class.getClassLoader()
 				.getResource("cpc_plus/success/2020/CPCPlus_2020-Guid-Updates.xml");
 		Path path = Paths.get(sample.toURI());
-		new JsonPathToXpathHelper(path, wrapper, false);
+		new JsonPathToXpathHelper(path, wrapper, false, new Context(apmEntityIds));
 		json = new ObjectMapper().readValue(wrapper.copyWithoutMetadata().toString(), HashMap.class);
-	}
-
-	@AfterAll
-	static void resetApmIds() {
-		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
 	}
 
 	@ParameterizedTest

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -49,7 +49,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@BeforeEach
 	void setup() {
-		apmEntityIds.setApmDataFile("test_apm_entity_ids.json");
+		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.TEST_MEASURE_DATA);
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import gov.cms.qpp.acceptance.cpc.CPCAcceptanceFixture;
+import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;
 import gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder;
@@ -44,22 +45,22 @@ class QualityMeasureIdRoundTripTest {
 	static final Path MISSING_COUNT_FOR_PERF_DENOM =
 		Paths.get("src/test/resources/negative/perfDenomAggCountMissing.xml");
 	static final Path MIPS_APM_FILE = Paths.get("src/test/resources/CpcMipsApm-2020.xml");
+	ApmEntityIds apmEntityIds;
 
 	@BeforeEach
 	void setup() {
-		ApmEntityIds.setApmDataFile("test_apm_entity_ids.json");
+		apmEntityIds.setApmDataFile("test_apm_entity_ids.json");
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.TEST_MEASURE_DATA);
 	}
 
 	@AfterEach
 	void teardown() {
-		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
 	}
 
 	@Test
 	void testRoundTripForQualityMeasureId() {
-		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE));
+		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE), new Context(apmEntityIds));
 		JsonWrapper qpp = converter.transform();
 
 		List<Map<String, ?>> qualityMeasures = JsonHelper.readJsonAtJsonPath(qpp.toString(),
@@ -73,7 +74,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@Test
 	void testMeasureCMS165DoesNotContainUnexpectedValue() {
-		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE));
+		Converter converter = new Converter(new PathSource(JUNK_QRDA3_FILE), new Context(apmEntityIds));
 		JsonWrapper qpp = converter.transform();
 		List<String> containsUnwantedValueList = JsonHelper.readJsonAtJsonPath(qpp.toString(),
 			"$.measurementSets[?(@.category=='quality')].measurements[0].value.value", new TypeRef<List<String>>() { });
@@ -86,7 +87,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@Test
 	void testMeasureCMS68v8PerformanceRateUuid() {
-		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE));
+		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE), new Context(apmEntityIds));
 		List<Detail> details = new ArrayList<>();
 
 		try {
@@ -109,7 +110,7 @@ class QualityMeasureIdRoundTripTest {
 	@Test
 	void testMeasureCMS138v7PerformanceRateUuid() {
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.TEST_MEASURE_DATA);
-		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE));
+		Converter converter = new Converter(new PathSource(INVALID_PERFORMANCE_UUID_FILE), new Context(apmEntityIds));
 		List<Detail> details = new ArrayList<>();
 
 		try {
@@ -125,7 +126,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@Test
 	void testMeasureCMS52v5WithInsensitiveTextUuid() {
-		Converter converter = new Converter(new PathSource(INSENSITIVE_TEXT_FILE));
+		Converter converter = new Converter(new PathSource(INSENSITIVE_TEXT_FILE), new Context(apmEntityIds));
 		List<Detail> details = new ArrayList<>();
 
 		try {
@@ -141,7 +142,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@Test
 	void testMeasureCMS52v5InsensitiveMeasureDataUuid() {
-		Converter converter = new Converter(new PathSource(INSENSITIVE_TEXT_FILE));
+		Converter converter = new Converter(new PathSource(INSENSITIVE_TEXT_FILE), new Context(apmEntityIds));
 		List<Detail> details = new ArrayList<>();
 
 		LocalizedProblem error = ProblemCode.QUALITY_MEASURE_ID_INCORRECT_UUID.format(
@@ -161,7 +162,7 @@ class QualityMeasureIdRoundTripTest {
 	@Test
 	void test2020CorrectMultiToSinglePerfMeasureExample() {
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
-		Converter converter = new Converter(new PathSource(CORRECT_MULTI_TO_SINGLE_PERF_RATE_FILE));
+		Converter converter = new Converter(new PathSource(CORRECT_MULTI_TO_SINGLE_PERF_RATE_FILE), new Context(apmEntityIds));
 		JsonWrapper qpp = converter.transform();
 
 		String cms135MeasureId= "005";
@@ -173,7 +174,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@Test
 	void testIncorrectMultiToSinglePerfMeasureExample() {
-		Converter converter = new Converter(new PathSource(INCORRECT_MULTI_TO_SINGLE_PERF_RATE_FILE));
+		Converter converter = new Converter(new PathSource(INCORRECT_MULTI_TO_SINGLE_PERF_RATE_FILE), new Context(apmEntityIds));
 		List<Detail> details = new ArrayList<>();
 
 		try {
@@ -191,7 +192,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@Test
 	void testMissingPerfDenomAggregateCount() {
-		Converter converter = new Converter(new PathSource(MISSING_COUNT_FOR_PERF_DENOM));
+		Converter converter = new Converter(new PathSource(MISSING_COUNT_FOR_PERF_DENOM), new Context(apmEntityIds));
 		List<Detail> details = new ArrayList<>();
 
 		try {
@@ -211,7 +212,7 @@ class QualityMeasureIdRoundTripTest {
 	@Test
 	void test2020TopLevelMipsApmSampleFile() {
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
-		Converter converter = new Converter(new PathSource(MIPS_APM_FILE));
+		Converter converter = new Converter(new PathSource(MIPS_APM_FILE), new Context(apmEntityIds));
 		JsonWrapper qpp = converter.transform();
 
 		List<String> programName = JsonHelper.readJsonAtJsonPath(qpp.toString(),

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;
 import gov.cms.qpp.conversion.model.error.AllErrors;
@@ -39,18 +40,13 @@ class CpcPlusAcceptanceTest {
 	private static final Path FAILURE_2020 = BASE.resolve("failure/2020");
 	private static final Path FAILURE_FIXTURE = FAILURE.resolve("fixture.json");
 	private static Map<String, CPCAcceptanceFixture> fixtureValues;
+	private ApmEntityIds apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
 
 	@BeforeAll
 	static void setUp() throws IOException {
-		ApmEntityIds.setApmDataFile("test_apm_entity_ids.json");
 		TypeReference<Map<String, CPCAcceptanceFixture>> ref =
 				new TypeReference<Map<String, CPCAcceptanceFixture>>() { };
 		fixtureValues = JsonHelper.readJson(FAILURE_FIXTURE, ref);
-	}
-
-	@AfterAll
-	static void teardown() {
-		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
 	}
 
 	@BeforeEach
@@ -97,7 +93,7 @@ class CpcPlusAcceptanceTest {
 		AllErrors errors = null;
 		List<Detail> warnings = null;
 
-		Converter converter = new Converter(new PathSource(entry));
+		Converter converter = new Converter(new PathSource(entry), new Context(apmEntityIds));
 
 		try {
 			converter.transform();
@@ -116,7 +112,7 @@ class CpcPlusAcceptanceTest {
 		String fileName = entry.getFileName().toString();
 		assertWithMessage("No associated entry in fixture.json for the file %s", fileName).that(fixtureValues).containsKey(fileName);
 
-		Converter converter = new Converter(new PathSource(entry));
+		Converter converter = new Converter(new PathSource(entry), new Context(apmEntityIds));
 
 		TransformException expected = Assertions.assertThrows(TransformException.class, converter::transform);
 		//running conversions on individual files

--- a/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/cpc/CpcPlusAcceptanceTest.java
@@ -127,7 +127,7 @@ class CpcPlusAcceptanceTest {
 		AllErrors errors = null;
 		List<Detail> warnings = null;
 
-		Converter converter = new Converter(new PathSource(entry));
+		Converter converter = new Converter(new PathSource(entry), new Context(apmEntityIds));
 
 		try {
 			converter.transform();
@@ -148,7 +148,7 @@ class CpcPlusAcceptanceTest {
 		String fileName = entry.getFileName().toString();
 		assertWithMessage("No associated entry in fixture.json for the file %s", fileName).that(fixtureValues).containsKey(fileName);
 
-		Converter converter = new Converter(new PathSource(entry));
+		Converter converter = new Converter(new PathSource(entry), new Context(apmEntityIds));
 
 		TransformException expected = Assertions.assertThrows(TransformException.class, converter::transform);
 		//running conversions on individual files

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/ApmEntityIdsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/ApmEntityIdsTest.java
@@ -1,39 +1,35 @@
 package gov.cms.qpp.conversion.model.validation;
 
-import static com.google.common.truth.Truth.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
 
 class ApmEntityIdsTest {
 
 	private static final String APM_ID_THAT_EXISTS = "DogCow";
+	private ApmEntityIds apmEntityIds;
 
-	@BeforeAll
-	static void setUp() {
-		ApmEntityIds.setApmDataFile("test_apm_entity_ids.json");
-	}
 
-	@AfterAll
-	static void tearDown() {
-		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
+	@BeforeEach
+	void setUp() {
+		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
 	}
 
 	@Test
 	void testIdExists() {
-		assertThat(ApmEntityIds.idExists(APM_ID_THAT_EXISTS)).isTrue();
+		assertThat(apmEntityIds.idExists(APM_ID_THAT_EXISTS)).isTrue();
 	}
 
 	@Test
 	void testIdDoesNotExistDueToCapitalization() {
-		assertThat(ApmEntityIds.idExists(APM_ID_THAT_EXISTS.toUpperCase(Locale.ENGLISH))).isFalse();
+		assertThat(apmEntityIds.idExists(APM_ID_THAT_EXISTS.toUpperCase(Locale.ENGLISH))).isFalse();
 	}
 
 	@Test
 	void testIdDoesNotExists() {
-		assertThat(ApmEntityIds.idExists("PropertyTaxes")).isFalse();
+		assertThat(apmEntityIds.idExists("PropertyTaxes")).isFalse();
 	}
 }

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidatorTest.java
@@ -1,8 +1,6 @@
 package gov.cms.qpp.conversion.validate;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,20 +24,12 @@ import static com.google.common.truth.Truth.assertWithMessage;
 class CpcClinicalDocumentValidatorTest {
 
 	private CpcClinicalDocumentValidator cpcValidator;
-
-	@BeforeAll
-	static void initApmIds() {
-		ApmEntityIds.setApmDataFile("test_apm_entity_ids.json");
-	}
-
-	@AfterAll
-	static void defaultApmIds() {
-		ApmEntityIds.setApmDataFile(ApmEntityIds.DEFAULT_APM_ENTITY_FILE_NAME);
-	}
+	private ApmEntityIds apmEntityIds;
 
 	@BeforeEach
-	void createNewValidator() {
-		cpcValidator = new CpcClinicalDocumentValidator(new Context());
+	void setUp() {
+		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
+		cpcValidator = new CpcClinicalDocumentValidator(new Context(apmEntityIds));
 	}
 
 	@AfterEach

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
 	public static final HashMap<String, String> ORG_ATTRIBUTE_MAP;
 	public static final String CPC_ORG = "cpcplus";
 	public static final String RTI_ORG = "rti";
+	public static final String APM_FILE_NAME_KEY = "apm_entity_ids.json";
 
 	static {
 		HashMap<String, String> mapBuilder = new HashMap<>();

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageService.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/StorageService.java
@@ -34,4 +34,13 @@ public interface StorageService {
 	 * @return file used for cpc+ validation.
 	 */
 	InputStream getCpcPlusValidationFile();
+
+	/**
+	 * Retrieve the APM entity list.
+	 * The purpose is for easier manipulation of the apm entity list in all live environments.
+	 * The static list will still be present with default testing data.
+	 *
+	 * @return file used for apm entity validation
+	 */
+	InputStream getApmValidationFile();
 }

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
@@ -86,8 +86,7 @@ public class QrdaServiceImpl implements QrdaService {
 	private ApmEntityIds retrieveApmEntityValidationFile() {
 		API_LOG.info("Trying to fetch the APM Validation file");
 		InputStream apmInputStream = retrieveApmValidationFile();
-		ApmEntityIds apmEntityIds = apmInputStream != null ? new ApmEntityIds(apmInputStream) : new ApmEntityIds();
-		return apmEntityIds;
+		return apmInputStream != null ? new ApmEntityIds(apmInputStream) : new ApmEntityIds();
 	}
 
 	/**

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
@@ -85,7 +85,8 @@ public class QrdaServiceImpl implements QrdaService {
 
 	private ApmEntityIds retrieveApmEntityValidationFile() {
 		API_LOG.info("Trying to fetch the APM Validation file");
-		ApmEntityIds apmEntityIds = new ApmEntityIds(retrieveApmValidationFile());
+		InputStream apmInputStream = retrieveApmValidationFile();
+		ApmEntityIds apmEntityIds = apmInputStream != null ? new ApmEntityIds(apmInputStream) : new ApmEntityIds();
 		return apmEntityIds;
 	}
 
@@ -110,7 +111,7 @@ public class QrdaServiceImpl implements QrdaService {
 	 * @return converter instance
 	 */
 	Converter initConverter(Source source) {
-		Context context = (apmData != null) ? new Context(apmData.get()) : new Context();
+		Context context = new Context(apmData.get());
 		CpcValidationInfoMap apmToNpiValidationFile = cpcValidationData.get();
 		if (apmToNpiValidationFile != null && apmToNpiValidationFile.getApmTinNpiCombinationMap() != null) {
 			context.setPiiValidator(new SpecPiiValidator(apmToNpiValidationFile));

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
@@ -86,12 +86,6 @@ public class QrdaServiceImpl implements QrdaService {
 	private ApmEntityIds retrieveApmEntityValidationFile() {
 		API_LOG.info("Trying to fetch the APM Validation file");
 		ApmEntityIds apmEntityIds = new ApmEntityIds(retrieveApmValidationFile());
-		if (apmEntityIds != null) {
-			API_LOG.info("Fetched APM Validation file");
-		} else {
-			API_LOG.info("Could not fetch the apm validation file");
-			apmEntityIds = null;
-		}
 		return apmEntityIds;
 	}
 

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
@@ -20,6 +20,7 @@ import gov.cms.qpp.conversion.api.internal.pii.SpecPiiValidator;
 import gov.cms.qpp.conversion.api.model.CpcValidationInfoMap;
 import gov.cms.qpp.conversion.api.services.QrdaService;
 import gov.cms.qpp.conversion.api.services.StorageService;
+import gov.cms.qpp.conversion.model.validation.ApmEntityIds;
 import gov.cms.qpp.conversion.model.validation.MeasureConfigs;
 
 /**
@@ -32,6 +33,8 @@ public class QrdaServiceImpl implements QrdaService {
 
 	private final StorageService storageService;
 	private Supplier<CpcValidationInfoMap> cpcValidationData = () -> null;
+	private Supplier<ApmEntityIds> apmData = () -> null;
+
 
 	QrdaServiceImpl(StorageService storageService) {
 		this.storageService = storageService;
@@ -47,7 +50,12 @@ public class QrdaServiceImpl implements QrdaService {
 
 	@PostConstruct
 	public void loadCpcValidationData() {
-		cpcValidationData = Suppliers.memoizeWithExpiration(this::retreiveCpcValidationInfoMap, 2, TimeUnit.HOURS);
+		cpcValidationData = Suppliers.memoizeWithExpiration(this::retrieveCpcValidationInfoMap, 2, TimeUnit.HOURS);
+	}
+
+	@PostConstruct
+	public void loadApmData() {
+		apmData = Suppliers.memoizeWithExpiration(this::retrieveApmEntityValidationFile, 2, TimeUnit.HOURS);
 	}
 
 	/**
@@ -64,17 +72,7 @@ public class QrdaServiceImpl implements QrdaService {
 		return converter.getReport();
 	}
 
-	/**
-	 * Opens a stream to retrieve the CPC+ Validation file for the QPP Service
-	 *
-	 * @return cpc+ validation file.
-	 */
-	@Override
-	public InputStream retrieveCpcPlusValidationFile() {
-		return storageService.getCpcPlusValidationFile();
-	}
-
-	private CpcValidationInfoMap retreiveCpcValidationInfoMap() {
+	private CpcValidationInfoMap retrieveCpcValidationInfoMap() {
 		API_LOG.info("Fetching CPC+ validations APM/NPI/TIN file");
 		CpcValidationInfoMap file = new CpcValidationInfoMap(retrieveCpcPlusValidationFile());
 		if (file.getApmTinNpiCombinationMap() != null) {
@@ -85,6 +83,32 @@ public class QrdaServiceImpl implements QrdaService {
 		return file;
 	}
 
+	private ApmEntityIds retrieveApmEntityValidationFile() {
+		API_LOG.info("Trying to fetch the APM Validation file");
+		ApmEntityIds apmEntityIds = new ApmEntityIds(retrieveApmValidationFile());
+		if (apmEntityIds != null) {
+			API_LOG.info("Fetched APM Validation file");
+		} else {
+			API_LOG.info("Could not fetch the apm validation file");
+			apmEntityIds = null;
+		}
+		return apmEntityIds;
+	}
+
+	/**
+	 * Opens a stream to retrieve the CPC+ Validation file for the QPP Service
+	 *
+	 * @return cpc+ validation file.
+	 */
+	@Override
+	public InputStream retrieveCpcPlusValidationFile() {
+		return storageService.getCpcPlusValidationFile();
+	}
+
+	protected InputStream retrieveApmValidationFile() {
+		return storageService.getApmValidationFile();
+	}
+
 	/**
 	 * Instantiate a {@link Converter} with a given {@link Source}
 	 *
@@ -92,7 +116,7 @@ public class QrdaServiceImpl implements QrdaService {
 	 * @return converter instance
 	 */
 	Converter initConverter(Source source) {
-		Context context = new Context();
+		Context context = (apmData != null) ? new Context(apmData.get()) : new Context();
 		CpcValidationInfoMap apmToNpiValidationFile = cpcValidationData.get();
 		if (apmToNpiValidationFile != null && apmToNpiValidationFile.getApmTinNpiCombinationMap() != null) {
 			context.setPiiValidator(new SpecPiiValidator(apmToNpiValidationFile));

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/StorageServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/StorageServiceImpl.java
@@ -124,6 +124,26 @@ public class StorageServiceImpl extends AnyOrderActionService<Supplier<PutObject
 	}
 
 	/**
+	 * Opens a stream to retrieve the APM Validation file
+	 *
+	 * @return file used for APM validation.
+	 */
+	@Override
+	public InputStream getApmValidationFile() {
+		String bucketName = environment.getProperty(Constants.BUCKET_NAME_ENV_VARIABLE);
+		if (StringUtils.isEmpty(bucketName)) {
+			API_LOG.warn("No bucket name and/or key specified");
+			return null;
+		}
+		API_LOG.info("Retrieving APM validation file from bucket {}", bucketName);
+
+		GetObjectRequest getObjectRequest = new GetObjectRequest(bucketName, Constants.APM_FILE_NAME_KEY);
+		S3Object s3Object = amazonS3.getObject(getObjectRequest);
+
+		return s3Object.getObjectContent();
+	}
+
+	/**
 	 * Uses the {@link TransferManager} to upload a file.
 	 *
 	 * @param objectToActOn The put request.

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/integration/QrdaRestIntegrationTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/integration/QrdaRestIntegrationTest.java
@@ -58,7 +58,7 @@ public class QrdaRestIntegrationTest {
 	void testInvalidQpp() throws Exception {
 		MockMultipartFile qrda3File = new MockMultipartFile("file", Files.newInputStream(Paths.get("../qrda-files/not-a-QDRA-III-file.xml")));
 		mockMvc.perform(MockMvcRequestBuilders
-			.multipart("/").file(qrda3File))
+			.multipart("/").file(qrda3File).accept(Constants.V1_API_ACCEPT))
 			.andExpect(status().is(422))
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.errors").exists());

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImplTest.java
@@ -1,5 +1,6 @@
 package gov.cms.qpp.conversion.api.services.internal;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,9 @@ class QrdaServiceImplTest {
 	private static final String MOCK_SUCCESS_QPP_STRING = "Good Qpp";
 	private static final String MOCK_ERROR_SOURCE_IDENTIFIER = "Error Identifier";
 	private static final Path VALIDATION_JSON_FILE_PATH = Paths.get("src/test/resources/testCpcPlusValidationFile.json");
+	private static final Path VALIDATION_APM_FILE_PATH = Paths.get("src/test/resources/test_apm_entity_ids.json");
 	private InputStream MOCK_INPUT_STREAM;
+	private InputStream MOCK_APM_INPUT_STREAM;
 
 	@Spy
 	@InjectMocks
@@ -54,6 +57,7 @@ class QrdaServiceImplTest {
 	@BeforeEach
 	void mockConverter() throws IOException {
 		MOCK_INPUT_STREAM = Files.newInputStream(VALIDATION_JSON_FILE_PATH);
+		MOCK_APM_INPUT_STREAM = Files.newInputStream(VALIDATION_APM_FILE_PATH);
 		Converter success = successConverter();
 		when(objectUnderTest.initConverter(MOCK_SUCCESS_QRDA_SOURCE))
 				.thenReturn(success);
@@ -61,9 +65,18 @@ class QrdaServiceImplTest {
 		when(objectUnderTest.retrieveCpcPlusValidationFile())
 				.thenReturn(MOCK_INPUT_STREAM);
 
+		when(objectUnderTest.retrieveApmValidationFile())
+			.thenReturn(MOCK_APM_INPUT_STREAM);
+
 		Converter error = errorConverter();
 		when(objectUnderTest.initConverter(MOCK_ERROR_QRDA_SOURCE))
 				.thenReturn(error);
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		MOCK_APM_INPUT_STREAM.close();
+		MOCK_APM_INPUT_STREAM.close();
 	}
 
 	@Test

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/StorageServiceImplTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/services/internal/StorageServiceImplTest.java
@@ -212,4 +212,18 @@ class StorageServiceImplTest {
 		
 		assertThat(actual).isEqualTo(expected);
 	}
+
+	@Test
+	void test_getApmValidationFile() {
+		S3ObjectInputStream expected = new S3ObjectInputStream(null, null);
+		S3Object mockS3Obj = mock(S3Object.class);
+		Mockito.when(mockS3Obj.getObjectContent()).thenReturn(expected);
+
+		Mockito.when(environment.getProperty(Constants.BUCKET_NAME_ENV_VARIABLE)).thenReturn("Mock_Bucket");
+		Mockito.when(amazonS3Client.getObject( any(GetObjectRequest.class) )).thenReturn(mockS3Obj);
+
+		InputStream actual = underTest.getApmValidationFile();
+
+		assertThat(actual).isEqualTo(expected);
+	}
 }

--- a/rest-api/src/test/resources/test_apm_entity_ids.json
+++ b/rest-api/src/test/resources/test_apm_entity_ids.json
@@ -1,0 +1,1 @@
+["DogCow", "TestApmEntityId"]

--- a/rest-api/src/test/resources/test_apm_entity_ids.json
+++ b/rest-api/src/test/resources/test_apm_entity_ids.json
@@ -1,1 +1,1 @@
-["DogCow", "TestApmEntityId"]
+["A123", "1234-0000"]


### PR DESCRIPTION
### Information
- Allows the rest api to have a configurable APM validation file. Testing environments can now allow any value we choose to be a proper APM. The validation from the Submission API can specify any test APMs they use and we can configure this to work for CT.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
