### PR TITLE
QPPSF-9296, Forward Conversion-Tool Cloudwatch logs to Splunk

### DIFF
--- a/infrastructure/terraform/modules/Kinesis-cloudwatch-splunk/README.md
+++ b/infrastructure/terraform/modules/Kinesis-cloudwatch-splunk/README.md
@@ -1,0 +1,3 @@
+Kinesis Stream to capture Cloudwatch Log groups and Forward to Splunk
+
+Code Source: https://github.com/murikadan/Stream-AWS-CloudWatch-Logs-via-AWS-Lambda-into-Splunk

--- a/infrastructure/terraform/modules/Kinesis-cloudwatch-splunk/index.js
+++ b/infrastructure/terraform/modules/Kinesis-cloudwatch-splunk/index.js
@@ -1,0 +1,80 @@
+/**
+ * Stream events from AWS CloudWatch Logs to Splunk
+ *
+ * This function streams AWS CloudWatch Logs to Splunk using
+ * Splunk's HTTP event collector API.
+ *
+ * Define the following Environment Variables in the console below to configure
+ * this function to stream logs to your Splunk host:
+ *
+ * 1. SPLUNK_HEC_URL: URL address for your Splunk HTTP event collector endpoint.
+ * Default port for event collector is 8088. Example: https://host.com:8088/services/collector
+ *
+ * 2. SPLUNK_HEC_TOKEN: Token for your Splunk HTTP event collector.
+ * To create a new token for this Lambda function, refer to Splunk Docs:
+ * http://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Create_an_Event_Collector_token
+ */
+
+'use strict';
+
+const loggerConfig = {
+    url: process.env.SPLUNK_URL,
+    token: process.env.SPLUNK_TOKEN,
+};
+
+const SplunkLogger = require('./lib/splunklogger');
+const zlib = require('zlib');
+
+const logger = new SplunkLogger(loggerConfig);
+
+exports.handler = (event, context, callback) => {
+    console.log('Received event:', JSON.stringify(event, null, 2));
+
+    event.Records.forEach(function(record) {
+        // Kinesis data is base64 encoded so decode here
+        var payload = Buffer.from(record.kinesis.data, 'base64');
+        console.log('Decoded payload:', payload);
+        zlib.gunzip(payload, (err, result) => {
+            if (err) {
+                callback(err);
+            } else {
+                const parsed = JSON.parse(result.toString('ascii'));
+                console.log('Decoded payload:', JSON.stringify(parsed, null, 2));
+                let count = 0;
+                if (parsed.logEvents) {
+                    parsed.logEvents.forEach((item) => {
+                        /* Log event to Splunk with explicit event timestamp.
+                        - Use optional 'context' argument to send Lambda metadata e.g. awsRequestId, functionName.
+                        - Change "item.timestamp" below if time is specified in another field in the event.
+                        - Change to "logger.log(item.message, context)" if no time field is present in event. */
+                        logger.logWithTime(item.timestamp, item.message, context);
+
+                        /* Alternatively, UNCOMMENT logger call below if you want to override Splunk input settings */
+                        /* Log event to Splunk with any combination of explicit timestamp, index, source, sourcetype, and host.
+                        - Complete list of input settings available at http://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTinput#services.2Fcollector */
+                        // logger.logEvent({
+                        //     time: new Date(item.timestamp).getTime() / 1000,
+                        //     host: 'serverless',
+                        //     source: `lambda:${context.functionName}`,
+                        //     sourcetype: 'httpevent',
+                        //     index: 'main',
+                        //     event: item.message,
+                        // });
+
+                        count += 1;
+                    });
+                }
+                // Send all the events in a single batch to Splunk
+                logger.flushAsync((error, response) => {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        console.log(`Response from Splunk:\n${response}`);
+                        console.log(`Successfully processed ${count} log event(s).`);
+                        callback(null, count); // Return number of log events
+                    }
+                });
+            }
+        });
+    });
+};

