### PR TITLE
QPPSF-10417: Jackson/Spring issue

### DIFF
--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -181,6 +182,7 @@ public class JsonWrapper {
 	 */
 	static {
 		jsonMapper = new ObjectMapper();
+		jsonMapper.configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false);
 		SimpleModule module = new SimpleModule();
 		module.addSerializer(JsonWrapper.class, new JsonWrapperSerilizer());
 		jsonMapper.registerModule(module);

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/JsonWrapper.java
@@ -1,5 +1,23 @@
 package gov.cms.qpp.conversion.encode;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.jayway.jsonpath.JsonPath;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import gov.cms.qpp.conversion.InputStreamSupplierSource;
+import gov.cms.qpp.conversion.Source;
+import gov.cms.qpp.conversion.model.Node;
+import gov.cms.qpp.conversion.util.CloneHelper;
+import gov.cms.qpp.conversion.util.FormatHelper;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -10,25 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.util.DefaultIndenter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.jayway.jsonpath.JsonPath;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import gov.cms.qpp.conversion.InputStreamSupplierSource;
-import gov.cms.qpp.conversion.Source;
-import gov.cms.qpp.conversion.model.Node;
-import gov.cms.qpp.conversion.util.CloneHelper;
-import gov.cms.qpp.conversion.util.FormatHelper;
 
 /**
  * Manages building an object container for JSON conversion.
@@ -182,7 +181,6 @@ public class JsonWrapper {
 	 */
 	static {
 		jsonMapper = new ObjectMapper();
-		jsonMapper.configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false);
 		SimpleModule module = new SimpleModule();
 		module.addSerializer(JsonWrapper.class, new JsonWrapperSerilizer());
 		jsonMapper.registerModule(module);

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v2/QrdaControllerV2.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v2/QrdaControllerV2.java
@@ -41,7 +41,7 @@ public class QrdaControllerV2 extends SkeletalQrdaController<ConvertResponse> {
 	protected ConvertResponse respond(MultipartFile file, String checkedPurpose, HttpHeaders httpHeaders) {
 		ConversionReport conversionReport = buildReport(file.getOriginalFilename(), inputStream(file), checkedPurpose);
 		ConvertResponse response = new ConvertResponse();
-		response.setQpp(conversionReport.getEncodedWithMetadata().copyWithoutMetadata().toObject());
+		response.setQpp(conversionReport.getEncodedWithMetadata().copyWithoutMetadata().toString());
 		response.setWarnings(conversionReport.getWarnings());
 		Metadata metadata = audit(conversionReport);
 		if (null != metadata) {

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v2/ZipController.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/controllers/v2/ZipController.java
@@ -72,7 +72,7 @@ public class ZipController extends SkeletalQrdaController<List<ConvertResponse>>
 			InputStream inputStream = zipFile.getInputStream(entry);
 			ConversionReport conversionReport = buildReport(entry.getName(), inputStream, purpose);
 			ConvertResponse response = new ConvertResponse();
-			response.setQpp(conversionReport.getEncodedWithMetadata().copyWithoutMetadata().toObject());
+			response.setQpp(conversionReport.getEncodedWithMetadata().copyWithoutMetadata().toString());
 			response.setWarnings(conversionReport.getWarnings());
 			Metadata metadata = audit(conversionReport);
 			if (null != metadata) {

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/ConvertResponse.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/model/ConvertResponse.java
@@ -1,14 +1,20 @@
 package gov.cms.qpp.conversion.api.model;
 
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
 import java.util.List;
 import java.util.Objects;
 
 import gov.cms.qpp.conversion.model.error.Detail;
 
+
 public class ConvertResponse {
 
 	private String location;
-	private Object qpp;
+
+	@JsonRawValue
+	private String qpp;
+
 	private List<Detail> warnings;
 
 	public String getLocation() {
@@ -23,7 +29,7 @@ public class ConvertResponse {
 		return qpp;
 	}
 
-	public void setQpp(Object qpp) {
+	public void setQpp(String qpp) {
 		this.qpp = qpp;
 	}
 

--- a/rest-api/src/main/resources/application.properties
+++ b/rest-api/src/main/resources/application.properties
@@ -4,4 +4,3 @@ spring.servlet.multipart.max-request-size=-1
 security.user.password=not_used
 server.port=8443
 server.ssl.key-store-type=PKCS12
-spring.jackson.serialization.fail-on-self-references=false

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v2/QrdaControllerV2Test.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v2/QrdaControllerV2Test.java
@@ -99,7 +99,9 @@ class QrdaControllerV2Test {
 		verify(qrdaService, atLeastOnce()).convertQrda3ToQpp(any(Source.class));
 
 		assertThat(qppResponse.getBody().getQpp().toString())
-				.isEqualTo(report.getEncodedWithMetadata().toObject().toString());
+				.isEqualTo("{\n"
+					+ "  \"key\" : \"Good Qpp\"\n"
+					+ "}");
 	}
 
 	@Test

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v2/ZipControllerTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/controllers/v2/ZipControllerTest.java
@@ -98,7 +98,9 @@ class ZipControllerTest {
 		verify(qrdaService, atLeastOnce()).convertQrda3ToQpp(any(Source.class));
 
 		assertThat(qppResponse.getBody().get(0).getQpp().toString())
-				.isEqualTo(report.getEncodedWithMetadata().toObject().toString());
+				.isEqualTo("{\n"
+					+ "  \"key\" : \"Good Qpp\"\n"
+					+ "}");
 	}
 
 	@Test


### PR DESCRIPTION
### Information
- Fixes a Jackson issue with Spring not accepting the `JsonWrapper.toObject` due to redundancy issues. 

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [x] New unit tests written to cover new functionality.
- [x] Added and updated JavaDocs for non-test classes and methods.
- [x] No local design debt. Do you feel that something is "ugly" after your changes?
- [x] Updated documentation (`README.md`, etc.) depending if the changes require it.
