### PR TITLE
QPPSF-8434 - Added iam user policy permissions to describe taskdefinition

### DIFF
--- a/infrastructure/terraform/dev/iam-ecs-gh/iam-gh-ecs.tf
+++ b/infrastructure/terraform/dev/iam-ecs-gh/iam-gh-ecs.tf
@@ -1,0 +1,50 @@
+terraform {
+    required_version = "0.13.7"
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "=3.52.0"
+        }
+    }
+}
+
+provider "aws" {
+    region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket  = "qppsf-conversion-tool-tf-state"
+    key     = "qppsf/qppsf-iam-ecs-gh-tf-state"
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+
+resource "aws_iam_user" "github-actions-ecr" {
+	name = "github-actions-ecr"
+}
+
+#IAM policy to describe task definition
+resource "aws_iam_user_policy" "ecsgithub" {
+  name = "ecs-github-describetask"
+  user = aws_iam_user.github-actions-ecr.name
+
+policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Sid": "githubecs",
+        Action = [
+          "ecs:DescribeTaskDefinition",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+


### PR DESCRIPTION
### Information
- Fixes #_.
QPPSF-8434

### Changes proposed in this PR:
- *Added iam policy, user "github-actions-ecr" gives permissions to describe task definitions* as needed for current conversion-tool git-hub workflow

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
