### PR TITLE
QPPSF-9309, QPPSF-8326 - TF upgrade to v1, remediated Checkov failed policies

### DIFF
--- a/.github/workflows/checkov-tf.yml
+++ b/.github/workflows/checkov-tf.yml
@@ -19,5 +19,5 @@ jobs:
         uses: bridgecrewio/checkov-action@master
         with:
           directory: infrastructure
-          skip_check: CKV_AWS_18,CKV_AWS_23,CKV_AWS_115,CKV_AWS_116,CKV_AWS_117,CKV_AWS_40,CKV_AWS_50,CKV_AWS_144,CKV_AWS_145,CKV_AWS_131,CKV_AWS_103,CKV_AWS_51,CKV_AWS_136,CKV_AWS_158
+          skip_check: CKV_AWS_18,CKV_AWS_23,CKV_AWS_115,CKV_AWS_116,CKV_AWS_117,CKV_AWS_40,CKV_AWS_50,CKV_AWS_144,CKV_AWS_145,CKV_AWS_131,CKV_AWS_103,CKV_AWS_51,CKV_AWS_136,CKV_AWS_158,CKV_AWS_173,CKV_AWS_32
           framework: terraform

--- a/infrastructure/terraform/dev/.terraform.lock.hcl
+++ b/infrastructure/terraform/dev/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.67.0"
-  constraints = "3.67.0"
+  version     = "3.70.0"
+  constraints = "3.70.0"
   hashes = [
-    "h1:p7CyS0dxRoxAMVeCBy7VS6yLm4hWkvl3ojhOvaog1n4=",
-    "zh:0bf1ecb4fe3ff79da63c82454a5dd9e12f867d5372b6bb30e560376537dc7a53",
-    "zh:0d5bedecf10ef6d8f8669661fe67b6ef572c7619a2322a825b9003ab2e93a396",
-    "zh:1a58d45c692071b566dccdb480c7ef968e034292f82f48d8948ff8d75a0a1198",
-    "zh:58bc36e36fffdc4e211d11101434941257e667fe7fb53514e3852ceaeaca55a6",
-    "zh:63bb67c92fd0eb938a02930be0af26f11f9ecad3c56870987a2ddac85613dff7",
-    "zh:7172053f58cdee02256dd4726196c22a80a256ff3bf46b60378c89463b1d9340",
-    "zh:804ca483b2bf451fc2278855cfaa97ad0179d43bf67259d1c36c50e9310c0c5c",
-    "zh:854e22be11c992042b31d728af049912da0eda70172d975ac8a94c3d2edb3326",
-    "zh:a9b18d34edb1a1beb6ed5a083de832ddd0019c594f5fed6554d1be659cebfe61",
-    "zh:b3dd0c0d77c25ad1c61665eb5ddde3ed1b3d525c5b99cfbbeaf245e0faa6a6bb",
-    "zh:dacf8f3a7408ac6439b01ef2774854837bb27fe7412fc9050b4f892d912873a5",
+    "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
+    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
+    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
+    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
+    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
+    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
+    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
+    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
+    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
+    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
+    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
+    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
   ]
 }
 

--- a/infrastructure/terraform/dev/main.tf
+++ b/infrastructure/terraform/dev/main.tf
@@ -12,10 +12,10 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "=3.67.0"
+            version = "=3.70.0"
         }
     }
-    required_version = "0.15.5"
+    required_version = "1.0.0"
 }
 
 provider "aws" {

--- a/infrastructure/terraform/devpre/.terraform.lock.hcl
+++ b/infrastructure/terraform/devpre/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.67.0"
-  constraints = "3.67.0"
+  version     = "3.70.0"
+  constraints = "3.70.0"
   hashes = [
-    "h1:p7CyS0dxRoxAMVeCBy7VS6yLm4hWkvl3ojhOvaog1n4=",
-    "zh:0bf1ecb4fe3ff79da63c82454a5dd9e12f867d5372b6bb30e560376537dc7a53",
-    "zh:0d5bedecf10ef6d8f8669661fe67b6ef572c7619a2322a825b9003ab2e93a396",
-    "zh:1a58d45c692071b566dccdb480c7ef968e034292f82f48d8948ff8d75a0a1198",
-    "zh:58bc36e36fffdc4e211d11101434941257e667fe7fb53514e3852ceaeaca55a6",
-    "zh:63bb67c92fd0eb938a02930be0af26f11f9ecad3c56870987a2ddac85613dff7",
-    "zh:7172053f58cdee02256dd4726196c22a80a256ff3bf46b60378c89463b1d9340",
-    "zh:804ca483b2bf451fc2278855cfaa97ad0179d43bf67259d1c36c50e9310c0c5c",
-    "zh:854e22be11c992042b31d728af049912da0eda70172d975ac8a94c3d2edb3326",
-    "zh:a9b18d34edb1a1beb6ed5a083de832ddd0019c594f5fed6554d1be659cebfe61",
-    "zh:b3dd0c0d77c25ad1c61665eb5ddde3ed1b3d525c5b99cfbbeaf245e0faa6a6bb",
-    "zh:dacf8f3a7408ac6439b01ef2774854837bb27fe7412fc9050b4f892d912873a5",
+    "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
+    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
+    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
+    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
+    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
+    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
+    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
+    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
+    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
+    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
+    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
+    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
   ]
 }
 

