### PR TITLE
QPPSF-7456: Measure Specific Validations

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
@@ -217,14 +217,17 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 			case MIPS_GROUP:
 				pair = new ImmutablePair<>(MIPS_PROGRAM_NAME, ENTITY_GROUP);
 				break;
-			// Fall through for the same Immutable pair with MIPS_APM program
-			case MIPS_APM:
-			case CPCPLUS:
+
+ 			case CPCPLUS:
 				pair = new ImmutablePair<>(CPCPLUS_PROGRAM_NAME, ENTITY_APM);
 				break;
 
 			case MIPS_VIRTUAL_GROUP:
 				pair = new ImmutablePair<>(MIPS_PROGRAM_NAME, ENTITY_VIRTUAL_GROUP);
+				break;
+
+			case MIPS_APM:
+				pair = new ImmutablePair<>(MIPS_PROGRAM_NAME, ENTITY_APM);
 				break;
 
 			default:

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Program.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Program.java
@@ -13,8 +13,8 @@ import java.util.stream.Collectors;
  * Construct that helps categorize submissions by program name.
  */
 public enum Program {
-	MIPS("MIPS_GROUP", "MIPS_INDIV", "MIPS_VIRTUALGROUP", "MIPS"),
-	CPC("CPCPLUS", "MIPSAPM"),
+	MIPS("MIPS_GROUP", "MIPS_INDIV", "MIPS_VIRTUALGROUP", "MIPS", "MIPSAPM"),
+	CPC("CPCPLUS"),
 	ALL;
 
 	private final Set<String> aliases;

--- a/converter/src/main/java/gov/cms/qpp/conversion/util/MeasureConfigHelper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/util/MeasureConfigHelper.java
@@ -25,6 +25,7 @@ public class MeasureConfigHelper {
 	public static final String NO_MEASURE = "No given measure id";
 	private static Set<String> MULTI_TO_SINGLE_PERF_RATE_MEASURE_ID = ImmutableSet.of("005", "007", "008", "143", "438");
 	public final static String SINGLE_TO_MULTI_PERF_RATE_MEASURE_ID = "370";
+	public static final Set<String> CPC_PLUS_MEASURES = ImmutableSet.of("001", "236");
 
 	private MeasureConfigHelper() {
 		// private for this helper class

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidator.java
@@ -112,7 +112,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 				.forEach(subPopulationLabel -> validateChildTypeCount(finalSubPopulationList, subPopulationLabel, node));
 
 		for (SubPopulation subPopulation : finalSubPopulationList) {
-			validateSubPopulation(node, subPopulation);
+			validateSubPopulation(node, subPopulation, measureConfig.getMeasureId());
 		}
 	}
 
@@ -149,11 +149,11 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 * @param node          to validate
 	 * @param subPopulation a grouping of measures
 	 */
-	private void validateSubPopulation(Node node, SubPopulation subPopulation) {
+	private void validateSubPopulation(Node node, SubPopulation subPopulation, String measureId) {
 		List<Consumer<Node>> validations = prepValidations(subPopulation);
 		validations.forEach(validate -> validate.accept(node));
 
-		validateDenomCountToIpopCount(node, subPopulation);
+		validateDenomCountToIpopCount(node, subPopulation, measureId);
 	}
 
 
@@ -174,7 +174,7 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 	 * @param node The current parent node
 	 * @param subPopulation the current sub population
 	 */
-	protected void validateDenomCountToIpopCount(Node node, SubPopulation subPopulation) {
+	protected void validateDenomCountToIpopCount(Node node, SubPopulation subPopulation, String measureId) {
 		Node denomNode = getDenominatorNodeFromCurrentSubPopulation(node, subPopulation);
 		Node ipopNode = getIpopNodeFromCurrentSubPopulation(node, subPopulation);
 		String program = node.getParent().getParent().getValue(ClinicalDocumentDecoder.PROGRAM_NAME);
@@ -183,7 +183,8 @@ abstract class QualityMeasureIdValidator extends NodeValidator {
 			Node denomCount = denomNode.findFirstNode(TemplateId.PI_AGGREGATE_COUNT);
 			Node ipopCount = ipopNode.findFirstNode(TemplateId.PI_AGGREGATE_COUNT);
 
-			if (ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.equalsIgnoreCase(program)) {
+			if (ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.equalsIgnoreCase(program)
+				&& MeasureConfigHelper.CPC_PLUS_MEASURES.contains(measureId)) {
 				validateCpcDenominatorCount(denomCount, ipopCount, subPopulation.getDenominatorUuid());
 			} else {
 				validateDenominatorCount(denomCount, ipopCount, subPopulation.getDenominatorUuid());

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -358,7 +358,7 @@
 		"strict": true,
 		"errorData": [
 			{
-				"errorCode": 101,
+				"errorCode": 13,
 				"subs" : [
 					"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 				],

--- a/sample-files/2020/MIPS_APM_Entity_Submission.xml
+++ b/sample-files/2020/MIPS_APM_Entity_Submission.xml
@@ -1,3535 +1,6710 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <realmCode code="US" />
-  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2019-05-01"/>
-  <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
-  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
-  <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>
-  <effectiveTime value="20170311061231" />
-  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" />
-  <languageCode code="en" />
-  <setId root="D5E68223-5760-11E7-1256-09173F13E4C5" />
-  <versionNumber value="1" />
-  <recordTarget>
-    <patientRole>
-      <id nullFlavor="NA" />
-    </patientRole>
-  </recordTarget>
-  <!--Device Author Example-->
-  <author>
-    <time value="20170311061231" />
-    <assignedAuthor>
-      <id root="D5E68225-5760-11E7-1256-09173F13E4C5" />
-      <assignedAuthoringDevice>
-        <softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
-      </assignedAuthoringDevice>
-      <representedOrganization>
-        <id root="2.16.840.1.113883.19.5" extension="223344" />
-        <name>Good Health Clinic</name>
-      </representedOrganization>
-    </assignedAuthor>
-  </author>
-  <!--Person Author Example-->
-  <author>
-    <time value="20180311061231" />
-    <assignedAuthor>
-      <id root="2.16.840.1.113883.4.6" extension="2567891421" assigningAuthorityName="NPI" />
-      <assignedPerson>
-        <name>
-          <given>Trevor</given>
-          <family>Phillips</family>
-        </name>
-      </assignedPerson>
-      <representedOrganization>
-        <id root="2.16.840.1.113883.19.5" extension="223344" />
-        <name>Good Health Clinic</name>
-      </representedOrganization>
-    </assignedAuthor>
-  </author>
-  <custodian>
-    <assignedCustodian>
-      <representedCustodianOrganization>
-        <id root="2.16.840.1.113883.19.5" extension="223344" />
-        <name>Good Health Clinic</name>
-      </representedCustodianOrganization>
-    </assignedCustodian>
-  </custodian>
-  <!--Program for which data is being submitted-->
-  <informationRecipient>
-    <intendedRecipient>
-      <id root="2.16.840.1.113883.3.249.7" extension="mipsapm" />
-    </intendedRecipient>
-  </informationRecipient>
-  <legalAuthenticator>
-    <time value="20170312153222" />
-    <signatureCode code="S" />
-    <assignedEntity>
-      <id root="D5E68226-5760-11E7-1256-09173F13E4C5" />
-      <representedOrganization>
-        <id root="2.16.840.1.113883.19.5" extension="223344" />
-        <name>Good Health Clinic</name>
-      </representedOrganization>
-    </assignedEntity>
-  </legalAuthenticator>
-  <participant typeCode="DEV">
-    <associatedEntity classCode="RGPR">
-      <id root="2.16.840.1.113883.3.2074.1" extension="0014ABC1D1EFG1H" />
-      <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
-    </associatedEntity>
-  </participant>
-  <!--Practice Site-->
-  <participant typeCode="LOC">
-    <associatedEntity classCode="SDLOC">
-      <id root="2.16.840.1.113883.3.249.5.1" extension="TestApmEntityId" assigningAuthorityName="CMS-CMMI" />
-      <code code="394730007" displayName="healthcare related organization" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
-      <addr>
-        <streetAddressLine>123 Healthcare St</streetAddressLine>
-        <city>Norman</city>
-        <state>OK</state>
-        <postalCode>73019</postalCode>
-      </addr>
-    </associatedEntity>
-  </participant>
-  <!--Providers in Practice Site for which data is being submitted-->
-  <documentationOf typeCode="DOC">
-    <serviceEvent classCode="PCPR">
-      <effectiveTime>
-        <low value="20170101" />
-        <high value="20171231" />
-      </effectiveTime>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2567891421" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2589654740" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2345872354" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2365987421" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2357943549" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-    </serviceEvent>
-  </documentationOf>
-  <authorization>
-    <consent>
-      <id root="D5E68227-5760-11E7-1256-09173F13E4C5" />
-      <code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
-      <statusCode code="completed" />
-    </consent>
-  </authorization>
-  <!--
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
 ********************************************************
-CDA Body
+CDA Header
 ********************************************************
 -->
-  <component>
-    <structuredBody>
-      <!--
-********************************************************
-QRDA Category III Measure Section (CMS EP)
-********************************************************
--->
-      <component>
-        <section>
-          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01" />
-          <templateId root="2.16.840.1.113883.10.20.24.2.2" />
-          <templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01" />
-          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1" displayName="measure document" />
-          <title>Measure Section</title>
-          <!--Performance Period-->
-          <entry>
-            <act classCode="ACT" moodCode="EVN">
-              <templateId root="2.16.840.1.113883.10.20.17.3.8" />
-              <id root="D5E68228-5760-11E7-1256-09173F13E4C5" />
-              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters" />
-              <effectiveTime>
-                <low value="20200101" />
-                <high value="20201231" />
-              </effectiveTime>
-            </act>
-          </entry>
-          <!--Measure Entry for CMS122v8-->
-      		<entry>
-      			<organizer classCode="CLUSTER" moodCode="EVN">
-      				<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-      				<!-- Measure Reference Template -->
-      				<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
-      				<!-- Measure Reference & Results Template -->
-      				<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2019-05-01" />
-      				<!-- CMS Measure Reference & Results Template -->
-      				<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
-      				<statusCode code="completed"/>
-      				<!--Measure Reference and Results-->
-      				<reference typeCode="REFR">
-      					<externalDocument classCode="DOC" moodCode="EVN">
-      						<id root="2.16.840.1.113883.4.738"
-      							extension="40280382-6963-bf5e-0169-da3833273869"/>
-      						<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
-      							  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
-      						<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
-      					</externalDocument>
-      				</reference>
-      				<!--Performance Rate-->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
-      						<!-- Performance Rate Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
-      						<!-- Performance Rate for Proportion Measure Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
-      						<!-- CMS Performance Rate for Proportion Measure Template -->
-      						<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
-      							  codeSystemName="LOINC" displayName="Performance Rate"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="REAL" value=".888889"/>
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="2CC2A289-445C-4F15-AFC4-80B934AF5E1E"/>
-      								<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="Numerator"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!--IPOP Population-->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--IPOP Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="1000"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6822A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6822B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6822C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6822D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6822E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6822F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68230-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68231-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68232-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68233-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68234-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68235-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-      						<!--IPOP Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="1DAA17CC-1F6C-4883-9887-C1F1F72589B9"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!-- DENOM Population -->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--DENOM Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="1000"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68236-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68237-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68238-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68239-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6823E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6823F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68240-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68241-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-      						<!--DENOM Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="AE3CD839-EC29-4826-B4F9-B2305474402C"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!-- DENEX Population -->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--DENEX Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="100"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68267-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68268-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68269-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6826A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6826F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68270-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68271-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68272-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>c
-      						<!--DENEX Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="6F7B3C8C-9741-454B-9C02-3F279DD08B53"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!-- NUMER Population -->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--NUMER Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="800"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68242-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68243-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68244-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68245-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68246-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68247-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68248-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68249-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-      						<!--NUMER Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="2CC2A289-445C-4F15-AFC4-80B934AF5E1E"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      			</organizer>
-      		</entry>
-          <!--Measure Entry for CMS165v7-->
-          <entry>
-            <organizer classCode="CLUSTER" moodCode="EVN">
-              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2019-05-01" />
-              <id root="D5E68474-5760-11E7-1256-09173F13E4C5" />
-              <statusCode code="completed" />
-              <!--Measure Reference and Results-->
-              <reference typeCode="REFR">
-                <externalDocument classCode="DOC" moodCode="EVN">
-                  <id root="2.16.840.1.113883.4.738" extension="40280382-6963-bf5e-0169-da5e74be38bf" />
-                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
-                  <text>Controlling High Blood Pressure</text>
-                </externalDocument>
-              </reference>
-              <!--Performance Rate-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
-                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Performance Rate" />
-                  <statusCode code="completed" />
-                  <value xsi:type="REAL" value=".888889" />
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="9306E83B-3C3B-4CDF-B3EA-F99AEFC55F87" />
-                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Numerator" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--IPOP Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--IPOP Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68475-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68476-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68477-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68478-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68479-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6847D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6847E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6847F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68480-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--IPOP Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="1A3C24A5-7E9E-461B-BEB8-834822CC0942" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENOM Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENOM Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68481-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68482-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68483-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68484-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68485-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68486-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68487-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68488-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68489-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6848A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6848B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6848C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENOM Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="E822DECB-5DD1-421D-BFCE-F5DA550EE238" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENEX Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENEX Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="100" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6848F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68490-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68491-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68492-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68493-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68494-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68495-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68496-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68497-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68498-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENEX Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="965140D9-663B-4B08-99F9-19E14AE0CB5C" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--NUMER Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--NUMER Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="800" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68499-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6849A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E684A0-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A1-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A2-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A3-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A4-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--NUMER Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="9306E83B-3C3B-4CDF-B3EA-F99AEFC55F87" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-            </organizer>
-          </entry>
-        </section>
-      </component>
-    </structuredBody>
-  </component>
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2019-05-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPSAPM"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+					<id root="2.16.840.1.113883.4.6" extension="0777777777"/>
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+		<structuredBody>
+			<!--
+			********************************************************
+			QRDA Category III Measure Section - CMS (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- QRDA Category III Measure Section (V4) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+					<!-- QRDA Category III Measure Section - CMS (V2) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="measure section"/>
+					<title>Measure Section</title>
+					<text>
+						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Controlling High Blood Pressure</td>
+									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+									<td>40280381-51f0-825b-0152-22b98cff181a</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>:0.842105
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:50
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>30
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>10
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
+									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+									<td>40280381-51f0-825b-0152-229afff616ee</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.947368
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:900
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>598
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>50
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Documentation of Current Medications in the Medical Record</td>
+									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
+									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.816327
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exceptions</content>:20
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>12
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>8
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>18
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>5
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>2
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+
+						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Depression Utilization of the PHQ-9 Tool</td>
+									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
+									<td>40280381-503f-a1fc-0150-afe320c01761</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.860177
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:35
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:486
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.921052
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:700
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.962963
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:520
+							</item>
+						</list>
+					</text>
+
+					<!--Measure Entry for CMS165v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="40280382-6963-bf5e-0169-da5e74be38bf"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9306E83B-3C3B-4CDF-B3EA-F99AEFC55F87"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="1A3C24A5-7E9E-461B-BEB8-834822CC0942"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="E822DECB-5DD1-421D-BFCE-F5DA550EE238"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="965140D9-663B-4B08-99F9-19E14AE0CB5C"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9306E83B-3C3B-4CDF-B3EA-F99AEFC55F87"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!--Measure Entry for CMS122v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Measure Reference Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<!-- Measure Reference & Results Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+							<!-- CMS Measure Reference & Results Template -->
+							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738"
+										extension="40280382-6963-bf5e-0169-da3833273869"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<!-- Performance Rate Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<!-- Performance Rate for Proportion Measure Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+									<!-- CMS Performance Rate for Proportion Measure Template -->
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="2CC2A289-445C-4F15-AFC4-80B934AF5E1E"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="1DAA17CC-1F6C-4883-9887-C1F1F72589B9"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENOM Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="AE3CD839-EC29-4826-B4F9-B2305474402C"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENEX Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="6F7B3C8C-9741-454B-9C02-3F279DD08B53"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- NUMER Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="2CC2A289-445C-4F15-AFC4-80B934AF5E1E"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!--Measure Entry for CMS68v9-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="95944FB9-241B-11E5-1027-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738"
+										extension="40280382-68d3-a5fe-0169-0c589537118f"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Documentation of Current Medications in the Medical Record</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value="0.816327"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="E64BD324-C96C-4287-A515-D16B17778480"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP"
+										   codeSystem="2.16.840.1.113883.5.1063"
+										   codeSystemName="ObservationValue"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="959451FA-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Male"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="959451FB-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Female"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="600"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="959451FC-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="959451FD-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="650"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="959451FE-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="300"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="959451FF-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="White"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945200-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Asian"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945201-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945202-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicare"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945203-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicaid"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945204-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945205-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Other"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="A6DABDC3-2E60-435D-BC94-888561EA383B"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEXCEP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEXCEP"
+										   codeSystem="2.16.840.1.113883.5.1063"
+										   codeSystemName="ObservationValue"/>
+									<!--DENEXCEP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="20"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="95945206-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Male"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="12"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="95945207-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Female"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="8"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="95945208-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="18"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="95945209-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="2"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="9594520A-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="3"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="9594520B-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="White"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="15"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="9594520C-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Asian"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="2"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="9594520D-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="9594520E-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicare"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="10"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="9594520F-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicaid"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="3"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945210-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="5"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945211-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Other"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="2"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEXCEP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="D8B84799-2481-4AE1-965C-D8EA597173D1"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM"
+										   codeSystem="2.16.840.1.113883.5.1063"
+										   codeSystemName="ObservationValue"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="95945212-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Male"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="95945213-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Female"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="600"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="95945214-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="95945215-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="650"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945216-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="300"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945217-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="White"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945218-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Asian"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945219-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="9594521A-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicare"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="9594521B-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicaid"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="9594521C-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="350"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="9594521D-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Other"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="AC6813F8-2411-4D4E-ACCD-3BCE094D8218"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER"
+										   codeSystem="2.16.840.1.113883.5.1063"
+										   codeSystemName="ObservationValue"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="9594521E-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Male"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="300"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="9594521F-241B-11E5-1027-09173F13E4C5"/>
+											<code code="76689-9"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F"
+												   codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode"
+												   displayName="Female"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="95945220-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="95945221-241B-11E5-1027-09173F13E4C5"/>
+											<code code="69490-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC"
+												  displayName="Ethnic"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="550"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945222-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945223-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="White"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="300"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945224-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Asian"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="95945225-241B-11E5-1027-09173F13E4C5"/>
+											<code code="72826-1"
+												  codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945226-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicare"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="300"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945227-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Medicaid"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945228-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="95945229-241B-11E5-1027-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D"
+															 codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Other"/>
+											</value>
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG"
+														  codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode"
+														  displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT"
+																codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod"
+																displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="E64BD324-C96C-4287-A515-D16B17778480"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20200101"/>
+								<high value="20201231"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+			<!--
+		  	********************************************************
+		  	Promoting Interoperability Section (V2)
+		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
+		  	********************************************************
+		  	-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Advancing Care Information Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>PI Measure Title</th>
+									<th>Measure Identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Provide Patient Access</td>
+									<td>PI_PEA_1</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Denominator:</content>800
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator:</content>600
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate:
+								</content>0.75
+							</item>
+						</list>
+						<list>
+							<item>
+								<content styleCode="Bold">Measure Answer (Yes/No):
+								</content>Yes
+							</item>
+						</list>
+					</text>
+					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
+					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.28"
+										extension="2017-06-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
+									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
+									<!-- PI measure title -->
+									<text>Provide Patient Access</text>
+								</externalDocument>
+							</reference>
+							<!-- Performance Rate for PI is optional -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Performance Rate templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.30"
+												extension="2016-09-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value="0.75"/>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.31"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Numerator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="600"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.32"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Denominator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20200201"/>
+								<high value="20200531"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!--
+			********************************************************
+			Improvement Activity Section (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Improvement Activity Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>Improvement Activity Name</th>
+									<th>Activity ID</th>
+									<th>Question Answer Code</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Collection and use of patient experience and satisfaction data on access</td>
+									<td>IA_EPA_3</td>
+									<td>Y</td>
+								</tr>
+
+								<tr>
+									<td>Care transition documentation practice improvements</td>
+									<td>IA_CC_10</td>
+									<td>Y</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
+					<!-- IA_EPA_3 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Collection and use of patient experience and satisfaction data on access</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- IA_CC_10 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33"
+										extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Care transition documentation practice improvements</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20200101"/>
+								<high value="20200430"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+		</structuredBody>
+	</component>
 </ClinicalDocument>

--- a/valid-QRDA-III-latest-qpp.json
+++ b/valid-QRDA-III-latest-qpp.json
@@ -1,0 +1,69 @@
+{
+  "performanceYear" : 2020,
+  "entityType" : "apm",
+  "measurementSets" : [ {
+    "category" : "quality",
+    "submissionMethod" : "electronicHealthRecord",
+    "measurements" : [ {
+      "measureId" : "236",
+      "value" : {
+        "isEndToEndReported" : true,
+        "performanceMet" : 800,
+        "eligiblePopulationExclusion" : 100,
+        "performanceNotMet" : 100,
+        "eligiblePopulation" : 1000
+      }
+    }, {
+      "measureId" : "001",
+      "value" : {
+        "isEndToEndReported" : true,
+        "performanceMet" : 800,
+        "eligiblePopulationExclusion" : 100,
+        "performanceNotMet" : 100,
+        "eligiblePopulation" : 1000
+      }
+    }, {
+      "measureId" : "130",
+      "value" : {
+        "isEndToEndReported" : true,
+        "performanceMet" : 800,
+        "eligiblePopulationException" : 20,
+        "performanceNotMet" : 180,
+        "eligiblePopulation" : 1000
+      }
+    } ],
+    "programName" : "mips",
+    "performanceStart" : "2020-01-01",
+    "performanceEnd" : "2020-12-31",
+    "source" : "qrda3"
+  }, {
+    "category" : "pi",
+    "submissionMethod" : "electronicHealthRecord",
+    "cehrtId" : "XX15EXXXXXXXXXX",
+    "measurements" : [ {
+      "measureId" : "PI_PEA_1",
+      "value" : {
+        "numerator" : 600,
+        "denominator" : 800
+      }
+    } ],
+    "programName" : "mips",
+    "performanceStart" : "2020-02-01",
+    "performanceEnd" : "2020-05-31",
+    "source" : "qrda3"
+  }, {
+    "category" : "ia",
+    "submissionMethod" : "electronicHealthRecord",
+    "measurements" : [ {
+      "measureId" : "IA_EPA_3",
+      "value" : true
+    }, {
+      "measureId" : "IA_CC_10",
+      "value" : true
+    } ],
+    "programName" : "mips",
+    "performanceStart" : "2020-01-01",
+    "performanceEnd" : "2020-04-30",
+    "source" : "qrda3"
+  } ]
+}


### PR DESCRIPTION
### Information
- Initial measure specific validations
- Update Ipop & Denom validation to include only the 2 CPC+ measures (CMS122v8, CMS165v8) for validation.

Addition:
- Update mips apm submissions to be excluded from cpc+ validations and included as mips.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
