### PR TITLE
QPPSF-8243, ECR scan notification lambda for Conversion-Tool

### DIFF
--- a/infrastructure/ecr-notification-lambda/.terraform.lock.hcl
+++ b/infrastructure/ecr-notification-lambda/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.65.0"
+  constraints = "3.65.0"
+  hashes = [
+    "h1:GCDkcISN83t+JK2U+ie3vaECnyxK0Sr6GjO7IrBOVeo=",
+    "zh:108aeaf5e18087d9ac852737a5be1347a28e40825817cc1a29ec523d40268294",
+    "zh:1a719c0c9754f906b2220d3bbf90d483ec0a74cf87768a464d2d657b7901ec6b",
+    "zh:21acdc35ae70a626cbc81eff06181a78843f1ddc2d9200f80fabf2e0466ecbda",
+    "zh:28846628e1a4227a1f2db256d6b22ed36922f37632999af7404aa74703cd9bfb",
+    "zh:32455550dbf86ae07d9782650e86d23c4fa13d7872e48680044692894e8da6ea",
+    "zh:4241246274627c752f9aef2806e810053306001e80fc5b51d27cbe997f75f95e",
+    "zh:5ca0fab3ceb3f41a97c1ebd29561a034cb83fda04da35fd5f8c3c5cb97bb3ea8",
+    "zh:5fed3b79d4ed6424055e8bbfb7a4393e8db5102cdba04b4590f8e0f4194637fb",
+    "zh:99a0bc325b0a59ded1152546c004953a2bb0e110978bf0cc55e1804384941bdb",
+    "zh:e74f9190a417c891992210f9af937ef55749d86a04762d982260fbbc989342a7",
+    "zh:fb6984405ca63d0373bd992ce157e933b8ae9dd94d74b1c5691632f062fe60b2",
+  ]
+}

--- a/infrastructure/ecr-notification-lambda/ecr-lambda-notification.py
+++ b/infrastructure/ecr-notification-lambda/ecr-lambda-notification.py
@@ -1,0 +1,41 @@
+import boto3
+import json
+import logging
+import os
+import time
+
+from base64 import b64decode
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+logger = logging.getLogger()
+
+def lambda_handler(event, context):
+
+    message = event['detail']
+    result  = event['detail']['scan-status']
+    findings = event['detail']['finding-severity-counts']
+    repo    = event['detail']['repository-name']
+
+    response = f"An Image was pushed to ECR {repo} with {findings}"
+    slack_color = "GREEN"
+
+    slack_message = {
+        'channel': os.environ['channel'],
+        'attachments': [
+            {
+                'color': slack_color,
+                'text': response,
+                'ts' : int(time.time())
+            }
+        ]
+    }
+    req = Request(os.environ['hook_url'], json.dumps(slack_message).encode('utf-8'))
+    try:
+        response = urlopen(req)
+        response.read()
+        logger.info("Message posted to %s", slack_message['channel'])
+    except HTTPError as e:
+        logger.error("Request failed: %d %s", e.code, e.reason)
+    except URLError as e:
+        logger.error("Server connection failed: %s", e.reason)

