### PR TITLE
QPPSF-8778: APP1 Apm Entity Fixes

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoder.java
@@ -33,6 +33,8 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 	public static final String PRACTICE_ID = "practiceId";
 	public static final String ENTITY_ID = "entityId";
 	public static final String PCF_ENTITY_ID = "pcfEntityId";
+	public static final String APM_ENTITY_ID = "apmEntityId";
+	public static final String VG_ID = "virtualGroupId";
 	public static final String CEHRT = "cehrtId";
 
 	//QPP Json value constants for: Node(Identifier, value)
@@ -52,7 +54,7 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 	public static final String CPCPLUS = "CPCPLUS";
 	private static final String MIPS_GROUP = "MIPS_GROUP";
 	private static final String MIPS_INDIVIDUAL = "MIPS_INDIV";
-	public static final String MIPS_APM = "MIPSAPM";
+	public static final String MIPS_APM = "MIPS_APMENTITY";
 	public static final String MIPS_VIRTUAL_GROUP = "MIPS_VIRTUALGROUP";
 	private static final String APP_GROUP = "MIPS_APP1_GROUP";
 	private static final String APP_INDIVIDUAL = "MIPS_APP1_INDIV";
@@ -85,7 +87,7 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 				setNationalProviderIdOnNode(element, thisNode);
 			}
 			if (ENTITY_VIRTUAL_GROUP.equals(entityType)) {
-				setEntityIdOnNode(element, thisNode, ClinicalDocumentDecoder.ENTITY_ID);
+				setEntityIdOnNode(element, thisNode, ClinicalDocumentDecoder.VG_ID);
 			}
 		}
 
@@ -109,7 +111,7 @@ public class ClinicalDocumentDecoder extends QrdaDecoder {
 				thisNode.putValue(PCF_ENTITY_ID, id.getValue(), false);
 			setOnNode(element, getXpath(PCF_ENTITY_ID), consumer, Filters.attribute(), false);
 		} else {
-			setEntityIdOnNode(element, thisNode, ClinicalDocumentDecoder.PRACTICE_ID);
+			setEntityIdOnNode(element, thisNode, ClinicalDocumentDecoder.APM_ENTITY_ID);
 		}
 	}
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
@@ -131,7 +131,7 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 				} else if (TemplateId.MEASURE_SECTION_V4.getRoot().equalsIgnoreCase(childType.getRoot())
 						&& ClinicalDocumentDecoder.APP_APM.equalsIgnoreCase(
 						currentNode.getValue(ClinicalDocumentDecoder.RAW_PROGRAM_NAME))) {
-					childWrapper.put(ClinicalDocumentDecoder.PROGRAM_NAME, ClinicalDocumentDecoder.APP.toLowerCase(Locale.getDefault()));
+					childWrapper.put(ClinicalDocumentDecoder.PROGRAM_NAME, ClinicalDocumentDecoder.APP_PROGRAM_NAME.toLowerCase(Locale.getDefault()));
 				}
 
 				measurementSetsWrapper.put(childWrapper);

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoder.java
@@ -73,8 +73,12 @@ public class ClinicalDocumentEncoder extends QppOutputEncoder {
 			wrapper.put(ClinicalDocumentDecoder.ENTITY_ID, thisNode.getValue(ClinicalDocumentDecoder.PCF_ENTITY_ID));
 		}
 
