### PR TITLE
QPPSF-7444: Ipop Denom Validations

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,6 +31,8 @@ jobs:
       run: mvn package -Dmaven.test.skip -Djacoco.skip=true
 
     - name: Run Unit tests & Sonar Scan
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: mvn --batch-mode verify -Psonar -Dsonar.organization=cmsgov -Dsonar.projectKey=gov.cms.qpp.conversion:qpp-conversion-new  -Dsonar.login=${{ secrets.SONAR_TOKEN }}
 
     - name: Run integration tests

--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -14,7 +14,7 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 9 : CT - Aggregate count value must be an integer
 * 11 : CT - This PI Reference and Results is missing a required Measure Performed child
 * 12 : CT - This PI Measure Performed Reference and Results requires a single Measure ID
-* 13 : CT - Denominator count must be equal to Initial Population count for a measure that is a proportion measure
+* 13 : CT - Denominator count must be less than equal to Initial Population count for the measure population `(measure population id)`
 * 14 : CT - The electronic measure id: `(Current eMeasure ID)` requires `(Number of Subpopulations required)` `(Type of Subpopulation required)`(s) but there are `(Number of Subpopulations existing)`
 * 15 : CT - PI Numerator Denominator element should have a PI Section element as a parent
 * 16 : CT - PI Numerator Denominator element does not contain a measure name ID
@@ -86,3 +86,4 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 98 : CT - The performance rate cannot have a value of 0 and must be of value Null Attribute (NA).
 * 99 : CT - The measure id `(Measure Id)` has a duplicate & invalid supplemental data of type `(Supplemental Type)`
 * 100 : CT - More than one Cehrt ID was found. Please submit with only one Cehrt id.
+* 101 : CT - Denominator count must be equal to Initial Population count for CPC Plus measure population `(measure population id)`.

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
@@ -39,8 +39,8 @@ public enum ProblemCode implements LocalizedProblem {
 		+ "Measure Performed child"),
 	PI_MEASURE_PERFORMED_RNR_MEASURE_ID_NOT_SINGULAR(12, "This PI Measure Performed Reference and Results requires "
 		+ "a single Measure ID"),
-	DENOMINATOR_COUNT_INVALID(13, "Denominator count must be equal to Initial Population count "
-			+ "for a measure that is a proportion measure"),
+	DENOMINATOR_COUNT_INVALID(13, "Denominator count must be less than equal to Initial Population count "
+			+ "for the measure population `(measure population id)`", true),
 	POPULATION_CRITERIA_COUNT_INCORRECT(14,
 			"The electronic measure id: `(Current eMeasure ID)` requires `(Number of Subpopulations required)` "
 			+ "`(Type of Subpopulation required)`(s) but there are `(Number of Subpopulations existing)`", true),
