### PR TITLE
Add CI build step to delete ~/.m2

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,7 +28,7 @@ jobs:
         java-version: 11
 
     - name: Delete old dependencies (may trigger Snyk vulnerability otherwise)
-      run: rm -rf ~/.m2
+      run: rm -vrf ~/.m2
 
     - name: Maven build
       run: mvn package -Dmaven.test.skip -Djacoco.skip=true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,6 +27,9 @@ jobs:
       with:
         java-version: 11
 
+    - name: Delete old dependencies (may trigger Snyk vulnerability otherwise)
+      run: rm -rf ~/.m2
+
     - name: Maven build
       run: mvn package -Dmaven.test.skip -Djacoco.skip=true
 


### PR DESCRIPTION
### Information
- JIRA story https://jira.cms.gov/browse/QPPSF-10419.

### Changes proposed in this PR:
- Adds a CI step to delete `~/.m2` Maven repository before building. This was causing a Snyk vulnerability error due to old dependencies being present.

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