-		if (ClinicalDocumentDecoder.ENTITY_VIRTUAL_GROUP.equals(entityType) ||
-			(!Program.isCpc(thisNode) || !Program.isPcf(thisNode) && ClinicalDocumentDecoder.ENTITY_APM.equalsIgnoreCase(entityType))) {
+		if (ClinicalDocumentDecoder.ENTITY_VIRTUAL_GROUP.equals(entityType)) {
+			wrapper.put(ClinicalDocumentDecoder.ENTITY_ID, thisNode.getValue(ClinicalDocumentDecoder.VG_ID));
+		}
+
+		if ((Program.isApp(thisNode) || Program.isMips(thisNode) &&
+			ClinicalDocumentDecoder.ENTITY_APM.equalsIgnoreCase(entityType))) {
 			wrapper.put(ClinicalDocumentDecoder.ENTITY_ID, thisNode.getValue(ClinicalDocumentDecoder.ENTITY_ID));
 		}
 	}

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/Program.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/Program.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
  * Construct that helps categorize submissions by program name.
  */
 public enum Program {
-	MIPS("MIPS_GROUP", "MIPS_INDIV", "MIPS_VIRTUALGROUP", "MIPS", "MIPSAPM"),
+	MIPS("MIPS_GROUP", "MIPS_INDIV", "MIPS_VIRTUALGROUP", "MIPS", "MIPS_APMENTITY"),
 	CPC("CPCPLUS"),
 	PCF("PCF"),
 	APP("MIPS_APP1_INDIV", "MIPS_APP1_GROUP", "MIPS_APP1_APMENTITY"),

--- a/converter/src/main/resources/pathing/path-correlation.json
+++ b/converter/src/main/resources/pathing/path-correlation.json
@@ -145,12 +145,22 @@
 					}
 				},
 				{
-					"decodeLabel": "entityId",
+					"decodeLabel": "virtualGroupId",
 					"encodeLabels": [
-						"entityId"
+						"virtualGroupId"
 					],
 					"goods": {
 						"relativeXPath": "./*[local-name() = 'documentationOf' and namespace-uri() = '<nsuri>']/*[local-name() = 'serviceEvent' and namespace-uri() = '<nsuri>']/*[local-name() = 'performer' and namespace-uri() = '<nsuri>']/*[local-name() = 'assignedEntity' and namespace-uri() = '<nsuri>']/*[local-name() = 'representedOrganization' and namespace-uri() = '<nsuri>']/*[local-name() = 'id' and namespace-uri() = '<nsuri>'][@root='2.16.840.1.113883.3.249.5.2']/@extension",
+						"xmltype": "attribute"
+					}
+				},
+				{
+					"decodeLabel": "apmEntityId",
+					"encodeLabels": [
+						"apmEntityId"
+					],
+					"goods": {
+						"relativeXPath": "./*[local-name() = 'documentationOf' and namespace-uri() = '<nsuri>']/*[local-name() = 'serviceEvent' and namespace-uri() = '<nsuri>']/*[local-name() = 'performer' and namespace-uri() = '<nsuri>']/*[local-name() = 'assignedEntity' and namespace-uri() = '<nsuri>']/*[local-name() = 'representedOrganization' and namespace-uri() = '<nsuri>']/*[local-name() = 'id' and namespace-uri() = '<nsuri>'][@root='2.16.840.1.113883.3.249.5.4']/@extension",
 						"xmltype": "attribute"
 					}
 				},

