### PR TITLE
QPPSF-10934: Numerator exclusion

### DIFF
--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulation.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulation.java
@@ -25,6 +25,9 @@ public class SubPopulation {
 	@JsonProperty("numeratorUuid")
 	private String numeratorUuid;
 
+	@JsonProperty("numeratorExclusionUuid")
+	private String numeratorExclusionUuid;
+
 	@JsonProperty("denominatorExceptionUuid")
 	private String denominatorExceptionsUuid;
 
@@ -76,6 +79,14 @@ public class SubPopulation {
 		this.numeratorUuid = numeratorUuid;
 	}
 
+	public String getNumeratorExclusionUuid() {
+		return numeratorExclusionUuid;
+	}
+
+	public void setNumeratorExclusionUuid(final String numeratorExclusionUuid) {
+		this.numeratorExclusionUuid = numeratorExclusionUuid;
+	}
+
 	public String getDenominatorExceptionsUuid() {
 		return denominatorExceptionsUuid;
 	}
@@ -112,6 +123,10 @@ public class SubPopulation {
 				? !numeratorUuid.equals(that.numeratorUuid) : (that.numeratorUuid != null)) {
 			isCool = false;
 		}
+		if (numeratorExclusionUuid != null
+			? !numeratorExclusionUuid.equals(that.numeratorExclusionUuid) : (that.numeratorExclusionUuid != null)) {
+			isCool = false;
+		}
 		if (strata != null ? !strata.equals(that.strata) : (that.strata != null)) {
 			isCool = false;
 		}
@@ -138,7 +153,7 @@ public class SubPopulation {
 	@Override
 	public int hashCode() {
 		return Objects.hash(initialPopulationUuid, denominatorUuid, denominatorExclusionsUuid,
-				numeratorUuid, denominatorExceptionsUuid, strata);
+				numeratorUuid, numeratorExclusionUuid, denominatorExceptionsUuid, strata);
 	}
 
 }

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/validation/SubPopulationLabel.java
@@ -15,6 +15,7 @@ public enum SubPopulationLabel {
 	DENEXCEP(SubPopulation::getDenominatorExceptionsUuid, "DENEXCEP"),
 	DENEX(SubPopulation::getDenominatorExclusionsUuid, "DENEX"),
 	NUMER(SubPopulation::getNumeratorUuid, "NUMER"),
+	NUMEX(SubPopulation::getNumeratorExclusionUuid, "NUMEX"),
 	DENOM(SubPopulation::getDenominatorUuid, "DENOM"),
 	IPOP(SubPopulation::getNumeratorUuid, "IPOP", "IPP");
 

--- a/converter/src/main/java/gov/cms/qpp/conversion/decode/MeasureDataDecoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/decode/MeasureDataDecoder.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 @Decoder(TemplateId.MEASURE_DATA_CMS_V4)
 public class MeasureDataDecoder extends QrdaDecoder {
 
-	static final Set<String> MEASURES = Stream.of("IPP", "IPOP", "DENEX", "DENOM", "DENEXCEP", "NUMER")
+	static final Set<String> MEASURES = Stream.of("IPP", "IPOP", "DENEX", "DENOM", "DENEXCEP", "NUMER", "NUMEX")
 			.collect(Collectors.toSet());
 
 	public static final String MEASURE_TYPE = "type";

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/MeasureDataEncoder.java
@@ -29,7 +29,8 @@ public class MeasureDataEncoder extends QppOutputEncoder {
 	 */
 	@Override
 	protected void internalEncode(JsonWrapper wrapper, Node node) {
-		if (!SubPopulationLabel.IPOP.hasAlias(node.getValue(MEASURE_TYPE))) {
+		if (!SubPopulationLabel.IPOP.hasAlias(node.getValue(MEASURE_TYPE)) &&
+			!SubPopulationLabel.NUMEX.hasAlias(node.getValue(MEASURE_TYPE))) {
 			String measureType = node.getValue(MEASURE_TYPE);
 			Node aggCount = node.findFirstNode(TemplateId.PI_AGGREGATE_COUNT);
 

--- a/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/MeasureDataRoundTripTest.java
@@ -37,7 +37,7 @@ class MeasureDataRoundTripTest {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = SubPopulationLabel.class, mode = EnumSource.Mode.EXCLUDE, names = {"IPOP"})
+	@EnumSource(value = SubPopulationLabel.class, mode = EnumSource.Mode.EXCLUDE, names = {"IPOP", "NUMEX"})
 	void decodeMeasureDataAsNode(SubPopulationLabel label) throws Exception {
 		test(label);
 	}

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
@@ -62,6 +62,7 @@ class SubPopulationsTest {
 		subPopulation.setDenominatorExclusionsUuid(expected.get(SubPopulationLabel.DENEX.name()));
 		subPopulation.setDenominatorUuid(expected.get(SubPopulationLabel.DENOM.name()));
 		subPopulation.setNumeratorUuid(expected.get(SubPopulationLabel.NUMER.name()));
+		subPopulation.setNumeratorExclusionUuid(expected.get(SubPopulationLabel.NUMEX.name()));
 
 		for (SubPopulationLabel key : SubPopulations.getExclusiveKeys(Sets.newHashSet(SubPopulationLabel.IPOP))) {
 			assertThat(SubPopulations.getUniqueIdForKey(key.name(), subPopulation))

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/SubPopulationsTest.java
@@ -29,7 +29,7 @@ class SubPopulationsTest {
  		assertWithMessage("Non excluded keys should be present")
 				.that(keys)
 				.containsExactly(SubPopulationLabel.DENEXCEP, SubPopulationLabel.DENOM,
-					SubPopulationLabel.NUMER, SubPopulationLabel.IPOP);
+					SubPopulationLabel.NUMER, SubPopulationLabel.NUMEX, SubPopulationLabel.IPOP);
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/QualityMeasureIdValidatorTest.java
@@ -42,6 +42,12 @@ class QualityMeasureIdValidatorTest {
 	private static final String REQUIRES_DENOM_EXCEPTION_DENOM_GUID = "375D0559-C749-4BB9-9267-81EDF447650B";
 	private static final String REQUIRES_DENOM_EXCEPTION_NUMER_GUID = "EFFE261C-0D57-423E-992C-7141B132768C";
 
+	private static final String REQUIRES_NUMER_EXCLUSION_GUID = "requiresNumeratorExclusionGuid";
+	private static final String REQUIRES_NUMER_EXCLUSION_NUMEX_GUID = "16F9E2DB-C09F-4E06-AFBD-C1E5E178D921";
+	private static final String REQUIRES_NUMER_EXCLUSION_NUMER_GUID = "14F9E2DB-C09F-4E06-AFBD-C1E5E178D920";
+	private static final String REQUIRES_NUMER_EXCLUSION_IPOP_GUID = "3E177A28-30DE-4381-8C7A-B42CD914DA33";
+	private static final String REQUIRES_NUMER_EXCLUSION_DENOM_GUID = "E7E1C3BB-730F-4020-9BF3-3AA508B914FC";
+
 	private static final String MULTIPLE_POPULATION_DENOM_EXCEPTION_GUID = "multiplePopulationDenominatorExceptionGuid";
 	private static final String MULTIPLE_POPULATION_DENOM_EXCEPTION_IPOP1_GUID = "E681DBF8-F827-4586-B3E0-178FF19EC3A2";
 	private static final String MULTIPLE_POPULATION_DENOM_EXCEPTION_DENOM1_GUID = "04BF53CE-6993-4EA2-BFE5-66E36172B388";
@@ -140,6 +146,21 @@ class QualityMeasureIdValidatorTest {
 		assertWithMessage("Incorrect validation error.")
 				.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 				.containsExactly(incorrectCount, incorrectUuid);
+	}
+
+	@Test
+	void testNumeratorExclusionMissing() {
+		LocalizedProblem incorrectCount = ProblemCode.POPULATION_CRITERIA_COUNT_INCORRECT.format(
+			"CMS156v9", 1, SubPopulationLabel.NUMEX.name(), 0);
+
+		Node measureReferenceResultsNode = createCorrectMeasureReference(REQUIRES_NUMER_EXCLUSION_GUID)
+			.removeSubPopulationMeasureData(SubPopulationLabel.NUMEX.name(), REQUIRES_NUMER_EXCLUSION_NUMEX_GUID)
+			.build();
+
+		List<Detail> details = objectUnderTest.validateSingleNode(measureReferenceResultsNode).getErrors();
+		assertWithMessage("Incorrect validation error.")
+			.that(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
+			.containsExactly(incorrectCount);
 	}
 
 	@Test
@@ -399,6 +420,13 @@ class QualityMeasureIdValidatorTest {
 					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(), REQUIRES_DENOM_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
 					.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENEX.name(), REQUIRES_DENOM_EXCLUSION_DENEX_GUID, ONE_HUNDRED)
 					.addSubPopulationPerformanceRate(REQUIRES_DENOM_EXCLUSION_NUMER_GUID);
+		} else if (REQUIRES_NUMER_EXCLUSION_GUID.equalsIgnoreCase(measureId)) {
+			measureReferenceResultsNode
+				.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.IPOP.name(), REQUIRES_NUMER_EXCLUSION_IPOP_GUID,
+					ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.DENOM.name(), REQUIRES_NUMER_EXCLUSION_DENOM_GUID, ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMER.name(), REQUIRES_NUMER_EXCLUSION_NUMER_GUID, ONE_HUNDRED)
+				.addSubPopulationMeasureDataWithCounts(SubPopulationLabel.NUMEX.name(), REQUIRES_NUMER_EXCLUSION_NUMEX_GUID, ONE_HUNDRED);
 		}
 
 		return measureReferenceResultsNode;

--- a/converter/src/test/resources/fixtures/measureDataHappy.xml
+++ b/converter/src/test/resources/fixtures/measureDataHappy.xml
@@ -75,7 +75,7 @@
                 </reference>
             </observation>
         </component>
-                <!--DENOM Population-->
+        <!--DENOM Population-->
         <component>
         <observation classCode="OBS" moodCode="EVN">
             <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
@@ -111,7 +111,7 @@
             </reference>
         </observation>
         </component>
-                <!--NUMER Population-->
+        <!--NUMER Population-->
         <component>
         <observation classCode="OBS" moodCode="EVN">
             <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
@@ -146,6 +146,42 @@
                 </externalObservation>
             </reference>
         </observation>
+        </component>
+        <!--NUMEX Population-->
+        <component>
+            <observation classCode="OBS" moodCode="EVN">
+                <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+                <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2016-11-01"/>
+                <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                      codeSystemName="ActCode" displayName="Assertion"/>
+                <statusCode code="completed"/>
+                <value xsi:type="CD" code="NUMEX"
+                       codeSystem="2.16.840.1.113883.5.1063"
+                       codeSystemName="ObservationValue"/>
+                <!--NUMEX Count-->
+                <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                        <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                        <templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+                        <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                              codeSystemName="ActCode"
+                              displayName="rate aggregation"/>
+                        <statusCode code="completed"/>
+                        <value xsi:type="INT" value="25"/>
+                        <methodCode code="COUNT"
+                                    codeSystem="2.16.840.1.113883.5.84"
+                                    codeSystemName="ObservationMethod"
+                                    displayName="Count"/>
+                    </observation>
+                </entryRelationship>
+
+                <!--NUMER Population ID from eMeasure-->
+                <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                        <id root="11223344-58CC-4CF5-929F-B83583701BFE"/>
+                    </externalObservation>
+                </reference>
+            </observation>
         </component>
         <!--DENEXCEP Population-->
         <component>

--- a/converter/src/test/resources/reduced-test-measures-data.json
+++ b/converter/src/test/resources/reduced-test-measures-data.json
@@ -134,6 +134,70 @@
 		]
 	},
 	{
+		"title": "Use of High-Risk Medications in Older Adults",
+		"eMeasureId": "CMS156v9",
+		"nqfEMeasureId": null,
+		"nqfId": "0022",
+		"measureId": "238",
+		"description": "Percentage of patients 65 years of age and older who were ordered at least two of the same high-risk medications.",
+		"nationalQualityStrategyDomain": "Patient Safety",
+		"measureType": "process",
+		"primarySteward": "National Committee for Quality Assurance",
+		"metricType": "singlePerformanceRate",
+		"firstPerformanceYear": 2017,
+		"lastPerformanceYear": null,
+		"isHighPriority": true,
+		"isInverse": true,
+		"isIcdImpacted": false,
+		"isClinicalGuidelineChanged": false,
+		"category": "quality",
+		"isRegistryMeasure": false,
+		"isRiskAdjusted": false,
+		"icdImpacted": [],
+		"clinicalGuidelineChanged": [],
+		"allowedPrograms": [
+			"mips",
+			"cpcPlus",
+			"pcf"
+		],
+		"submissionMethods": [
+			"electronicHealthRecord",
+			"registry"
+		],
+		"measureSets": [
+			"allergyImmunology",
+			"cardiology",
+			"familyMedicine",
+			"internalMedicine",
+			"ophthalmology",
+			"rheumatology",
+			"geriatrics",
+			"skilledNursingFacility",
+			"pulmonology"
+		],
+		"measureSpecification": {
+			"electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2021/cms156v9",
+			"registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2021_Measure_238_MIPSCQM.pdf"
+		},
+		"strata": [
+			{
+				"name": "overall",
+				"description": "Percentage of patients who were ordered at least one high-risk medication",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "3E177A28-30DE-4381-8C7A-B42CD914DA33",
+					"denominatorUuid": "E7E1C3BB-730F-4020-9BF3-3AA508B914FC",
+					"numeratorUuid": "14F9E2DB-C09F-4E06-AFBD-C1E5E178D920",
+					"numeratorExclusionUuid": "16F9E2DB-C09F-4E06-AFBD-C1E5E178D921"
+				}
+			}
+		],
+		"eMeasureUuid": "requiresNumeratorExclusionGuid",
+		"benchmarks": {
+			"electronicHealthRecord": "removed",
+			"registry": "removed"
+		}
+	},
+	{
 		"category": "quality",
 		"firstPerformanceYear": 2017,
 		"lastPerformanceYear": null,


### PR DESCRIPTION
### Information
- Adds decoding and validation for the new numerator exclusion field.
- Ability to read the numerator exclusion field in the measures data configuration.
- Adds test coverage of the new field.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
