### PR TITLE
QPPSF-8394: Update Error messaging

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -56,10 +56,10 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 61 : CT - A Performance Rate must contain a single Numerator UUID reference.
 * 62 : CT - The Alternative Payment Model (APM) Entity Identifier must not be empty. Here is a link to the IG section on identifiers: https://ecqi.healthit.gov/sites/default/files/2021-CMS-QRDA-III-Eligible-Clinicians-and-EP-IG-v1.3.pdf#page=15
 * 63 : CT - The Alternative Payment Model (APM) Entity Identifier is not valid.  Here is a link to the IG section on identifiers: https://ecqi.healthit.gov/sites/default/files/2021-CMS-QRDA-III-Eligible-Clinicians-and-EP-IG-v1.3.pdf#page=15
-* 64 : CT - CPC+ or PCF Submissions must have at least `(CPC+ measure group minimum)` of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`
+* 64 : CT - CPC+ Submissions must have at least `(CPC+ measure group minimum)` of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`
 * 66 : CT - Missing the `(Supplemental Type)` - `(Type Qualification)` supplemental data for code `(Supplemental Data Code)` for the measure id `(Measure Id)`'s Sub-population `(Sub Population)`
 * 67 : CT - Must have one count for Supplemental Data `(Supplemental Data Code)` on Sub-population `(Sub Population)` for the measure id `(Measure Id)`
-* 68 : CT - Your CPC+ or PCF submission was made after the CPC+/PCF Measure section submission deadline of `(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at `(CPC+ contact email)` for assistance.
+* 68 : CT - Your `(Program name)` submission was made after the CPC+/PCF Measure section submission deadline of `(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at `(CPC+ contact email)` for assistance.
 * 69 : CT - `(Performance period start or end date)` is an invalid date format. Please use a standard ISO date format. Example valid values are 2019-02-26, 2019/02/26T01:45:23, or 2019-02-26T01:45:23.123. Please see the Implementation Guide for information on the performance period here: https://ecqi.healthit.gov/sites/default/files/2021-CMS-QRDA-III-Eligible-Clinicians-and-EP-IG-v1.3.pdf#page=17
 * 70 : CT - The measure section measure reference and results has an incorrect number of measure GUID supplied. Please ensure that only one measure GUID is provided per measure.
 * 71 : CT - Two or more different measure section measure reference and results have the same measure GUID. Please ensure that each measure section measure reference and results do not have the same measure GUID.
@@ -69,20 +69,20 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 80 : CT - NPI `(npi)` and TIN `(tin)` are not reported as expected. This NPI/TIN combination is missing from the QRDA III file or is not in the CPC+ Practitioner Roster for `(apm)`. Please ensure your submission contains all required NPI/TIN combinations and your CPC+ Practitioner Roster is up-to-date.
 * 81 : CT - At least one measure is required in a measure section
 * 82 : CT - There are too many errors associated with this QRDA-III file. Showing 100 out of `(Error amount)` errors. Please fix the given errors and re-submit
-* 84 : CT - CPC+ or PCF QRDA-III Submissions require at least one TIN to be present.
-* 85 : CT - CPC+ or PCF QRDA-III Submission TINs require a 9 digit numerical value
-* 86 : CT - This CPC+ or PCF QRDA-III submission is missing a TIN. Please ensure there is a TIN associated with every NPI submitted
-* 87 : CT - CPC+ or PCF QRDA-III Submissions require at least one NPI to be present
-* 88 : CT - CPC+ or PCF QRDA-III Submission NPIs require a 10 digit numerical value
-* 89 : CT - This CPC+ or PCF QRDA-III submission is missing a NPI. Please ensure there is an NPI associated with every TIN submitted
-* 90 : CT - CPC+ or PCF QRDA-III submissions must not contain an IA or PI section
+* 84 : CT - `(Program name)` QRDA-III Submissions require at least one TIN to be present.
+* 85 : CT - `(Program name)` QRDA-III Submission TINs require a 9 digit numerical value
+* 86 : CT - This `(Program name)` QRDA-III submission is missing a TIN. Please ensure there is a TIN associated with every NPI submitted
+* 87 : CT - `(Program name)` QRDA-III Submissions require at least one NPI to be present
+* 88 : CT - `(Program name)` QRDA-III Submission NPIs require a 10 digit numerical value
+* 89 : CT - This `(Program name)` QRDA-III submission is missing a NPI. Please ensure there is an NPI associated with every TIN submitted
+* 90 : CT - `(Program name)` QRDA-III submissions must not contain an IA or PI section
 * 91 : CT - The performance rate `(performanceRateUuid)` has an invalid null value. A performance rate cannot be null unless the performance denominator is 0
 * 92 : CT - The performance denominator for measure `(measureId)` was less than 0. A performance rate cannot be null unless the performance denominator is 0
 * 93 : CT - The numerator id `(numeratorUuid)` has a count value that is greater than the denominator and/or the performance denominator (Denominator count - Denominator exclusion count - Denominator Exception count)
 * 94 : CT - The denominator exclusion id `(denexUuid)` has a count value that is greater than the denominator. The Denominator exclusion cannot be a greater value than the denominator.
 * 95 : CT - The Clinical Document must contain one Measure Section v4 with the extension 2017-06-01
 * 96 : CT - The APM to TIN/NPI Combination file is missing.
-* 97 : CT - CPC+ or PCF QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)
+* 97 : CT - `(Program name)` QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)
 * 98 : CT - The performance rate cannot have a value of 0 and must be of value Null Attribute (NA).
 * 100 : CT - More than one Cehrt ID was found. Please submit with only one Cehrt id.
 * 101 : CT - Denominator count must be equal to Initial Population count for CPC Plus measure population `(measure population id)`.

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
@@ -133,13 +133,13 @@ public enum ProblemCode implements LocalizedProblem {
 			+ "Here is a link to the IG section on identifiers: " + DocumentationReference.IDENTIFIERS),
 	CPC_PCF_CLINICAL_DOCUMENT_INVALID_APM(63, "The Alternative Payment Model (APM) Entity Identifier is not valid. "
 			+ " Here is a link to the IG section on identifiers: " + DocumentationReference.IDENTIFIERS),