--- a/converter/src/test/java/gov/cms/qpp/SingularAttributeTest.java
+++ b/converter/src/test/java/gov/cms/qpp/SingularAttributeTest.java
@@ -54,6 +54,8 @@ class SingularAttributeTest{
 						ClinicalDocumentDecoder.PRACTICE_SITE_ADDR,
 						//We have validations implemented
 						ClinicalDocumentDecoder.PCF_ENTITY_ID,
+						ClinicalDocumentDecoder.VG_ID,
+						ClinicalDocumentDecoder.APM_ENTITY_ID,
 						PerformanceRateProportionMeasureDecoder.PERFORMANCE_RATE,
 						PerformanceRateProportionMeasureDecoder.NULL_PERFORMANCE_RATE,
 						//There are no validations for performanceYear

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -46,7 +46,7 @@ class QualityMeasureIdRoundTripTest {
 		Paths.get("src/test/resources/negative/perfRateDenomZero.xml");
 	static final Path DECIMAL_ZERO_COUNT_FOR_PERF_DENOM =
 		Paths.get("src/test/resources/negative/decimalPerfRateDenomZero.xml");
-	static final Path MIPS_APM_FILE = Paths.get("src/test/resources/CpcMipsApm-2020.xml");
+	static final Path MIPS_APM_FILE = Paths.get("src/test/resources/Mips-Apm-Entity-2021.xml");
 	ApmEntityIds apmEntityIds;
 
 	@BeforeEach
@@ -229,7 +229,7 @@ class QualityMeasureIdRoundTripTest {
 	}
 
 	@Test
-	void test2020TopLevelMipsApmSampleFile() {
+	void testTopLevelMipsApmSampleFile() {
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
 		Converter converter = new Converter(new PathSource(MIPS_APM_FILE), new Context(apmEntityIds));
 		JsonWrapper qpp = converter.transform();
@@ -240,8 +240,7 @@ class QualityMeasureIdRoundTripTest {
 			"$.measurementSets[?(@.category=='quality' && @.programName=='mips')].category", new TypeRef<List<String>>() { });
 		List<String> submissionMethod = JsonHelper.readJsonAtJsonPath(qpp.toString(),
 			"$.measurementSets[?(@.category=='quality' && @.programName=='mips')].submissionMethod", new TypeRef<List<String>>() { });
-		List<String> practiceId = JsonHelper.readJsonAtJsonPath(qpp.toString(),
-			"$.measurementSets[?(@.category=='quality' && @.programName=='mips')].practiceId", new TypeRef<List<String>>() { });
+		String entityId = JsonHelper.readJsonAtJsonPath(qpp.toString(), "$.entityId", new TypeRef<String>() { });
 		List<String> source = JsonHelper.readJsonAtJsonPath(qpp.toString(),
 			"$.measurementSets[?(@.category=='quality' && @.programName=='mips')].source", new TypeRef<List<String>>() { });
 		List<LinkedHashMap<String, Object>> measurements = JsonHelper.readJsonAtJsonPath(qpp.toString(),
@@ -251,7 +250,7 @@ class QualityMeasureIdRoundTripTest {
 		assertThat(programName).contains("mips");
 		assertThat(category).contains("quality");
 		assertThat(submissionMethod).contains("electronicHealthRecord");
-		assertThat(practiceId).isEmpty();
+		assertThat(entityId).isEqualTo("TEST_APM");
 		assertThat(source).contains("qrda3");
 		assertThat(measurements).hasSize(1);
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/decode/ClinicalDocumentDecoderTest.java
@@ -441,13 +441,12 @@ class ClinicalDocumentDecoderTest {
 		assertThat(testParentNode.getValue(ClinicalDocumentDecoder.ENTITY_TYPE))
 			.isEqualTo(ClinicalDocumentDecoder.ENTITY_APM);
 		assertThat(testParentNode.getValue(ClinicalDocumentDecoder.ENTITY_ID))
-			.isEqualTo("AR000000");
+			.isEqualTo("TEST_APM");
 	}
 
 	@Test
 	void decodeMipsAppApmTest() {
 		Element clinicalDocument = makeClinicalDocument(ClinicalDocumentDecoder.APP_APM);
-		clinicalDocument.addContent(prepareParticipant(clinicalDocument.getNamespace(), CPC_PRACTICE_ROOT));
 		Node testParentNode = new Node();
 
 		ClinicalDocumentDecoder objectUnderTest = new ClinicalDocumentDecoder(new Context());
@@ -457,7 +456,7 @@ class ClinicalDocumentDecoderTest {
 		assertThat(testParentNode.getValue(ClinicalDocumentDecoder.ENTITY_TYPE))
 				.isEqualTo(ClinicalDocumentDecoder.ENTITY_APM);
 		assertThat(testParentNode.getValue(ClinicalDocumentDecoder.ENTITY_ID))
-				.isEqualTo("AR000000");
+				.isEqualTo("TEST_APM");
 	}
 
 	@Test
@@ -539,9 +538,13 @@ class ClinicalDocumentDecoderTest {
 		Element virtualGroup2 = new Element("id", rootns)
 			.setAttribute("root", "2.16.840.1.113883.3.249.5.2")
 			.setAttribute("extension", "x12345");
+		Element apmEntity = new Element("id", rootns)
+			.setAttribute("root", "2.16.840.1.113883.3.249.5.4")
+			.setAttribute("extension", "TEST_APM");
 
 		Element representedOrganization = prepareRepOrgWithTaxPayerId(rootns, "123456789");
 		representedOrganization.addContent(virtualGroup);
+		representedOrganization.addContent(apmEntity);
 		assignedEntity.addContent(representedOrganization);
 		assignedEntity.addContent(nationalProviderIdentifier);
 		performer.addContent(assignedEntity);

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/ClinicalDocumentEncoderTest.java
@@ -115,6 +115,7 @@ class ClinicalDocumentEncoderTest {
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.NATIONAL_PROVIDER_IDENTIFIER, "2567891421");
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.PRACTICE_ID,  "AR000000" );
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.ENTITY_ID,  "x12345" );
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.VG_ID,  "x12345" );
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.CEHRT, "xxxxxxxxxx12345");
 		clinicalDocumentNode.addChildNode(aciSectionNode);
 
@@ -241,7 +242,10 @@ class ClinicalDocumentEncoderTest {
 	@Test
 	void testApmIncludesEntityID() throws EncodeException {
 		JsonWrapper testJsonWrapper = new JsonWrapper();
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.APM_ENTITY_ID, "apm");
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.ENTITY_TYPE, "apm");
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.RAW_PROGRAM_NAME, "MIPS_APP1_APMENTITY");
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.PROGRAM_NAME, "app1");
 
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());
 		clinicalDocumentEncoder.internalEncode(testJsonWrapper, clinicalDocumentNode);
@@ -273,7 +277,9 @@ class ClinicalDocumentEncoderTest {
 	@Test
 	void testAppApmIncludesEntityID() throws EncodeException {
 		JsonWrapper testJsonWrapper = new JsonWrapper();
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.APM_ENTITY_ID, "apm");
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.ENTITY_TYPE, "apm");
+		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.RAW_PROGRAM_NAME, "MIPS_APP1_APMENTITY");
 		clinicalDocumentNode.putValue(ClinicalDocumentDecoder.PROGRAM_NAME, "app1");
 
 		ClinicalDocumentEncoder clinicalDocumentEncoder = new ClinicalDocumentEncoder(new Context());