--- a/infrastructure/terraform/modules/Kinesis-cloudwatch-splunk/lib/splunklogger.js
+++ b/infrastructure/terraform/modules/Kinesis-cloudwatch-splunk/lib/splunklogger.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const url = require('url');
+
+const Logger = function Logger(config) {
+    this.url = config.url;
+    this.token = config.token;
+
+    this.addMetadata = true;
+    this.setSource = true;
+
+    this.parsedUrl = url.parse(this.url);
+    // eslint-disable-next-line import/no-dynamic-require
+    this.requester = require(this.parsedUrl.protocol.substring(0, this.parsedUrl.protocol.length - 1));
+    // Initialize request options which can be overridden & extended by consumer as needed
+    this.requestOptions = {
+        hostname: this.parsedUrl.hostname,
+        path: this.parsedUrl.path,
+        port: this.parsedUrl.port,
+        method: 'POST',
+        headers: {
+            Authorization: `Splunk ${this.token}`,
+        },
+        rejectUnauthorized: false,
+    };
+
+    this.payloads = [];
+};
+
+// Simple logging API for Lambda functions
+Logger.prototype.log = function log(message, context) {
+    this.logWithTime(Date.now(), message, context);
+};
+
+Logger.prototype.logWithTime = function logWithTime(time, message, context) {
+    const payload = {};
+
+    if (Object.prototype.toString.call(message) === '[object Array]') {
+        throw new Error('message argument must be a string or a JSON object.');
+    }
+    payload.event = message;
+
+    // Add Lambda metadata
+    if (typeof context !== 'undefined') {
+        if (this.addMetadata) {
+            // Enrich event only if it is an object
+            if (message === Object(message)) {
+                payload.event = JSON.parse(JSON.stringify(message)); // deep copy
+                payload.event.awsRequestId = context.awsRequestId;
+            }
+        }
+        if (this.setSource) {
+            payload.source = `CloudWatch:${context.functionName}`;
+        }
+    }
+
+    payload.time = new Date(time).getTime() / 1000;
+
+    this.logEvent(payload);
+};
+
+Logger.prototype.logEvent = function logEvent(payload) {
+    this.payloads.push(JSON.stringify(payload));
+};
+
+Logger.prototype.flushAsync = function flushAsync(callback) {
+    callback = callback || (() => {}); // eslint-disable-line no-param-reassign
+
+    console.log('Sending event(s)');
+    const req = this.requester.request(this.requestOptions, (res) => {
+        res.setEncoding('utf8');
+
+        console.log('Response received');
+        res.on('data', (data) => {
+            let error = null;
+            if (res.statusCode !== 200) {
+                error = new Error(`error: statusCode=${res.statusCode}\n\n${data}`);
+                console.error(error);
+            }
+            this.payloads.length = 0;
+            callback(error, data);
+        });
+    });
+
+    req.on('error', (error) => {
+        callback(error);
+    });
+
+    req.end(this.payloads.join(''), 'utf8');
+};
+
+module.exports = Logger;

--- a/infrastructure/terraform/modules/ecs.tf
+++ b/infrastructure/terraform/modules/ecs.tf
@@ -83,6 +83,15 @@ resource "aws_cloudwatch_log_group" "conversion-tool" {
   retention_in_days = 30
 }
 
