### PR TITLE
QPPSF-7463: Revert Supplemental Validation

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -84,6 +84,5 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 96 : CT - The APM to TIN/NPI Combination file is missing.
 * 97 : CT - CPC+ QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)
 * 98 : CT - The performance rate cannot have a value of 0 and must be of value Null Attribute (NA).
-* 99 : CT - The measure id `(Measure Id)` has a duplicate & invalid supplemental data of type `(Supplemental Type)`
 * 100 : CT - More than one Cehrt ID was found. Please submit with only one Cehrt id.
 * 101 : CT - Denominator count must be equal to Initial Population count for CPC Plus measure population `(measure population id)`.

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
@@ -185,7 +185,6 @@ public enum ProblemCode implements LocalizedProblem {
 	MISSING_API_TIN_NPI_FILE(96, "The APM to TIN/NPI Combination file is missing."),
 	CPC_MISSING_CEHRT_ID(97, "CPC+ QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)"),
 	CPC_PLUS_ZERO_PERFORMANCE_RATE(98, "The performance rate cannot have a value of 0 and must be of value Null Attribute (NA)."),
-	CPC_PLUS_EXTRA_SUPPLEMENTAL_DATA(99, "The measure id `(Measure Id)` has a duplicate & invalid supplemental data of type `(Supplemental Type)`", true),
 	CPC_PLUS_DUPLICATE_CEHRT(100, "More than one Cehrt ID was found. Please submit with only one Cehrt id."),
 	CPC_PLUS_DENOMINATOR_COUNT_INVALID(101, "Denominator count must be equal to Initial Population count for CPC Plus measure population `(measure population id)`.", true);
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidator.java
@@ -67,11 +67,6 @@ public class CpcMeasureDataValidator extends NodeValidator {
 		MeasureConfig measureConfig = MeasureConfigHelper.getMeasureConfig(node.getParent());
 		if (measureConfig != null) {
 			String electronicMeasureId = measureConfig.getElectronicMeasureId();
-			if (supplementalDataNodes.size() > codes.size()) {
-				LocalizedProblem error =
-					ProblemCode.CPC_PLUS_EXTRA_SUPPLEMENTAL_DATA.format(electronicMeasureId, supplementalDataType);
-				addError(Detail.forProblemAndNode(error, node));
-			}
 			for (SupplementalData supplementalData : codes) {
 				Node validatedSupplementalNode = filterCorrectNode(supplementalDataNodes, supplementalData);
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcMeasureDataValidatorTest.java
@@ -66,21 +66,6 @@ class CpcMeasureDataValidatorTest {
 			.contains(expectedError);
 	}
 
-	@Test
-	void validateFailureExtraSupplementalDataTest() throws Exception {
-		String failurePayerFile = TestHelper.getFixture("failureExtraSupplementalDataFile.xml");
-		Node placeholder = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(failurePayerFile));
-		CpcMeasureDataValidator validator = new CpcMeasureDataValidator();
-		Node underTest = placeholder.findFirstNode(TemplateId.MEASURE_DATA_CMS_V4);
-		List<Detail> errors = validator.validateSingleNode(underTest).getErrors();
-
-		LocalizedProblem expectedError = ProblemCode.CPC_PLUS_EXTRA_SUPPLEMENTAL_DATA.format(MEASURE_ID,
-			SupplementalData.SupplementalType.SEX);
-
-		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(expectedError);
-	}
-
 	@DisplayName("Should fail on absent supplemental race data")
 	@ParameterizedTest(name = "{index} => Supplemental data=''{0}''")
 	@EnumSource(value = SupplementalData.class, mode = EnumSource.Mode.INCLUDE,


### PR DESCRIPTION
### Information
- Removes the extra supplemental data validation

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [n/a] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