--- a/infrastructure/ecr-notification-lambda/ecr-scan-notification.tf
+++ b/infrastructure/ecr-notification-lambda/ecr-scan-notification.tf
@@ -1,0 +1,150 @@
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "=3.65.0"
+        }
+    }
+    required_version = "0.14.11"
+}
+
+provider "aws" {
+    region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket  = "qppsf-conversion-tool-tf-state"
+    key     = "qppsf/conversion-tool-ecr-notification.tfstate"
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}
+
+data "aws_caller_identity" "current" {
+}
+
+resource "aws_ssm_parameter" "slack_hook_url" {
+  name        = "/qppar-sf/${var.environment}/conversion_tool/slack_hook_url"
+  description = "Slack Webhook Url for Scoring"
+  type        = "SecureString"
+  value       = var.slack_hook_url
+  overwrite   = true
+  
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
+  tags = {
+    Name            = "${var.project_name}-ssm-${var.environment}",
+    owner           = var.owner,
+    project         = var.project_name
+    terraform       = "true"
+    application     = var.application
+  }
+}
+
+# Event Rule to monitor ECR imaage scan which is set to complete
+resource "aws_cloudwatch_event_rule" "ecr-scan-notification" {
+  name        = "ecr-scan-notification-${var.project_name}-${var.environment}"
+  description = "Triggers an event upon completition of ECR image scan"
+
+  event_pattern = <<EOF
+{
+  "source": ["aws.ecr"],
+  "detail-type": ["ECR Image Scan"],
+  "detail":{
+      "image-tags": ["latest"],
+      "scan-status": ["COMPLETE"],
+      "repository-name": ["qppsf/conversion-tool/dev","qppsf/conversion-tool/impl","qppsf/conversion-tool/devpre","qppsf/conversion-tool/prod"]
+  }
+}
+EOF
+}
+
+# Event Bridge Target to invoke Lambda Function
+resource "aws_cloudwatch_event_target" "ecrevent-invoke-lambda" {
+    rule = aws_cloudwatch_event_rule.ecr-scan-notification.name
+    target_id = "ecr-scan-event-lambda"
+    arn = aws_lambda_function.ecr-lambda-notification.arn
+}
+
+# IAM Role permissions on Lambda Function
+resource "aws_iam_role" "lambda_executionrole" {
+ name   = "ecr-lambda-execrole-${var.project_name}-${var.environment}"
+ path = "/delegatedadmin/developer/"
+ permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+ assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowLambda"
+    }
+  ]
+}
+EOF
+}
+
+# IAM policy for Lambda to submit to Cloudwatch Logs
+resource "aws_iam_policy" "lambda_cloudwatch_logging" {
+
+  name         = "ecr_lambda_cloudwatch_policy"
+  path         = "/delegatedadmin/developer/"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+#IAM policy attachment for Cloudwatch Logging
+resource "aws_iam_role_policy_attachment" "cloudwatchlogs-lambda" {
+  role        = aws_iam_role.lambda_executionrole.name
+  policy_arn  = aws_iam_policy.lambda_cloudwatch_logging.arn
+}
+
+# Allow permissions for Event bridge to Invoke Lambda
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ecr-lambda-notification.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.ecr-scan-notification.arn
+}
+
+# ECR notification Lambda
+resource "aws_lambda_function" "ecr-lambda-notification" {
+  filename      = "ecr-lambda-notification.zip"
+  function_name = "ecr-lambda-notification"
+  role          = aws_iam_role.lambda_executionrole.arn
+  handler       = "ecr-lambda-notification.lambda_handler"
+  timeout       =  "120"
+  runtime = "python3.7"
+  environment {
+    variables = {
+        "channel" = "p-qpp-sub-alerts"
+        "hook_url" = var.slack_hook_url
+
+    }
+  }
+
+}

--- a/infrastructure/ecr-notification-lambda/terraform.tfvars
+++ b/infrastructure/ecr-notification-lambda/terraform.tfvars
@@ -1,0 +1,5 @@
+environment= "dev"
+owner="qppsf-scoring"
+application="Conversion-Tool"
+region="us-east-1"
+project_name="qppsf-ct"

--- a/infrastructure/ecr-notification-lambda/variables.tf
+++ b/infrastructure/ecr-notification-lambda/variables.tf
@@ -1,0 +1,28 @@
+variable "project_name" {
+  description = "Name of the Project"
+  type        = string
+  default     = "qppsf-ct"
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "slack_hook_url" {
+  type = string
+  description = "Slack webhook p-qpp-sub channel"
+}
+
+variable "owner" {
+  type = string
+}
+
+variable "application" {
+  type = string
+}


### PR DESCRIPTION
### Information
- Fixes #_.
QPPSF-8243

### Changes proposed in this PR:
- Creates lambda function for sending ECR Scan findings to scoring slack channel
- Creates Event-bridge rule to trigger event after image scan is complete and with latest tag
- Creates SSM parameter to store slack web-hook url
- Creates lambda execution role & policy

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