--- a/infrastructure/terraform/devpre/main.tf
+++ b/infrastructure/terraform/devpre/main.tf
@@ -12,10 +12,10 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "=3.67.0"
+            version = "=3.70.0"
         }
     }
-    required_version = "0.15.5"
+    required_version = "1.0.0"
 }
 
 provider "aws" {

--- a/infrastructure/terraform/impl/.terraform.lock.hcl
+++ b/infrastructure/terraform/impl/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.67.0"
-  constraints = "3.67.0"
+  version     = "3.70.0"
+  constraints = "3.70.0"
   hashes = [
-    "h1:p7CyS0dxRoxAMVeCBy7VS6yLm4hWkvl3ojhOvaog1n4=",
-    "zh:0bf1ecb4fe3ff79da63c82454a5dd9e12f867d5372b6bb30e560376537dc7a53",
-    "zh:0d5bedecf10ef6d8f8669661fe67b6ef572c7619a2322a825b9003ab2e93a396",
-    "zh:1a58d45c692071b566dccdb480c7ef968e034292f82f48d8948ff8d75a0a1198",
-    "zh:58bc36e36fffdc4e211d11101434941257e667fe7fb53514e3852ceaeaca55a6",
-    "zh:63bb67c92fd0eb938a02930be0af26f11f9ecad3c56870987a2ddac85613dff7",
-    "zh:7172053f58cdee02256dd4726196c22a80a256ff3bf46b60378c89463b1d9340",
-    "zh:804ca483b2bf451fc2278855cfaa97ad0179d43bf67259d1c36c50e9310c0c5c",
-    "zh:854e22be11c992042b31d728af049912da0eda70172d975ac8a94c3d2edb3326",
-    "zh:a9b18d34edb1a1beb6ed5a083de832ddd0019c594f5fed6554d1be659cebfe61",
-    "zh:b3dd0c0d77c25ad1c61665eb5ddde3ed1b3d525c5b99cfbbeaf245e0faa6a6bb",
-    "zh:dacf8f3a7408ac6439b01ef2774854837bb27fe7412fc9050b4f892d912873a5",
+    "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
+    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
+    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
+    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
+    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
+    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
+    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
+    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
+    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
+    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
+    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
+    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
   ]
 }
 

--- a/infrastructure/terraform/impl/main.tf
+++ b/infrastructure/terraform/impl/main.tf
@@ -12,10 +12,10 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "=3.67.0"
+            version = "=3.70.0"
         }
     }