+resource "aws_cloudwatch_log_subscription_filter" "cw-kinesis-subscription-filter" {
+  name            = "cwlogs-subscription-to-kinesis"
+  role_arn        = aws_iam_role.cwlogs_to_kinesis.arn
+  distribution    = "Random"
+  log_group_name  = aws_cloudwatch_log_group.conversion-tool.name
+  filter_pattern  = ""
+  destination_arn = aws_kinesis_stream.kinesis-stream-cw-logs.arn
+}
+
 resource "aws_security_group" "ct_app" {
   name        = "conversion-tool-app-${var.environment}"
   description = "Allow inbound traffic"

--- a/infrastructure/terraform/modules/iam.tf
+++ b/infrastructure/terraform/modules/iam.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 #TODO: lockdown resources better
 resource "aws_iam_role" "ecs_execution_role" {
   name        = "${var.project_name}-execution-role-${var.environment}"
@@ -21,9 +23,128 @@ EOF
 
 }
 
+# IAM Role permissions to allow Cloudwatch logs to write to Kinesis Stream
+resource "aws_iam_role" "cwlogs_to_kinesis" {
+  name = "cloudwatch-to-kinesis-${var.environment}"
+  path = "/delegatedadmin/developer/"
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCloudwatchtoKinesis",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logs.us-east-1.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "cwlogs_to_kinesis_policy" {
+  name = "cloudwatch-to-kinesis-${var.environment}"
+  path = "/delegatedadmin/developer/"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:DescribeStream",
+                "kinesis:GetShardIterator",
+                "kinesis:GetRecords",
+                "kinesis:ListStreams",
+                "kinesis:PutRecords",
+                "kinesis:PutRecord",
+                "kinesis:ListShards",
+                "kinesis:DescribeStreamSummary",
+                "kinesis:RegisterStreamConsumer"
+            ],
+            "Resource": "${aws_kinesis_stream.kinesis-stream-cw-logs.arn}"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "kinesis_lambda_role" {
+  name = "conversiontool_kinesis_lambda_role"
+  path = "/delegatedadmin/developer/"
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowLambda"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "kinesis_lambda_role" {
+  name = "conversiontool_kinesis_lambda_role_policy"
+  path = "/delegatedadmin/developer/"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:DescribeStream",
+                "kinesis:GetShardIterator",
+                "kinesis:GetRecords",
+                "kinesis:ListStreams",
+                "kinesis:PutRecords"
+            ],
+            "Resource": [
+              "${aws_kinesis_stream.kinesis-stream-cw-logs.arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+                
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+
+resource "aws_iam_role_policy_attachment" "kinesis_lambda_policy" {
+  role       = aws_iam_role.kinesis_lambda_role.name
+  policy_arn = aws_iam_policy.kinesis_lambda_role.arn
+}
+
+resource "aws_iam_role_policy_attachment" "cwlogs_to_kinesis_policy" {
+  role       = aws_iam_role.cwlogs_to_kinesis.name
+  policy_arn = aws_iam_policy.cwlogs_to_kinesis_policy.arn
+}
+
 resource "aws_iam_policy" "conversion_tool_iam_policy" {
   name = "${var.project_name}-execution-policy-${var.environment}"
-
   policy = data.template_file.ecs_execution_policy_template.rendered
 
 }

--- a/infrastructure/terraform/modules/kinesis-lambda.tf
+++ b/infrastructure/terraform/modules/kinesis-lambda.tf
@@ -1,0 +1,29 @@
+data "aws_ssm_parameter" "splunk_endpoint" {
+  name = "/global/splunk_url"
+}
+
+data "aws_ssm_parameter" "splunk_token" {
+  name = "/global/splunk_token"
+}
+
+resource "aws_lambda_function" "kinesis_cw_lambda" {
+  filename = "${path.module}/Kinesis-cloudwatch-splunk.zip"
+  function_name = "${var.application}-${var.environment}"
+  role = "${aws_iam_role.kinesis_lambda_role.arn}"
+  handler = "index.handler"
+  runtime = "nodejs12.x"
+  timeout = 30
+
+  environment {
+    variables = {
+      SPLUNK_URL = data.aws_ssm_parameter.splunk_endpoint.value
+      SPLUNK_TOKEN = data.aws_ssm_parameter.splunk_token.value
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "kinesis_lambda_source" {
+  event_source_arn = "${aws_kinesis_stream.kinesis-stream-cw-logs.arn}"
+  function_name = "${aws_lambda_function.kinesis_cw_lambda.arn}"
+  starting_position = "TRIM_HORIZON"
+}

--- a/infrastructure/terraform/modules/kinesis.tf
+++ b/infrastructure/terraform/modules/kinesis.tf
@@ -1,0 +1,16 @@
+resource "aws_kinesis_stream" "kinesis-stream-cw-logs" {
+  name             = "conversion-tool-${var.environment}-kinesis-stream"
+  shard_count      = 1
+  retention_period = 192
+
+  encryption_type = "KMS"
+  kms_key_id      = "alias/aws/kinesis"
+
+  tags = {
+    owner           = var.owner
+    environment     = var.environment
+    project         = var.project_name
+    application     = var.application
+    sensitivity     = var.sensitivity
+  }
+}


### PR DESCRIPTION
### Information
- Fixes #_.
_QPPSF-9296_


### Changes proposed in this PR:

- Added Lambda function code to forward Cloudwatch log groups to Splunk

**Terraform code:**
- Creates CT Cloudwatch log groups subscription filter to kinesis stream
- Creates IAM Role permissions to allow Cloudwatch logs to write to Kinesis Stream
- Creates lambda function resource and event source mapping 
- Creates Kinesis Stream per Environment

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