@@ -186,7 +186,8 @@ public enum ProblemCode implements LocalizedProblem {
 	CPC_MISSING_CEHRT_ID(97, "CPC+ QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)"),
 	CPC_PLUS_ZERO_PERFORMANCE_RATE(98, "The performance rate cannot have a value of 0 and must be of value Null Attribute (NA)."),
 	CPC_PLUS_EXTRA_SUPPLEMENTAL_DATA(99, "The measure id `(Measure Id)` has a duplicate & invalid supplemental data of type `(Supplemental Type)`", true),
-	CPC_PLUS_DUPLICATE_CEHRT(100, "More than one Cehrt ID was found. Please submit with only one Cehrt id.");
+	CPC_PLUS_DUPLICATE_CEHRT(100, "More than one Cehrt ID was found. Please submit with only one Cehrt id."),
+	CPC_PLUS_DENOMINATOR_COUNT_INVALID(101, "Denominator count must be equal to Initial Population count for CPC Plus measure population `(measure population id)`.", true);
 
 
 	private static final Map<Integer, ProblemCode> CODE_TO_VALUE = Arrays.stream(values())

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.decode.AggregateCountDecoder;
+import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.Detail;
@@ -173,16 +174,20 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 * @param node The current parent node
 	 * @param subPopulation the current sub population
 	 */
-	private void validateDenomCountToIpopCount(Node node, SubPopulation subPopulation) {
+	protected void validateDenomCountToIpopCount(Node node, SubPopulation subPopulation) {
 		Node denomNode = getDenominatorNodeFromCurrentSubPopulation(node, subPopulation);
-
 		Node ipopNode = getIpopNodeFromCurrentSubPopulation(node, subPopulation);
+		String program = node.getParent().getParent().getValue(ClinicalDocumentDecoder.PROGRAM_NAME);
 
 		if (denomNode != null && ipopNode != null) {
 			Node denomCount = denomNode.findFirstNode(TemplateId.PI_AGGREGATE_COUNT);
 			Node ipopCount = ipopNode.findFirstNode(TemplateId.PI_AGGREGATE_COUNT);
 
-			validateDenominatorCount(denomCount, ipopCount);
+			if (ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.equalsIgnoreCase(program)) {
+				validateCpcDenominatorCount(denomCount, ipopCount, subPopulation.getDenominatorUuid());
+			} else {
+				validateDenominatorCount(denomCount, ipopCount, subPopulation.getDenominatorUuid());
+			}
 		}
 	}
 
@@ -220,13 +225,28 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 * @param denomCount Aggregate Count node of denominator
 	 * @param ipopCount Aggregate Count node of initial population
 	 */
-	private void validateDenominatorCount(Node denomCount, Node ipopCount) {
+	private void validateDenominatorCount(Node denomCount, Node ipopCount, String denominatorUuid) {
 		forceCheckErrors(denomCount)
 				.incompleteValidation()
 				.intValue(ProblemCode.AGGREGATE_COUNT_VALUE_NOT_INTEGER,
 						AggregateCountDecoder.AGGREGATE_COUNT)
-				.valueIn(ProblemCode.DENOMINATOR_COUNT_INVALID, AggregateCountDecoder.AGGREGATE_COUNT,
-						ipopCount.getValue(AggregateCountDecoder.AGGREGATE_COUNT));
+				.lessThanOrEqualTo(ProblemCode.DENOMINATOR_COUNT_INVALID.format(denominatorUuid),
+					Integer.parseInt(ipopCount.getValue(AggregateCountDecoder.AGGREGATE_COUNT)));
+	}
+
+	/**
+	 * Performs a validation on a CPC Denominator node's aggregate count to the Initial Population node's aggregate count
+	 *
+	 * @param denomCount Aggregate Count node of denominator
+	 * @param ipopCount Aggregate Count node of initial population
+	 */
+	private void validateCpcDenominatorCount(Node denomCount, Node ipopCount, String denominatorUuid) {
+		forceCheckErrors(denomCount)
+			.incompleteValidation()
+			.intValue(ProblemCode.AGGREGATE_COUNT_VALUE_NOT_INTEGER,
+				AggregateCountDecoder.AGGREGATE_COUNT)
+			.valueIn(ProblemCode.DENOMINATOR_COUNT_INVALID.format(denominatorUuid), AggregateCountDecoder.AGGREGATE_COUNT,
+				ipopCount.getValue(AggregateCountDecoder.AGGREGATE_COUNT));
 	}
 
 	/**

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -245,7 +245,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 			.incompleteValidation()
 			.intValue(ProblemCode.AGGREGATE_COUNT_VALUE_NOT_INTEGER,
 				AggregateCountDecoder.AGGREGATE_COUNT)
-			.valueIn(ProblemCode.DENOMINATOR_COUNT_INVALID.format(denominatorUuid), AggregateCountDecoder.AGGREGATE_COUNT,
+			.valueIn(ProblemCode.CPC_PLUS_DENOMINATOR_COUNT_INVALID.format(denominatorUuid), AggregateCountDecoder.AGGREGATE_COUNT,
 				ipopCount.getValue(AggregateCountDecoder.AGGREGATE_COUNT));
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdMultiRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdMultiRoundTripTest.java
@@ -158,7 +158,7 @@ class QualityMeasureIdMultiRoundTripTest {
 		}
 
 		assertThat(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.contains(ProblemCode.DENOMINATOR_COUNT_INVALID);
+				.contains(ProblemCode.DENOMINATOR_COUNT_INVALID.format("D4D2DEE7-385A-4C28-A09C-884A062A97AA"));
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -1,12 +1,10 @@
 package gov.cms.qpp.acceptance;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.jayway.jsonpath.TypeRef;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import gov.cms.qpp.acceptance.cpc.CPCAcceptanceFixture;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcQualityMeasureIdValidatorTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import gov.cms.qpp.conversion.decode.AggregateCountDecoder;
+import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
 import gov.cms.qpp.conversion.decode.PerformanceRateProportionMeasureDecoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
@@ -23,12 +24,17 @@ class CpcQualityMeasureIdValidatorTest {
 
 	private CpcQualityMeasureIdValidator validator;
 	private Node testNode;
+	private Node clinicalDoc;
+	private Node measureSection;
 
 	@BeforeEach
 	void setUp() {
 		validator = new CpcQualityMeasureIdValidator();
 
-		testNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V4);
+		clinicalDoc = new Node(TemplateId.CLINICAL_DOCUMENT);
+		clinicalDoc.putValue(ClinicalDocumentDecoder.PROGRAM_NAME, ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME);
+		measureSection = new Node(TemplateId.MEASURE_SECTION_V4, clinicalDoc);
+		testNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V4, measureSection);
 		testNode.putValue(MeasureConfigHelper.MEASURE_ID, MEASURE_ID);
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.Lists;
 
 import gov.cms.qpp.conversion.decode.AggregateCountDecoder;
+import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
 import gov.cms.qpp.conversion.model.Node;
 import gov.cms.qpp.conversion.model.TemplateId;
 import gov.cms.qpp.conversion.model.error.Detail;
@@ -287,9 +288,7 @@ class QualityMeasureIdValidatorTest {
 
 		List<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode).getErrors();
 		assertWithMessage("There must not be any validation errors.")
-			.that(details)
-			.comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(ProblemCode.DENOMINATOR_COUNT_INVALID);
+			.that(details).isEmpty();
 	}
 
 	@Test
@@ -312,7 +311,7 @@ class QualityMeasureIdValidatorTest {
 		List<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode).getErrors();
 		assertWithMessage("Must contain the correct error message.")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ProblemCode.DENOMINATOR_COUNT_INVALID);
+				.containsExactly(ProblemCode.DENOMINATOR_COUNT_INVALID.format("375D0559-C749-4BB9-9267-81EDF447650B"));
 	}
 
 	@Test
@@ -422,9 +421,12 @@ class QualityMeasureIdValidatorTest {
 
 	private static class MeasureReferenceBuilder {
 		Node measureReferenceResultsNode;
+		Node clinicalDoc = new Node(TemplateId.CLINICAL_DOCUMENT);
+		Node measureSection = new Node(TemplateId.MEASURE_SECTION_V4, clinicalDoc);
 
 		MeasureReferenceBuilder() {
-			measureReferenceResultsNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V4);
+			clinicalDoc.putValue(ClinicalDocumentDecoder.PROGRAM_NAME, ClinicalDocumentDecoder.MIPS_PROGRAM_NAME);
+			measureReferenceResultsNode = new Node(TemplateId.MEASURE_REFERENCE_RESULTS_CMS_V4, measureSection);
 		}
 
 		MeasureReferenceBuilder addMeasureId(String measureId) {

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -346,7 +346,10 @@
 		"strict": true,
 		"errorData": [
 			{
-				"errorCode": 13,
+				"errorCode": 101,
+				"subs" : [
+					"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+				],
 				"occurrences": 1
 			}
 		]
@@ -355,7 +358,10 @@
 		"strict": true,
 		"errorData": [
 			{
-				"errorCode": 13,
+				"errorCode": 101,
+				"subs" : [
+					"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+				],
 				"occurrences": 1
 			}
 		]

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/services/internal/QrdaServiceImpl.java
@@ -7,6 +7,7 @@ import javax.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Supplier;
@@ -36,6 +37,7 @@ public class QrdaServiceImpl implements QrdaService {
 	private Supplier<ApmEntityIds> apmData = () -> null;
 
 
+	@Autowired
 	QrdaServiceImpl(StorageService storageService) {
 		this.storageService = storageService;
 	}


### PR DESCRIPTION
### Information
- Updates the Initial Population to Denominator validations
    - Denom. allowed to be <= I. Pop for non CPC+ submissions
    - Denom = Ipop for CPC+ submissions.
    - 
### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