-    required_version = "0.15.5"
+    required_version = "1.0.0"
 }
 
 provider "aws" {

--- a/infrastructure/terraform/modules/ssm.tf
+++ b/infrastructure/terraform/modules/ssm.tf
@@ -5,7 +5,7 @@
 resource "aws_ssm_parameter" "app_env" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/APP_ENV"
   description = "APP_ENV"
-  type        = "String"
+  type        = "SecureString"
   value       = "dev"
   overwrite   = true
 
@@ -30,7 +30,7 @@ resource "aws_ssm_parameter" "app_env" {
 resource "aws_ssm_parameter" "ar_api_base_url" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/AR_API_BASE_URL"
   description = "AR_API_BASE_URL"
-  type        = "String"
+  type        = "SecureString"
   value       = "https://dev.ar.qpp.internal/api/v1/fms/file/qpp_data/qppct/testCpcPlusValidationFile.json"
   overwrite   = true
 
@@ -54,7 +54,7 @@ resource "aws_ssm_parameter" "ar_api_base_url" {
 resource "aws_ssm_parameter" "bucket_name" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/BUCKET_NAME"
   description = "BUCKET_NAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "aws-hhs-cms-ccsq-qpp-navadevops-pii-convrtr-audt-dev-us-east-1"
   overwrite   = true
 
@@ -78,7 +78,7 @@ resource "aws_ssm_parameter" "bucket_name" {
 resource "aws_ssm_parameter" "cpc_end_date" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/CPC_END_DATE"
   description = "CPC_END_DATE"
-  type        = "String"
+  type        = "SecureString"
   value       = "2021-03-13 - 20:00:00"
   overwrite   = true
 
@@ -102,7 +102,7 @@ resource "aws_ssm_parameter" "cpc_end_date" {
 resource "aws_ssm_parameter" "cpc_plus_bucket_name" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/CPC_PLUS_BUCKET_NAME"
   description = "CPC_PLUS_BUCKET_NAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "aws-hhs-cms-ccsq-qpp-navadevops-pii-cnvrt-npicpc-dev-us-east-1"
   overwrite   = true
 
@@ -126,7 +126,7 @@ resource "aws_ssm_parameter" "cpc_plus_bucket_name" {
 resource "aws_ssm_parameter" "cpc_plus_unprocessed_filter_start_date" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/CPC_PLUS_UNPROCESSED_FILTER_START_DATE"
   description = "CPC_PLUS_UNPROCESSED_FILTER_START_DATE"
-  type        = "String"
+  type        = "SecureString"
   value       = "2020-01-02T04:59:59.999Z"
   overwrite   = true
 
@@ -150,7 +150,7 @@ resource "aws_ssm_parameter" "cpc_plus_unprocessed_filter_start_date" {
 resource "aws_ssm_parameter" "cpc_plus_validation_file" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/CPC_PLUS_VALIDATION_FILE"
   description = "CPC_PLUS_VALIDATION_FILE"
-  type        = "String"
+  type        = "SecureString"
   value       = "testCpcPlusValidationFile.json"
   overwrite   = true
 
@@ -174,7 +174,7 @@ resource "aws_ssm_parameter" "cpc_plus_validation_file" {
 resource "aws_ssm_parameter" "db_app_username" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/DB_APP_USERNAME"
   description = "DB_APP_USERNAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "app"
   overwrite   = true
 
@@ -198,7 +198,7 @@ resource "aws_ssm_parameter" "db_app_username" {
 resource "aws_ssm_parameter" "db_master_username" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/DB_MASTER_USERNAME"
   description = "DB_MASTER_USERNAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "supersuit"
   overwrite   = true
 
@@ -222,7 +222,7 @@ resource "aws_ssm_parameter" "db_master_username" {
 resource "aws_ssm_parameter" "deploy0a_public-i-p" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/DEPLOY0A_PUBLIC-I-P"
   description = "DEPLOY0A_PUBLIC-I-P"
-  type        = "String"
+  type        = "SecureString"
   value       = "34.198.65.93"
   overwrite   = true
 
@@ -246,7 +246,7 @@ resource "aws_ssm_parameter" "deploy0a_public-i-p" {
 resource "aws_ssm_parameter" "dynamo_table_name" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/DYNAMO_TABLE_NAME"
   description = "DYNAMO_TABLE_NAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "qpp-qrda3converter-dev-metadata"
   overwrite   = true
 
@@ -270,7 +270,7 @@ resource "aws_ssm_parameter" "dynamo_table_name" {
 resource "aws_ssm_parameter" "gdit_nessus_pub_key" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/GDIT_NESSUS_PUB_KEY"
   description = "GDIT_NESSUS_PUB_KEY"
-  type        = "String"
+  type        = "SecureString"
   value       = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLu1Q+kvJSbTD7cKHPwZ9aW3qb0SISHDt3EzEvBTUhGGYYLzG2FFUIkjTd1cc8OyJ9DNlrujIGTNmLjbdQ//F8CtH5990oWN7MtcM0BToTgJ9yhEvhZ7iq2YYxANTBNL6wiTWkS70a6bjsqHGWYJ9jvduGftzHVMYkkapl/oVysRJaNu+38B0Z0FXNmoorlO74/Rt7XK5MhcGbN0z4/1urEWlSl9ygHA4umWw2OM17F6NAEY9fM9W+hcZsK0SzQsFYNI0g1JADKgnXBYOmuPeg/M/6wKctHSiZBporprZ8h7sgK8Sts8Gc/loBVp8DkmnC/eZzi0MnZ4esy6mldW5"
   overwrite   = true
 
@@ -294,7 +294,7 @@ resource "aws_ssm_parameter" "gdit_nessus_pub_key" {
 resource "aws_ssm_parameter" "java_opts" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/JAVA_OPTS"
   description = "JAVA_OPTS"
-  type        = "String"
+  type        = "SecureString"
   value       = "-Xms6G -Xmx6G -Xmn5G -XX:+UseStringDeduplication -XX:-AggressiveOpts"
   overwrite   = true
 
@@ -318,7 +318,7 @@ resource "aws_ssm_parameter" "java_opts" {
 resource "aws_ssm_parameter" "kms_key" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/KMS_KEY"
   description = "KMS_KEY"
-  type        = "String"
+  type        = "SecureString"
   value       = "arn:aws:kms:us-east-1:003384571330:alias/qpp-qrda3converter-dev-kms_alias"
   overwrite   = true
 
@@ -342,7 +342,7 @@ resource "aws_ssm_parameter" "kms_key" {
 resource "aws_ssm_parameter" "nexus_host" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/NEXUS_HOST"
   description = "NEXUS_HOST"
-  type        = "String"
+  type        = "SecureString"
   value       = "ec2-52-201-239-45.compute-1.amazonaws.com"
   overwrite   = true
 
@@ -366,7 +366,7 @@ resource "aws_ssm_parameter" "nexus_host" {
 resource "aws_ssm_parameter" "org_name" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/ORG_NAME"
   description = "ORG_NAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "cpc-plus-conversion-tool"
   overwrite   = true
 
@@ -390,7 +390,7 @@ resource "aws_ssm_parameter" "org_name" {
 resource "aws_ssm_parameter" "rti_org_name" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/RTI_ORG_NAME"
   description = "RTI_ORG_NAME"
-  type        = "String"
+  type        = "SecureString"
   value       = "rti-conversion-tool"
   overwrite   = true
 
@@ -414,7 +414,7 @@ resource "aws_ssm_parameter" "rti_org_name" {
 resource "aws_ssm_parameter" "validation_url" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/VALIDATION_URL"
   description = "VALIDATION_URL"
-  type        = "String"
+  type        = "SecureString"
   value       = "https://preview.qpp.cms.gov/api/submissions/public/validate-submission"
   overwrite   = true
 

--- a/infrastructure/terraform/prod/.terraform.lock.hcl
+++ b/infrastructure/terraform/prod/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.67.0"
-  constraints = "3.67.0"
+  version     = "3.70.0"
+  constraints = "3.70.0"
   hashes = [
-    "h1:p7CyS0dxRoxAMVeCBy7VS6yLm4hWkvl3ojhOvaog1n4=",
-    "zh:0bf1ecb4fe3ff79da63c82454a5dd9e12f867d5372b6bb30e560376537dc7a53",
-    "zh:0d5bedecf10ef6d8f8669661fe67b6ef572c7619a2322a825b9003ab2e93a396",
-    "zh:1a58d45c692071b566dccdb480c7ef968e034292f82f48d8948ff8d75a0a1198",
-    "zh:58bc36e36fffdc4e211d11101434941257e667fe7fb53514e3852ceaeaca55a6",
-    "zh:63bb67c92fd0eb938a02930be0af26f11f9ecad3c56870987a2ddac85613dff7",
-    "zh:7172053f58cdee02256dd4726196c22a80a256ff3bf46b60378c89463b1d9340",
-    "zh:804ca483b2bf451fc2278855cfaa97ad0179d43bf67259d1c36c50e9310c0c5c",
-    "zh:854e22be11c992042b31d728af049912da0eda70172d975ac8a94c3d2edb3326",
-    "zh:a9b18d34edb1a1beb6ed5a083de832ddd0019c594f5fed6554d1be659cebfe61",
-    "zh:b3dd0c0d77c25ad1c61665eb5ddde3ed1b3d525c5b99cfbbeaf245e0faa6a6bb",
-    "zh:dacf8f3a7408ac6439b01ef2774854837bb27fe7412fc9050b4f892d912873a5",
+    "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
+    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
+    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
+    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
+    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
+    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
+    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
+    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
+    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
+    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
+    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
+    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
   ]
 }
 

--- a/infrastructure/terraform/prod/main.tf
+++ b/infrastructure/terraform/prod/main.tf
@@ -12,10 +12,10 @@ terraform {
     required_providers {
         aws = {
             source = "hashicorp/aws"
-            version = "=3.67.0"
+            version = "=3.70.0"
         }
     }
-    required_version = "0.15.5"
+    required_version = "1.0.0"
 }
 
 provider "aws" {


### PR DESCRIPTION
### Information
- Fixes #_.
QPPSF-8326
QPPSF-9309

### Changes proposed in this PR:
**QPPSF-8326**
- _Upgraded terraform required_version from `0.15.5` to `1.0.0`_
- _Upgraded aws provider version from `3.67.0` to `3.70.0`_
- _Ran terraform init and plan in all Environments_

**QPPSF-9309**
- Remediated Checkov failed policies:
SSM Parameter should be Encrypted, Modified ssm parameter type from `String` to `SecureString`
Skipped checks on `CKV_AWS_173`,`CKV_AWS_32` policies

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
