### PR TITLE
QPPSF-10053, Added drop http header attribute for CT ALB

### DIFF
--- a/infrastructure/terraform/modules/alb.tf
+++ b/infrastructure/terraform/modules/alb.tf
@@ -22,6 +22,7 @@ resource "aws_lb" "qppsf" {
     prefix  = "conversion-tool/${var.environment}"
     enabled = true
   }
+  drop_invalid_header_fields = true
 }
 
 #ALB Target group for HTTPS


### PR DESCRIPTION
### Information
- Fixes #_.
_QPPSF-10053_

### Changes proposed in this PR:
_Currently, qppsf-conversion-tool-lb-{env} is not set to drop invalid headers. Allowing invalid headers can introduce unforeseen security issues, so it's best to ensure this setting is enabled on all ALBs_

Added attribute `drop_invalid_header_fields = true` to all CT ALBs


### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