-	CPC_PLUS_TOO_FEW_QUALITY_MEASURE_CATEGORY(64, "CPC+ or PCF Submissions must have at least `(CPC+ measure group minimum)` "
+	CPC_PLUS_TOO_FEW_QUALITY_MEASURE_CATEGORY(64, "CPC+ Submissions must have at least `(CPC+ measure group minimum)` "
 			+ "of the following `(CPC+ measure group label)` measures: `(Listing of valid measure ids)`", true),
 	CPC_PCF_PLUS_MISSING_SUPPLEMENTAL_CODE(66, "Missing the `(Supplemental Type)` - `(Type Qualification)` supplemental data for code "
 		+ "`(Supplemental Data Code)` for the measure id `(Measure Id)`'s Sub-population `(Sub Population)`", true),
 	CPC_PCF_PLUS_SUPPLEMENTAL_DATA_MISSING_COUNT(67, "Must have one count for Supplemental Data `(Supplemental Data Code)` "
 		+ "on Sub-population `(Sub Population)` for the measure id `(Measure Id)`", true),
-	CPC_PCF_PLUS_SUBMISSION_ENDED(68, "Your CPC+ or PCF submission was made after the CPC+/PCF Measure section submission deadline of "
+	CPC_PCF_PLUS_SUBMISSION_ENDED(68, "Your `(Program name)` submission was made after the CPC+/PCF Measure section submission deadline of "
 		+ "`(Submission end date)`. Your CPC+ QRDA III file has not been processed. Please contact CPC+ Support at "
 		+ "`(CPC+ contact email)` for assistance.", true),
 	INVALID_PERFORMANCE_PERIOD_FORMAT(69, "`(Performance period start or end date)` is an invalid date format. "
@@ -163,15 +163,15 @@ public enum ProblemCode implements LocalizedProblem {
 	MEASURE_SECTION_MISSING_MEASURE(81, "At least one measure is required in a measure section"),
 	TOO_MANY_ERRORS(82, "There are too many errors associated with this QRDA-III file. Showing 100 out of `(Error amount)` errors."
 		+ " Please fix the given errors and re-submit", true),
-	CPC_PCF_PLUS_TIN_REQUIRED(84, "CPC+ or PCF QRDA-III Submissions require at least one TIN to be present."),
-	CPC_PCF_PLUS_INVALID_TIN(85, "CPC+ or PCF QRDA-III Submission TINs require a 9 digit numerical value"),
-	CPC_PCF_PLUS_MISSING_TIN(86, "This CPC+ or PCF QRDA-III submission is missing a TIN. Please ensure there is a TIN associated with every "
-		+ "NPI submitted"),
-	CPC_PCF_PLUS_NPI_REQUIRED(87, "CPC+ or PCF QRDA-III Submissions require at least one NPI to be present"),
-	CPC_PCF_PLUS_INVALID_NPI(88, "CPC+ or PCF QRDA-III Submission NPIs require a 10 digit numerical value"),
-	CPC_PCF_PLUS_MISSING_NPI(89, "This CPC+ or PCF QRDA-III submission is missing a NPI. Please ensure there is an NPI associated with "
-		+ "every TIN submitted"),
-	CPC_PCF_PLUS_NO_IA_OR_PI(90, "CPC+ or PCF QRDA-III submissions must not contain an IA or PI section"),
+	CPC_PCF_PLUS_TIN_REQUIRED(84, "`(Program name)` QRDA-III Submissions require at least one TIN to be present.", true),
+	CPC_PCF_PLUS_INVALID_TIN(85, "`(Program name)` QRDA-III Submission TINs require a 9 digit numerical value", true),
+	CPC_PCF_PLUS_MISSING_TIN(86, "This `(Program name)` QRDA-III submission is missing a TIN. Please ensure there is a TIN associated with every "
+		+ "NPI submitted", true),
+	CPC_PCF_PLUS_NPI_REQUIRED(87, "`(Program name)` QRDA-III Submissions require at least one NPI to be present", true),
+	CPC_PCF_PLUS_INVALID_NPI(88, "`(Program name)` QRDA-III Submission NPIs require a 10 digit numerical value",true ),
+	CPC_PCF_PLUS_MISSING_NPI(89, "This `(Program name)` QRDA-III submission is missing a NPI. Please ensure there is an NPI associated with "
+		+ "every TIN submitted", true),
+	CPC_PCF_PLUS_NO_IA_OR_PI(90, "`(Program name)` QRDA-III submissions must not contain an IA or PI section", true),
 	CPC_PCF_PLUS_INVALID_NULL_PERFORMANCE_RATE(91, "The performance rate `(performanceRateUuid)` has an invalid null value. "
 		+ "A performance rate cannot be null unless the performance denominator is 0", true),
 	CPC_PCF_PLUS_PERFORMANCE_DENOM_LESS_THAN_ZERO(92, "The performance denominator for measure `(measureId)` was less than 0. "
@@ -183,7 +183,7 @@ public enum ProblemCode implements LocalizedProblem {
 		+ "denominator. The Denominator exclusion cannot be a greater value than the denominator.", true),
 	MEASURE_SECTION_V4_REQUIRED(95, "The Clinical Document must contain one Measure Section v4 with the extension 2017-06-01"),
 	MISSING_API_TIN_NPI_FILE(96, "The APM to TIN/NPI Combination file is missing."),
-	CPC_PCF_MISSING_CEHRT_ID(97, "CPC+ or PCF QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)"),
+	CPC_PCF_MISSING_CEHRT_ID(97, "`(Program name)` QRDA-III Submissions require a valid Cehrt ID (Valid Format: XX15EXXXXXXXXXX)", true),
 	CPC_PCF_PLUS_ZERO_PERFORMANCE_RATE(98, "The performance rate cannot have a value of 0 and must be of value Null Attribute (NA)."),
 	CPC_PCF_PLUS_DUPLICATE_CEHRT(100, "More than one Cehrt ID was found. Please submit with only one Cehrt id."),
 	CPC_PCF_PLUS_DENOMINATOR_COUNT_INVALID(101, "Denominator count must be equal to Initial Population count for CPC Plus measure population `(measure population id)`.", true),

--- a/commons/src/main/resources/measures-data.json
+++ b/commons/src/main/resources/measures-data.json
@@ -1963,8 +1963,7 @@
       "internalMedicine",
       "preventiveMedicine",
       "nephrology",
-      "endocrinology",
-      "nutritionDietician"
+      "endocrinology"
     ],
     "measureSpecification": {
       "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2021/cms122v9",

--- a/converter/src/main/java/gov/cms/qpp/conversion/validate/PcfClinicalDocumentValidator.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/validate/PcfClinicalDocumentValidator.java
@@ -39,7 +39,8 @@ public class PcfClinicalDocumentValidator extends CpcClinicalDocumentValidator {
 			.singleValue(ProblemCode.CPC_PCF_CLINICAL_DOCUMENT_ONLY_ONE_APM_ALLOWED, ClinicalDocumentDecoder.PCF_ENTITY_ID)
 			.valueIsNotEmpty(ProblemCode.CPC_PCF_CLINICAL_DOCUMENT_EMPTY_APM, ClinicalDocumentDecoder.PCF_ENTITY_ID)
 			.childExact(ProblemCode.PCF_NO_PI, 0, TemplateId.PI_SECTION_V2)
-			.listValuesAreInts(ProblemCode.CPC_PCF_PLUS_INVALID_NPI, ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER);
+			.listValuesAreInts(ProblemCode.CPC_PCF_PLUS_INVALID_NPI.format(node.getValue(ClinicalDocumentDecoder.PROGRAM_NAME)),
+				ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER);
 
 		validateApmEntityId(node, ClinicalDocumentDecoder.PCF_ENTITY_ID);
 	}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/NegativePcfRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/NegativePcfRoundTripTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import gov.cms.qpp.conversion.Context;
 import gov.cms.qpp.conversion.Converter;
 import gov.cms.qpp.conversion.PathSource;
+import gov.cms.qpp.conversion.decode.ClinicalDocumentDecoder;
 import gov.cms.qpp.conversion.model.error.AllErrors;
 import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.LocalizedProblem;
@@ -72,7 +73,8 @@ public class NegativePcfRoundTripTest {
 		List<Detail> details = conversionError(Y5_NEGATIVE_PCF);
 
 		assertThat(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(ProblemCode.CPC_PCF_MISSING_CEHRT_ID.getProblemCode());
+			.contains(ProblemCode.CPC_PCF_MISSING_CEHRT_ID.
+				format(ClinicalDocumentDecoder.PCF_PROGRAM_NAME.toUpperCase()));
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/CpcClinicalDocumentValidatorTest.java
@@ -140,7 +140,7 @@ class CpcClinicalDocumentValidatorTest {
 
 		assertThat(errors)
 			.comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.containsExactly(ProblemCode.CPC_PCF_PLUS_SUBMISSION_ENDED.format(formattedDate, expected));
+			.containsExactly(ProblemCode.CPC_PCF_PLUS_SUBMISSION_ENDED.format(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME, formattedDate, expected));
 	}
 
 	@Test
@@ -151,7 +151,8 @@ class CpcClinicalDocumentValidatorTest {
 
 		assertWithMessage("Must validate with the correct error")
 			.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.containsExactly(ProblemCode.CPC_PCF_PLUS_TIN_REQUIRED);
+			.containsExactly(ProblemCode.CPC_PCF_PLUS_TIN_REQUIRED
+				.format(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.toUpperCase()));
 	}
 
 	@Test
@@ -162,7 +163,8 @@ class CpcClinicalDocumentValidatorTest {
 
 		assertWithMessage("Must validate with the correct error")
 			.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.containsExactly(ProblemCode.CPC_PCF_PLUS_NPI_REQUIRED);
+			.containsExactly(ProblemCode.CPC_PCF_PLUS_NPI_REQUIRED
+				.format(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.toUpperCase()));
 	}
 
 	@Test
@@ -173,7 +175,7 @@ class CpcClinicalDocumentValidatorTest {
 
 		assertWithMessage("Must validate with the correct error")
 			.that(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.containsExactly(ProblemCode.CPC_PCF_MISSING_CEHRT_ID);
+			.containsExactly(ProblemCode.CPC_PCF_MISSING_CEHRT_ID.format(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.toUpperCase()));
 	}
 
 	@Test
@@ -185,7 +187,7 @@ class CpcClinicalDocumentValidatorTest {
 
 		assertThat(warnings)
 			.comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-			.contains(ProblemCode.CPC_PCF_PLUS_NO_IA_OR_PI);
+			.contains(ProblemCode.CPC_PCF_PLUS_NO_IA_OR_PI.format(ClinicalDocumentDecoder.CPCPLUS_PROGRAM_NAME.toUpperCase()));
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/PcfClinicalDocumentValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/PcfClinicalDocumentValidatorTest.java
@@ -134,7 +134,7 @@ public class PcfClinicalDocumentValidatorTest {
 
 		List<Detail> errors = validator.validateSingleNode(clinicalDocumentNode).getErrors();
 		assertThat(errors).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
-				.containsExactly(ProblemCode.CPC_PCF_PLUS_INVALID_NPI);
+				.containsExactly(ProblemCode.CPC_PCF_PLUS_INVALID_NPI.format(ClinicalDocumentDecoder.PCF_PROGRAM_NAME.toUpperCase()));
 	}
 
 	private Node createPcfClinicalDocumentNodeWithMeasureSection() {

--- a/converter/src/test/resources/cpc_plus/failure/fixture.json
+++ b/converter/src/test/resources/cpc_plus/failure/fixture.json
@@ -1,3 +1,4 @@
+
 {
 	"CPCPlus_CMS122v7IncUUID_SampleQRDA-III.xml": {
 		"strict": false,
@@ -698,6 +699,9 @@
 		"errorData": [
 			{
 				"errorCode": 86,
+				"subs": [
+					".*"
+				],
 				"occurrences": 1
 			}
 		]
@@ -707,42 +711,57 @@
 		"errorData": [
 			{
 				"errorCode": 85,
+				"subs": [
+					".*"
+				],
 				"occurrences": 1
 			}
 		]
 	},
 	"CPCPLUS-7a-ImproperNPIFormat_04152019.xml": {
-		"strict": true,
+		"strict": false,
 		"errorData": [
 			{
 				"errorCode": 88,
+				"subs": [
+					".*"
+				],
 				"occurrences": 1
 			}
 		]
 	},
 	"CPCPLUS-2f-MissingNpi_03282019.xml": {
-		"strict": true,
+		"strict": false,
 		"errorData": [
 			{
 				"errorCode": 89,
+				"subs": [
+					".*"
+				],
 				"occurrences": 1
 			}
 		]
 	},
 	"CPCPlus_InvalidAlphaNpi.xml": {
-		"strict": true,
+		"strict": false,
 		"errorData": [
 			{
 				"errorCode": 88,
+				"subs": [
+					".*"
+				],
 				"occurrences": 1
 			}
 		]
 	},
 	"CPCPlus_InvalidAlphaTin.xml": {
-		"strict": true,
+		"strict": false,
 		"errorData": [
 			{
 				"errorCode": 85,
+				"subs": [
+					".*"
+				],
 				"occurrences": 1
 			}
 		]


### PR DESCRIPTION
### Information
- Updates error messages that include `CPC & PCF` verbiage to now accept program name as input to be more precise in error message formatting.
- Fixes the issue with the APM combination warning message outputting only CPC+ program name. It will now output PCF program name on PCF submissions

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