--- a/converter/src/test/resources/Mips-Apm-Entity-2021.xml
+++ b/converter/src/test/resources/Mips-Apm-Entity-2021.xml
@@ -59,7 +59,7 @@
   <!--Program for which data is being submitted-->
   <informationRecipient>
     <intendedRecipient>
-      <id root="2.16.840.1.113883.3.249.7" extension="MIPSAPM" />
+      <id root="2.16.840.1.113883.3.249.7" extension="MIPS_APMENTITY" />
     </intendedRecipient>
   </informationRecipient>
   <legalAuthenticator>
@@ -68,7 +68,7 @@
     <assignedEntity>
       <id root="D5E68226-5760-11E7-1256-09173F13E4C5" />
       <representedOrganization>
-        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <id root="2.16.840.1.113883.19.4" extension="223344" />
         <name>Good Health Clinic</name>
       </representedOrganization>
     </assignedEntity>
@@ -105,61 +105,8 @@
           <high value="20171231" />
         </time>
         <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2567891421" />
           <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2589654740" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2345872354" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2365987421" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
-            <name>Good Health Clinic</name>
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-      <performer typeCode="PRF">
-        <time>
-          <low value="20170101" />
-          <high value="20171231" />
-        </time>
-        <assignedEntity>
-          <id root="2.16.840.1.113883.4.6" extension="2357943549" />
-          <representedOrganization>
-            <id root="2.16.840.1.113883.4.2" extension="990000099" />
+            <id root="2.16.840.1.113883.3.249.5.4" extension="TEST_APM" />
             <name>Good Health Clinic</name>
           </representedOrganization>
         </assignedEntity>

--- a/sample-files/2021/App1-ApmEntity-Qrda-III.xml
+++ b/sample-files/2021/App1-ApmEntity-Qrda-III.xml
@@ -1,0 +1,3482 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US" />
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
+  <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>
+  <effectiveTime value="20170311061231" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" />
+  <languageCode code="en" />
+  <setId root="D5E68223-5760-11E7-1256-09173F13E4C5" />
+  <versionNumber value="1" />
+  <recordTarget>
+    <patientRole>
+      <id nullFlavor="NA" />
+    </patientRole>
+  </recordTarget>
+  <!--Device Author Example-->
+  <author>
+    <time value="20170311061231" />
+    <assignedAuthor>
+      <id root="D5E68225-5760-11E7-1256-09173F13E4C5" />
+      <assignedAuthoringDevice>
+        <softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+      </assignedAuthoringDevice>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <!--Person Author Example-->
+  <author>
+    <time value="20180311061231" />
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.4.6" extension="2567891421" assigningAuthorityName="NPI" />
+      <assignedPerson>
+        <name>
+          <given>Trevor</given>
+          <family>Phillips</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!--Program for which data is being submitted-->
+  <informationRecipient>
+    <intendedRecipient>
+      <id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_APMENTITY" />
+    </intendedRecipient>
+  </informationRecipient>
+  <legalAuthenticator>
+    <time value="20170312153222" />
+    <signatureCode code="S" />
+    <assignedEntity>
+      <id root="D5E68226-5760-11E7-1256-09173F13E4C5" />
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.4" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <participant typeCode="DEV">
+    <associatedEntity classCode="RGPR">
+      <id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX" />
+      <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    </associatedEntity>
+  </participant>
+  <!--Practice Site-->
+  <participant typeCode="LOC">
+    <associatedEntity classCode="SDLOC">
+      <id root="2.16.840.1.113883.3.249.5.1" extension="TestApmEntityId" assigningAuthorityName="CMS-CMMI" />
+      <code code="394730007" displayName="healthcare related organization" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <addr>
+        <streetAddressLine>123 Healthcare St</streetAddressLine>
+        <city>Norman</city>
+        <state>OK</state>
+        <postalCode>73019</postalCode>
+      </addr>
+    </associatedEntity>
+  </participant>
+  <!--Providers in Practice Site for which data is being submitted-->
+  <documentationOf typeCode="DOC">
+    <serviceEvent classCode="PCPR">
+      <effectiveTime>
+        <low value="20170101" />
+        <high value="20171231" />
+      </effectiveTime>
+      <performer typeCode="PRF">
+        <time>
+          <low value="20170101" />
+          <high value="20171231" />
+        </time>
+        <assignedEntity>
+          <representedOrganization>
+            <id root="2.16.840.1.113883.3.249.5.4" extension="TEST_APM" />
+            <name>Good Health Clinic</name>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <authorization>
+    <consent>
+      <id root="D5E68227-5760-11E7-1256-09173F13E4C5" />
+      <code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <statusCode code="completed" />
+    </consent>
+  </authorization>
+  <!--
+********************************************************
+CDA Body
+********************************************************
+-->
+  <component>
+    <structuredBody>
+      <!--
+********************************************************
+QRDA Category III Measure Section (CMS EP)
+********************************************************
+-->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01" />
+          <templateId root="2.16.840.1.113883.10.20.24.2.2" />
+          <templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01" />
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1" displayName="measure document" />
+          <title>Measure Section</title>
+          <!--Performance Period-->
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.17.3.8" />
+              <id root="D5E68228-5760-11E7-1256-09173F13E4C5" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters" />
+              <effectiveTime>
+                <low value="20210101" />
+                <high value="20211231" />
+              </effectiveTime>
+            </act>
+          </entry>
+          <!--Measure Entry for CMS122v8-->
+      		<entry>
+      			<organizer classCode="CLUSTER" moodCode="EVN">
+      				<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+      				<!-- Measure Reference Template -->
+      				<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+      				<!-- Measure Reference & Results Template -->
+      				<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+      				<!-- CMS Measure Reference & Results Template -->
+      				<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+      				<statusCode code="completed"/>
+      				<!--Measure Reference and Results-->
+      				<reference typeCode="REFR">
+      					<externalDocument classCode="DOC" moodCode="EVN">
+      						<id root="2.16.840.1.113883.4.738"
+      							extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
+      						<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+      							  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+      						<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+      					</externalDocument>
+      				</reference>
+      				<!--Performance Rate-->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+      						<!-- Performance Rate Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+      						<!-- Performance Rate for Proportion Measure Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+      						<!-- CMS Performance Rate for Proportion Measure Template -->
+      						<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+      							  codeSystemName="LOINC" displayName="Performance Rate"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="REAL" value=".888889"/>
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+      								<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="Numerator"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!--IPOP Population-->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--IPOP Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="1000"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6822A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6822B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6822C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6822D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6822E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6822F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68230-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68231-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68232-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68233-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68234-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68235-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+      						<!--IPOP Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!-- DENOM Population -->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--DENOM Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="1000"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68236-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68237-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68238-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68239-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6823E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6823F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68240-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68241-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+      						<!--DENOM Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!-- DENEX Population -->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--DENEX Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="100"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68267-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68268-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68269-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6826A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6826F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68270-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68271-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68272-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>c
+      						<!--DENEX Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!-- NUMER Population -->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--NUMER Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="800"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68242-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68243-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68244-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68245-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68246-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68247-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68248-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68249-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+      						<!--NUMER Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      			</organizer>
+      		</entry>
+          <!--Measure Entry for CMS165v7-->
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
+              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
+              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01" />
+              <id root="D5E68474-5760-11E7-1256-09173F13E4C5" />
+              <statusCode code="completed" />
+              <!--Measure Reference and Results-->
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab" />
+                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
+                  <text>Controlling High Blood Pressure</text>
+                </externalDocument>
+              </reference>
+              <!--Performance Rate-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Performance Rate" />
+                  <statusCode code="completed" />
+                  <value xsi:type="REAL" value=".888889" />
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748" />
+                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Numerator" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--IPOP Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--IPOP Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1000" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68475-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68476-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68477-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68478-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68479-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6847A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6847B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6847C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6847D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6847E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6847F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68480-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--IPOP Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="87338BA5-170B-4264-9E59-6A4A3A57C785" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENOM Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--DENOM Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1000" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68481-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68482-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68483-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68484-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68485-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68486-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68487-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68488-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68489-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6848A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6848B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6848C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--DENOM Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="B2E2AA67-26CD-48CB-9536-094F1D047149" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEX Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--DENEX Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="100" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6848D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6848E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6848F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68490-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68491-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68492-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68493-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68494-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68495-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68496-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68497-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68498-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--DENEX Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="9B6EDB4C-A390-4833-A135-2A2AC6334126" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--NUMER Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--NUMER Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="800" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68499-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6849A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6849B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6849C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6849D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6849E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6849F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E684A0-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A1-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A2-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A3-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A4-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--NUMER Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/sample-files/2021/App1-Group-QRDA-III.xml
+++ b/sample-files/2021/App1-Group-QRDA-III.xml
@@ -1,0 +1,4767 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
+********************************************************
+CDA Header
+********************************************************
+-->
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_GROUP"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+				<!-- NPI Not allowed-->
+				<!-- <id root="2.16.840.1.113883.4.6" extension="0777777777"/>-->
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+		<structuredBody>
+			<!--
+			********************************************************
+			QRDA Category III Measure Section - CMS (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- QRDA Category III Measure Section (V4) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+					<!-- QRDA Category III Measure Section - CMS (V2) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="measure section"/>
+					<title>Measure Section</title>
+					<text>
+						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Controlling High Blood Pressure</td>
+									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+									<td>40280381-51f0-825b-0152-22b98cff181a</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>:0.842105
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:50
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>30
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>10
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
+									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+									<td>40280381-51f0-825b-0152-229afff616ee</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.947368
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:900
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>598
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>50
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Documentation of Current Medications in the Medical Record</td>
+									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
+									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.816327
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exceptions</content>:20
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>12
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>8
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>18
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>5
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>2
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+
+						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Depression Utilization of the PHQ-9 Tool</td>
+									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
+									<td>40280381-503f-a1fc-0150-afe320c01761</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.860177
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:35
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:486
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.921052
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:700
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.962963
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:520
+							</item>
+						</list>
+					</text>
+
+					<!--Measure Entry for CMS165v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="87338BA5-170B-4264-9E59-6A4A3A57C785"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="B2E2AA67-26CD-48CB-9536-094F1D047149"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9B6EDB4C-A390-4833-A135-2A2AC6334126"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!--Measure Entry for CMS122v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Measure Reference Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<!-- Measure Reference & Results Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+							<!-- CMS Measure Reference & Results Template -->
+							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738"
+										extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<!-- Performance Rate Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<!-- Performance Rate for Proportion Measure Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+									<!-- CMS Performance Rate for Proportion Measure Template -->
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENOM Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENEX Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- NUMER Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20210101"/>
+								<high value="20211231"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+			<!--
+		  	********************************************************
+		  	Promoting Interoperability Section (V2)
+		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
+		  	********************************************************
+		  	-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Advancing Care Information Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>PI Measure Title</th>
+									<th>Measure Identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Provide Patient Access</td>
+									<td>PI_PEA_1</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Denominator:</content>800
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator:</content>600
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate:
+								</content>0.75
+							</item>
+						</list>
+						<list>
+							<item>
+								<content styleCode="Bold">Measure Answer (Yes/No):
+								</content>Yes
+							</item>
+						</list>
+					</text>
+					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
+					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.28"
+										extension="2017-06-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
+									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
+									<!-- PI measure title -->
+									<text>Provide Patient Access</text>
+								</externalDocument>
+							</reference>
+							<!-- Performance Rate for PI is optional -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Performance Rate templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.30"
+												extension="2016-09-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value="0.75"/>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.31"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Numerator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="600"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.32"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Denominator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20210201"/>
+								<high value="20210531"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!--
+			********************************************************
+			Improvement Activity Section (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Improvement Activity Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>Improvement Activity Name</th>
+									<th>Activity ID</th>
+									<th>Question Answer Code</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Collection and use of patient experience and satisfaction data on access</td>
+									<td>IA_EPA_3</td>
+									<td>Y</td>
+								</tr>
+
+								<tr>
+									<td>Care transition documentation practice improvements</td>
+									<td>IA_CC_10</td>
+									<td>Y</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
+					<!-- IA_EPA_3 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Collection and use of patient experience and satisfaction data on access</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- IA_CC_10 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33"
+										extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Care transition documentation practice improvements</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20210101"/>
+								<high value="20210430"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+		</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/sample-files/2021/App1-Indv-QRDA-III.xml
+++ b/sample-files/2021/App1-Indv-QRDA-III.xml
@@ -1,0 +1,4766 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
+********************************************************
+CDA Header
+********************************************************
+-->
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_INDIV"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+					<id root="2.16.840.1.113883.4.6" extension="0777777777"/>
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+		<structuredBody>
+			<!--
+			********************************************************
+			QRDA Category III Measure Section - CMS (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- QRDA Category III Measure Section (V4) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+					<!-- QRDA Category III Measure Section - CMS (V2) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="measure section"/>
+					<title>Measure Section</title>
+					<text>
+						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Controlling High Blood Pressure</td>
+									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+									<td>40280381-51f0-825b-0152-22b98cff181a</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>:0.842105
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:50
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>30
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>10
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
+									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+									<td>40280381-51f0-825b-0152-229afff616ee</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.947368
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:900
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>598
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>50
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Documentation of Current Medications in the Medical Record</td>
+									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
+									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.816327
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exceptions</content>:20
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>12
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>8
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>18
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>5
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>2
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+
+						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Depression Utilization of the PHQ-9 Tool</td>
+									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
+									<td>40280381-503f-a1fc-0150-afe320c01761</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.860177
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:35
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:486
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.921052
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:700
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.962963
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:520
+							</item>
+						</list>
+					</text>
+
+					<!--Measure Entry for CMS165v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="87338BA5-170B-4264-9E59-6A4A3A57C785"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="B2E2AA67-26CD-48CB-9536-094F1D047149"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9B6EDB4C-A390-4833-A135-2A2AC6334126"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!--Measure Entry for CMS122v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Measure Reference Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<!-- Measure Reference & Results Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+							<!-- CMS Measure Reference & Results Template -->
+							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738"
+										extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<!-- Performance Rate Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<!-- Performance Rate for Proportion Measure Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+									<!-- CMS Performance Rate for Proportion Measure Template -->
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENOM Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENEX Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- NUMER Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20210101"/>
+								<high value="20211231"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+			<!--
+		  	********************************************************
+		  	Promoting Interoperability Section (V2)
+		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
+		  	********************************************************
+		  	-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Advancing Care Information Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>PI Measure Title</th>
+									<th>Measure Identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Provide Patient Access</td>
+									<td>PI_PEA_1</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Denominator:</content>800
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator:</content>600
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate:
+								</content>0.75
+							</item>
+						</list>
+						<list>
+							<item>
+								<content styleCode="Bold">Measure Answer (Yes/No):
+								</content>Yes
+							</item>
+						</list>
+					</text>
+					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
+					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.28"
+										extension="2017-06-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
+									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
+									<!-- PI measure title -->
+									<text>Provide Patient Access</text>
+								</externalDocument>
+							</reference>
+							<!-- Performance Rate for PI is optional -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Performance Rate templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.30"
+												extension="2016-09-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value="0.75"/>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.31"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Numerator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="600"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.32"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Denominator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20210201"/>
+								<high value="20210531"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!--
+			********************************************************
+			Improvement Activity Section (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Improvement Activity Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>Improvement Activity Name</th>
+									<th>Activity ID</th>
+									<th>Question Answer Code</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Collection and use of patient experience and satisfaction data on access</td>
+									<td>IA_EPA_3</td>
+									<td>Y</td>
+								</tr>
+
+								<tr>
+									<td>Care transition documentation practice improvements</td>
+									<td>IA_CC_10</td>
+									<td>Y</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
+					<!-- IA_EPA_3 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Collection and use of patient experience and satisfaction data on access</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- IA_CC_10 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33"
+										extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Care transition documentation practice improvements</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20210101"/>
+								<high value="20210430"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+		</structuredBody>
+	</component>
+</ClinicalDocument>


### PR DESCRIPTION
### Information
- QPPSF-8778

### Changes proposed in this PR:
- Updates Mips Apm submissions to use the XML program name `MIPS_APMENTITY` instead of `MIPS_APM`
- Updates the location in XML where the Apm Entity id is found for `MIPS_APP1_APMENTITY` and `MIPS_APMENTITY`
- Updates test coverage for `MIPS_APP1_APMENTITY` and `MIPS_APMENTITY`
- Adds a new, happy-path sample files for APP Individual, Group and ApmEntity.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
