### PR TITLE
QPPSF-10742: Template ID Extension Update

### DIFF
--- a/commandline/src/test/resources/qrda_bad_denominator.xml
+++ b/commandline/src/test/resources/qrda_bad_denominator.xml
@@ -30,7 +30,7 @@ CDA Header
 	<!-- QRDA Category III Report (QRDA III) -->
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
 	<!-- QRDA Category III Report - CMS EP -->
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<!-- SHALL contain exactly one [1..1] id (CONF:17236).  This id SHALL be a globally unique identifier for the document (CONF:17242). -->
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).
@@ -340,8 +340,8 @@ CDA Header
 							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
 								  displayName="Observation Parameters"/>
 							<effectiveTime>
-								<low value="20180201"/>
-								<high value="20180531"/>
+								<low value="20210201"/>
+								<high value="20210531"/>
 							</effectiveTime>
 						</act>
 					</entry>

--- a/commandline/src/test/resources/valid-QRDA-III-latest.xml
+++ b/commandline/src/test/resources/valid-QRDA-III-latest.xml
@@ -63,7 +63,7 @@ CDA Header
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
@@ -4478,8 +4478,8 @@ CDA Header
 							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
 								  displayName="Observation Parameters"/>
 							<effectiveTime>
-								<low value="20200101"/>
-								<high value="20201231"/>
+								<low value="20210101"/>
+								<high value="20211231"/>
 							</effectiveTime>
 						</act>
 					</entry>
@@ -4631,8 +4631,8 @@ CDA Header
 							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
 								  displayName="Observation Parameters"/>
 							<effectiveTime>
-								<low value="20200201"/>
-								<high value="20200531"/>
+								<low value="20210201"/>
+								<high value="20210531"/>
 							</effectiveTime>
 						</act>
 					</entry>
@@ -4754,8 +4754,8 @@ CDA Header
 							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
 								  displayName="Observation Parameters"/>
 							<effectiveTime>
-								<low value="20200101"/>
-								<high value="20200430"/>
+								<low value="20210101"/>
+								<high value="20210430"/>
 							</effectiveTime>
 						</act>
 					</entry>

--- a/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/model/TemplateId.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
  * An enumeration of known templates IDs.
  */
 public enum TemplateId {
-	CLINICAL_DOCUMENT("2.16.840.1.113883.10.20.27.1.2", Extension.MAY_2020, "Clinical Document"),
+	CLINICAL_DOCUMENT("2.16.840.1.113883.10.20.27.1.2", Extension.JULY_2021, "Clinical Document"),
 	PI_AGGREGATE_COUNT("2.16.840.1.113883.10.20.27.3.3"),
 	IA_SECTION("2.16.840.1.113883.10.20.27.2.4", Extension.JUNE_2017, "IA Section"),
 	PI_SECTION_V2("2.16.840.1.113883.10.20.27.2.5", Extension.JUNE_2017, "PI Section"),
@@ -52,6 +52,7 @@ public enum TemplateId {
 		NONE(""),
 		JUNE_2017("2017-06-01"),
 		JULY_2017("2017-07-01"),
+		JULY_2021("2021-07-01"),
 		SEPTEMBER_2016("2016-09-01"),
 		NOVEMBER_2016("2016-11-01"),
 		MAY_2018("2018-05-01"),

--- a/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentRoundTripTest.java
@@ -61,7 +61,7 @@ class ClinicalDocumentRoundTripTest {
 			+ "\t<realmCode code=\"US\"/>\n"
 			+ "\t<typeId root=\"2.16.840.1.113883.1.3\" extension=\"POCD_HD000040\"/>\n"
 			+ "\t<templateId root=\"2.16.840.1.113883.10.20.27.1.2\"/>\n"
-			+ "\t<templateId root=\"2.16.840.1.113883.10.20.27.1.2\" extension=\"2020-05-01\"/>\n"
+			+ "\t<templateId root=\"2.16.840.1.113883.10.20.27.1.2\" extension=\"2021-07-01\"/>\n"
 			+ "</ClinicalDocument>";
 
 		Node root = new QrdaDecoderEngine(new Context()).decode(XmlUtils.stringToDom(similarClinicalDocumentBlob));

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/TemplateIdTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/TemplateIdTest.java
@@ -35,7 +35,7 @@ class TemplateIdTest implements EnumContract {
 
 	@Test
 	void testExtension() {
-		assertThat(TemplateId.CLINICAL_DOCUMENT.getExtension()).isEqualTo("2020-05-01");
+		assertThat(TemplateId.CLINICAL_DOCUMENT.getExtension()).isEqualTo("2021-07-01");
 	}
 
 	@Test

--- a/converter/src/test/resources/Mips-Apm-Entity-2021.xml
+++ b/converter/src/test/resources/Mips-Apm-Entity-2021.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/QRDA-III-with-extra-elements.xml
+++ b/converter/src/test/resources/QRDA-III-with-extra-elements.xml
@@ -11,7 +11,7 @@
 	<!-- QRDA Category III Report (QRDA III) -->
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
 	<!-- QRDA Category III Report - CMS EP -->
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
 	<title>Eligible Clinicians (EC) Meaningful Use Group Sample QRDA-III		(Informative)</title>

--- a/converter/src/test/resources/Qrda_CatIII_Provider.xml
+++ b/converter/src/test/resources/Qrda_CatIII_Provider.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/converter/defaultedNode.xml
+++ b/converter/src/test/resources/converter/defaultedNode.xml
@@ -5,7 +5,7 @@
         xmlns="urn:hl7-org:v3"
         xmlns:voc="urn:hl7-org:v3/voc">
     <!-- QRDA Category III Report - CMS EP -->
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <component>
     <structuredBody>
     <!--

--- a/converter/src/test/resources/converter/errantDefaultedNode.xml
+++ b/converter/src/test/resources/converter/errantDefaultedNode.xml
@@ -5,7 +5,7 @@
         xmlns="urn:hl7-org:v3"
         xmlns:voc="urn:hl7-org:v3/voc">
     <!-- QRDA Category III Report - CMS EP -->
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <component>
         <structuredBody>
             <!--

--- a/converter/src/test/resources/correctMultiToSinglePerfMeasureExample.xml
+++ b/converter/src/test/resources/correctMultiToSinglePerfMeasureExample.xml
@@ -59,7 +59,7 @@ CDA Header
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-10a-ImproperPerformancePeriod_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-10a-ImproperPerformancePeriod_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-10b-ImproperPerformancePeriod-2_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-10b-ImproperPerformancePeriod-2_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-10c-NoPerformancePeriod_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-10c-NoPerformancePeriod_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-11a-CMS165v9IncorrectUUID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-11a-CMS165v9IncorrectUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-11b-CMS122v9IncorrectUUID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-11b-CMS122v9IncorrectUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-12a-CMS165Fail_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-12a-CMS165Fail_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-12b-CMS122Fail_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-12b-CMS122Fail_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13a-CMS122IPOPMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13a-CMS122IPOPMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13b-CMS122DENOMMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13b-CMS122DENOMMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13c-CMS122DENEXMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13c-CMS122DENEXMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13d-CMS122NUMERMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13d-CMS122NUMERMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13e-CMS165IPOPMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13e-CMS165IPOPMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13f-CMS165DENOMMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13f-CMS165DENOMMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13g-CMS165DENEXMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13g-CMS165DENEXMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13h-CMS165NUMERMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13h-CMS165NUMERMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13i-CMS122IPOPBlank_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-13i-CMS122IPOPBlank_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14a-CMS122PRMissing_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14a-CMS122PRMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14b-CMS165PRNotTiedToNUMER_06222021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14b-CMS165PRNotTiedToNUMER_06222021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14c-CMS122TwoPR_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14c-CMS122TwoPR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14d-CMS165TwoPR_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-14d-CMS165TwoPR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15b-CMS165InvalidNA-PR_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15b-CMS165InvalidNA-PR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15c-CMS165PRLessThan0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15c-CMS165PRLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15d-CMS122PRGreaterThan1_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15d-CMS122PRGreaterThan1_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15e-CMS165DENOM0PR0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15e-CMS165DENOM0PR0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15f-CMS122PerfDENOM0PR0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-15f-CMS122PerfDENOM0PR0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-16a-CMS122NUMERGreaterPerfDENOM_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-16a-CMS122NUMERGreaterPerfDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-16b-CMS165NUMERGreaterPerfDENOM_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-16b-CMS165NUMERGreaterPerfDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-17a-CMS122DENEXGreaterDENOM_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-17a-CMS122DENEXGreaterDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-17b-CMS165DENEXGreaterDENOM_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-17b-CMS165DENEXGreaterDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-18a-PISectionAdded_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-18a-PISectionAdded_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-18b-IAandPISectionAdded_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-18b-IAandPISectionAdded_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-19a-CMS122DENOMLessThanIPOP_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-19a-CMS122DENOMLessThanIPOP_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-19b-CMS165DENOMGreaterthanIPOP_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-19b-CMS165DENOMGreaterthanIPOP_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-1a-ImproperProgramName_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-1a-ImproperProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-1c-IncorrectProgramName_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-1c-IncorrectProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20a-CMS122IPOPLessThan0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20a-CMS122IPOPLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20b-CMS122DENOMLessThan0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20b-CMS122DENOMLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20c-CMS165DENEXLessThan0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20c-CMS165DENEXLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20d-CMS165NUMERLessThan0_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20d-CMS165NUMERLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20e-CMS165IPOPWrongTemplateID_06252021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20e-CMS165IPOPWrongTemplateID_06252021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20f-CMS122NUMERMissingTemplateID_06252021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20f-CMS122NUMERMissingTemplateID_06252021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20g-CMS122IPOPDecimal_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20g-CMS122IPOPDecimal_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20h-CMS165NUMERDecimal_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-20h-CMS165NUMERDecimal_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21a-CMS122IPOPNoSDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21a-CMS122IPOPNoSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21b-CMS122DENOMNoSexSDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21b-CMS122DENOMNoSexSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21c-CMS122DENEXNoRaceSDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21c-CMS122DENEXNoRaceSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21d-CMS165NUMERNoEthnicitySDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21d-CMS165NUMERNoEthnicitySDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21e-CMS165IPOPNoPayerSDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21e-CMS165IPOPNoPayerSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21f-CMS165DENOMNoMaleSDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21f-CMS165DENOMNoMaleSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21g-CMS165NUMERNoAsianSDE_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-21g-CMS165NUMERNoAsianSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22a-CMS122ReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22a-CMS122ReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22b-CMS165ReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22b-CMS165ReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22c-CMS122IPOPReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22c-CMS122IPOPReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22d-CMS122DENOMReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22d-CMS122DENOMReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22e-CMS165DENEXReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22e-CMS165DENEXReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22f-CMS165NUMERReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22f-CMS165NUMERReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22g-CMS122IPOPCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22g-CMS122IPOPCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22h-CMS122DENOMCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22h-CMS122DENOMCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22i-CMS165DENEXCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22i-CMS165DENEXCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22j-CMS165NUMERCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-22j-CMS165NUMERCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-23a-CMS122Missing_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-23a-CMS122Missing_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-23b-CMS165Missing_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-23b-CMS165Missing_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24c-CMS165v9IncorrectDENOM_UUID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24c-CMS165v9IncorrectDENOM_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24d-CMS122v9IncorrectNUMERforPR_UUID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24d-CMS122v9IncorrectNUMERforPR_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24e-CMS122v9IncorrectNUMER_UUID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24e-CMS122v9IncorrectNUMER_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24f-CMS165v9IncorrectDENEX_UUID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-24f-CMS165v9IncorrectDENEX_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-25a-IncorrectQRDAIIIMsrSectionTempID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-25a-IncorrectQRDAIIIMsrSectionTempID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-25b-IncorrectCMSQRDAIIIMsrSecTempID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-25b-IncorrectCMSQRDAIIIMsrSecTempID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-28a-InvalidCMSEHRCertID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-28a-InvalidCMSEHRCertID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-28b-MissingCMSEHRCertID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-28b-MissingCMSEHRCertID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-28c-MultipleCMSEHRCertID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-28c-MultipleCMSEHRCertID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2a-NullNPI_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2a-NullNPI_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2b-NoNPISection_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2b-NoNPISection_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2c-NullNPI-2_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2c-NullNPI-2_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2d-NullTIN_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2d-NullTIN_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2e-MissingTIN_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2e-MissingTIN_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2f-MultiTINandNPISinglePerformer_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-2f-MultiTINandNPISinglePerformer_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-3a-NullCPC+ID_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-3a-NullCPC+ID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-3b-NoCPC+ID_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-3b-NoCPC+ID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4a-ImproperCPC+ID_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4a-ImproperCPC+ID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4b-ImproperCPC+ID-2_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4b-ImproperCPC+ID-2_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4c-ImproperCPC+ID-3_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4c-ImproperCPC+ID-3_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4d-LowerCaseCPC+ID_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-4d-LowerCaseCPC+ID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-5a-PracticeSiteAddressNotProvided_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-5a-PracticeSiteAddressNotProvided_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-6a-InvalidTIN_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-6a-InvalidTIN_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-6b-InvalidTIN-2_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-6b-InvalidTIN-2_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-6c-NullFlavorTIN_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-6c-NullFlavorTIN_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7a-ImproperNPIFormat_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7a-ImproperNPIFormat_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7b-ImproperNPIFormat-2_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7b-ImproperNPIFormat-2_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7c-ImproperNPIFormat-3_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7c-ImproperNPIFormat-3_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7d-ImproperNPIFormat-4_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7d-ImproperNPIFormat-4_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7e-NullFlavorNPI_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-7e-NullFlavorNPI_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-8a-NoQualityCategory_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/failure/CPCPLUS-8a-NoQualityCategory_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/pending/CPCPLUS-1g-MIPS_VIRTUALGROUP_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/pending/CPCPLUS-1g-MIPS_VIRTUALGROUP_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/pending/CPCPLUS-5c-PracticeSiteAddressBlank_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/pending/CPCPLUS-5c-PracticeSiteAddressBlank_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-11c-CMS122v9UpperCaseUUID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-11c-CMS122v9UpperCaseUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-11d-CMS165v9UpperCaseUUID_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-11d-CMS165v9UpperCaseUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-11e-CMS165v9LowerCaseUUID_06222021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-11e-CMS165v9LowerCaseUUID_06222021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-15a-CMS122ValidNA-PR_06292021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-15a-CMS122ValidNA-PR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1b-LowerCaseProgramName_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1b-LowerCaseProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1d-MixedCaseProgramName_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1d-MixedCaseProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1e-MIPS_INDIV_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1e-MIPS_INDIV_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1f-MIPS_GROUP_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-1f-MIPS_GROUP_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-23c-AdditionalMeasureReported_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-23c-AdditionalMeasureReported_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-24a-CMS122v9LowerCaseNUMERforPR_UUID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-24a-CMS122v9LowerCaseNUMERforPR_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-24b-CMS165v9LowercaseIPOP_UUID_06282021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-24b-CMS165v9LowercaseIPOP_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-5b-AddressProvided_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-5b-AddressProvided_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-5d-PracticeSiteAddressNullFlavor_06162021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/success/CPCPLUS-5d-PracticeSiteAddressNullFlavor_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/acceptance2021/warning/CPCPLUS-9a-IASectionAdded_06182021.xml
+++ b/converter/src/test/resources/cpc_plus/acceptance2021/warning/CPCPLUS-9a-IASectionAdded_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="6d603997-c839-476b-8af9-d4b8f7112ceb"/>
    <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
          displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus-2020-Updates-Failures.xml
+++ b/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus-2020-Updates-Failures.xml
@@ -4,7 +4,7 @@
 	<realmCode code="US" />
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
 	<title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus_2020-Alpha-Performance-Rate.xml
+++ b/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus_2020-Alpha-Performance-Rate.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus_2020-Error-PI-Section.xml
+++ b/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus_2020-Error-PI-Section.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus_2020-Invalid-Performance-Period-Dates.xml
+++ b/converter/src/test/resources/cpc_plus/failure/2020/CPCPlus_2020-Invalid-Performance-Period-Dates.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-15b-CMS165PerfDenomNotZero.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-15b-CMS165PerfDenomNotZero.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-16a-CMS122NumerGreaterPerfDenom.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-16a-CMS122NumerGreaterPerfDenom.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-17a-CMS122NumerGreaterDenom.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-17a-CMS122NumerGreaterDenom.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-2e-MissingTIN_03282019.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-2e-MissingTIN_03282019.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-2f-MissingNpi_03282019.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-2f-MissingNpi_03282019.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-6a-InvalidTIN_04152019.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-6a-InvalidTIN_04152019.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-7a-ImproperNPIFormat_04152019.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-7a-ImproperNPIFormat_04152019.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS-CMS122DenexGreaterDenomAndNegativePerfDenom.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS-CMS122DenexGreaterDenomAndNegativePerfDenom.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS_Performance_Rate_Number.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS_Performance_Rate_Number.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPLUS_Performance_Rate_Sample.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPLUS_Performance_Rate_Sample.xml
@@ -12,7 +12,7 @@ Description:
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS122v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS122v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS124v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS124v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS125v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS125v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS130v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS130v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS131v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS131v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS137v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS137v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS138v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS138v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS139v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS139v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS149v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS149v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS156v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS156v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS159v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS159v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS165v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS165v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS50v7IncUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMS50v7IncUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMSPrgrm_DiffCode_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_CMSPrgrm_DiffCode_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_IncNumofGroup1Measures_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_IncNumofGroup1Measures_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidAlphaNpi.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidAlphaNpi.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidAlphaTin.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidAlphaTin.xml
@@ -14,7 +14,7 @@ Description:
     <realmCode code="US"/>
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <id root="52de40bb-322b-4625-9c7c-0ad3bfe81941"/>
     <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
         displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidApmId.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidApmId.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidPerformancePeriod_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_InvalidPerformancePeriod_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_Measure_Section.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_Measure_Section.xml
@@ -3,7 +3,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
 	<code code="55184-6"
 		  codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_Multi_Perf_Rate_Numer_Greater_Than_Perf_Denom.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_Multi_Perf_Rate_Numer_Greater_Than_Perf_Denom.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_PracID_Null_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_PracID_Null_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_QualityWithDupNumOfDenomPops_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_QualityWithDupNumOfDenomPops_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_QualityWithIncNumOfNumerPops_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_QualityWithIncNumOfNumerPops_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithOnlyACI_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithOnlyACI_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithOnlyACIandIA_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithOnlyACIandIA_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithOnlyIA_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithOnlyIA_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_122_IPOPLessThanDenom_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_122_IPOPLessThanDenom_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_130_IPOPLessThanDenom_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_130_IPOPLessThanDenom_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_137OnlyOnePerfRateSampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_137OnlyOnePerfRateSampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_137_IncNumerator_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_137_IncNumerator_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_139_IncDenomUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_139_IncDenomUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_149_IncNumerUUID_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_149_IncNumerUUID_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_156OnlyOnePerfRate_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_156OnlyOnePerfRate_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_156_IncNumberator_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_156_IncNumberator_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_165NegativePerfRate_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_165NegativePerfRate_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_165_IncSuppData_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_165_IncSuppData_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
 	<code code="55184-6"
 		  codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_ExtraPopulationForCMS149_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_ExtraPopulationForCMS149_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_PerfRateNotPresent_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/failure/CPCPlus_WithQuality_PerfRateNotPresent_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/2020/CPCPlus_2020-Guid-Updates.xml
+++ b/converter/src/test/resources/cpc_plus/success/2020/CPCPlus_2020-Guid-Updates.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/2020/warnings/CPCPlus_2020-Warning-IA-Section.xml
+++ b/converter/src/test/resources/cpc_plus/success/2020/warnings/CPCPlus_2020-Warning-IA-Section.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPLUS_Performance_Rate_Sample.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPLUS_Performance_Rate_Sample.xml
@@ -12,7 +12,7 @@ Description:
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_AddressEx1_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_AddressEx1_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_CMSPrgrm_LowerCase_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_CMSPrgrm_LowerCase_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_CMSPrgrm_MixedCase_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_CMSPrgrm_MixedCase_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_CMSPrgrm_UpperCase_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_CMSPrgrm_UpperCase_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx1_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx1_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx2_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx2_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx3_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx3_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx4_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_StructurallyCorrectAddressEx4_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_WithQuality_159_PerfDenZero_PRNA_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_WithQuality_159_PerfDenZero_PRNA_SampleQRDA-III.xml
@@ -12,7 +12,7 @@ Description:
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_WithQuality_PRCMS122WithNullFlavor_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_WithQuality_PRCMS122WithNullFlavor_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/CPCPlus_WithQuality_SampleQRDA-III.xml
+++ b/converter/src/test/resources/cpc_plus/success/CPCPlus_WithQuality_SampleQRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/ComprehensivePrimaryCareSampleQRDA-III_SDE.xml
+++ b/converter/src/test/resources/cpc_plus/success/ComprehensivePrimaryCareSampleQRDA-III_SDE.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/cpc_plus/success/QRDAIII_CMS74_153_155_NonCPCPlusMsrs.xml
+++ b/converter/src/test/resources/cpc_plus/success/QRDAIII_CMS74_153_155_NonCPCPlusMsrs.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/fixtures/multiPerformanceRatePropMeasure.xml
+++ b/converter/src/test/resources/fixtures/multiPerformanceRatePropMeasure.xml
@@ -6,7 +6,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/fixtures/textInsensitiveQualityMeasureUuids.xml
+++ b/converter/src/test/resources/fixtures/textInsensitiveQualityMeasureUuids.xml
@@ -6,7 +6,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/AciMeasurePerformedGarbage.xml
+++ b/converter/src/test/resources/negative/AciMeasurePerformedGarbage.xml
@@ -30,7 +30,7 @@ CDA Header
 	<!-- QRDA Category III Report (QRDA III) -->
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
 	<!-- QRDA Category III Report - CMS EP -->
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<!-- SHALL contain exactly one [1..1] id (CONF:17236).  This id SHALL be a globally unique identifier for the document (CONF:17242). -->
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).

--- a/converter/src/test/resources/negative/angerClinicalDocumentValidations.xml
+++ b/converter/src/test/resources/negative/angerClinicalDocumentValidations.xml
@@ -7,7 +7,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
 	<title>Eligible Clinicians (EC) Meaningful Use Group Sample QRDA-III		(Informative)</title>

--- a/converter/src/test/resources/negative/angerMeasureDataValidations.xml
+++ b/converter/src/test/resources/negative/angerMeasureDataValidations.xml
@@ -6,7 +6,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/angerTheConverter.xml
+++ b/converter/src/test/resources/negative/angerTheConverter.xml
@@ -30,7 +30,7 @@ CDA Header
     <!-- QRDA Category III Report (QRDA III) -->
     <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
     <!-- QRDA Category III Report - CMS EP -->
-    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+    <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
     <!-- SHALL contain exactly one [1..1] id (CONF:17236).  This id SHALL be a globally unique identifier for the document (CONF:17242). -->
     <id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
     <!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).

--- a/converter/src/test/resources/negative/decimalPerfRateDenomZero.xml
+++ b/converter/src/test/resources/negative/decimalPerfRateDenomZero.xml
@@ -3,7 +3,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/iaSectionContainsWrongChild.xml
+++ b/converter/src/test/resources/negative/iaSectionContainsWrongChild.xml
@@ -8,7 +8,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/iaSectionMissingMeasures.xml
+++ b/converter/src/test/resources/negative/iaSectionMissingMeasures.xml
@@ -8,7 +8,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/iaSectionMissingReportingParameter.xml
+++ b/converter/src/test/resources/negative/iaSectionMissingReportingParameter.xml
@@ -8,7 +8,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/junk_in_quality_measure.xml
+++ b/converter/src/test/resources/negative/junk_in_quality_measure.xml
@@ -31,7 +31,7 @@ CDA Header
 	<!-- QRDA Category III Report (QRDA III) -->
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
 	<!-- QRDA Category III Report - CMS EP -->
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<!-- SHALL contain exactly one [1..1] id (CONF:17236).  This id SHALL be a globally unique identifier for the document (CONF:17242). -->
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).

--- a/converter/src/test/resources/negative/mipsDenominatorInitialPopulationFailure.xml
+++ b/converter/src/test/resources/negative/mipsDenominatorInitialPopulationFailure.xml
@@ -6,7 +6,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/mipsInvalidPIMeasureIds.xml
+++ b/converter/src/test/resources/negative/mipsInvalidPIMeasureIds.xml
@@ -7,7 +7,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/mipsInvalidPerformanceRateUuid.xml
+++ b/converter/src/test/resources/negative/mipsInvalidPerformanceRateUuid.xml
@@ -4,7 +4,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="26a42253-99f5-48e7-9274-b467c6c7f623" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>

--- a/converter/src/test/resources/negative/perfDenomAggCountMissing.xml
+++ b/converter/src/test/resources/negative/perfDenomAggCountMissing.xml
@@ -3,7 +3,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/perfRateDenomZero.xml
+++ b/converter/src/test/resources/negative/perfRateDenomZero.xml
@@ -3,7 +3,7 @@
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="D5E68223-5760-11E7-1256-09173F13E4C5"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/negative/tooManyErrors.xml
+++ b/converter/src/test/resources/negative/tooManyErrors.xml
@@ -12,7 +12,7 @@
   <!-- QRDA Category III template ID (this template ID differs from QRDA III comment only template ID). -->
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
   <!-- QRDA Category III Report - CMS V2 -->
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root='a0b51520-23d3-0137-59c4-000d3a380e5a'  />
 
 

--- a/converter/src/test/resources/negative/wrongSubPopulationsMeasure135.xml
+++ b/converter/src/test/resources/negative/wrongSubPopulationsMeasure135.xml
@@ -59,7 +59,7 @@ CDA Header
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-10a-ImproperPerformancePeriod_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-10a-ImproperPerformancePeriod_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-10b-ImproperPerformancePeriod-2_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-10b-ImproperPerformancePeriod-2_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-10c-NoPerformancePeriod_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-10c-NoPerformancePeriod_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-11a-CMS165v9IncorrectUUID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-11a-CMS165v9IncorrectUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-11b-CMS122v9IncorrectUUID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-11b-CMS122v9IncorrectUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-11c-CMS130v9IncorrectUUID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-11c-CMS130v9IncorrectUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-12a-CMS165Fail_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-12a-CMS165Fail_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-12b-CMS122Fail_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-12b-CMS122Fail_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-12c-CMS130Fail_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-12c-CMS130Fail_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13a-CMS122IPOPMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13a-CMS122IPOPMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13b-CMS122DENOMMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13b-CMS122DENOMMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13c-CMS122DENEXMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13c-CMS122DENEXMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13d-CMS122NUMERMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13d-CMS122NUMERMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13e-CMS165IPOPMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13e-CMS165IPOPMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13f-CMS165DENOMMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13f-CMS165DENOMMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13g-CMS165DENEXMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13g-CMS165DENEXMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13h-CMS165NUMERMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13h-CMS165NUMERMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13i-CMS130IPOPMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13i-CMS130IPOPMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13j-CMS130DENOMMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13j-CMS130DENOMMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13k-CMS130DENEXMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13k-CMS130DENEXMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13l-CMS130NUMERMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13l-CMS130NUMERMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13m-CMS122IPOPBlank_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-13m-CMS122IPOPBlank_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14a-CMS122PRMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14a-CMS122PRMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14b-CMS165PRNotTiedToNUMER_06222021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14b-CMS165PRNotTiedToNUMER_06222021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14c-CMS122TwoPR_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14c-CMS122TwoPR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14d-CMS165TwoPR_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14d-CMS165TwoPR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14e-CMS130PRMissing_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14e-CMS130PRMissing_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14f-CMS130PRNotTiedToNUMER_06222021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-14f-CMS130PRNotTiedToNUMER_06222021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15c-CMS165InvalidNA-PR_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15c-CMS165InvalidNA-PR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15d-CMS165PRLessThan0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15d-CMS165PRLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15e-CMS130PRGreaterThan1_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15e-CMS130PRGreaterThan1_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15f-CMS165DENOM0PR0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15f-CMS165DENOM0PR0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15g-CMS122PerfDENOM0PR0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-15g-CMS122PerfDENOM0PR0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-16a-CMS122NUMERGreaterPerfDENOM_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-16a-CMS122NUMERGreaterPerfDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-16b-CMS165NUMERGreaterPerfDENOM_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-16b-CMS165NUMERGreaterPerfDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-16c-CMS130NUMERGreaterPerfDENOM_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-16c-CMS130NUMERGreaterPerfDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-17a-CMS122DENEXGreaterDENOM_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-17a-CMS122DENEXGreaterDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-17b-CMS165DENEXGreaterDENOM_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-17b-CMS165DENEXGreaterDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-17c-CMS130DENEXGreaterDENOM_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-17c-CMS130DENEXGreaterDENOM_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-18b-IAandPISectionAdded_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-18b-IAandPISectionAdded_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-18c-PISectionAdded_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-18c-PISectionAdded_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-19a-CMS122DENOMLessThanIPOP_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-19a-CMS122DENOMLessThanIPOP_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-19b-CMS165DENOMGreaterthanIPOP_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-19b-CMS165DENOMGreaterthanIPOP_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-19c-CMS130DENOMGreaterthanIPOP_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-19c-CMS130DENOMGreaterthanIPOP_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-1a-ImproperProgramName_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-1a-ImproperProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-1c-IncorrectProgramName_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-1c-IncorrectProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20a-CMS122IPOPLessThan0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20a-CMS122IPOPLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20b-CMS122DENOMLessThan0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20b-CMS122DENOMLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20c-CMS165DENEXLessThan0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20c-CMS165DENEXLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20d-CMS130NUMERLessThan0_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20d-CMS130NUMERLessThan0_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20e-CMS165IPOPWrongTemplateID_06252021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20e-CMS165IPOPWrongTemplateID_06252021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20f-CMS122NUMERMissingTemplateID_06252021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20f-CMS122NUMERMissingTemplateID_06252021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20g-CMS130IPOPDecimal_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20g-CMS130IPOPDecimal_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20h-CMS165NUMERDecimal_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-20h-CMS165NUMERDecimal_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21a-CMS122IPOPNoSDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21a-CMS122IPOPNoSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21b-CMS122DENOMNoSexSDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21b-CMS122DENOMNoSexSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21c-CMS130DENEXNoRaceSDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21c-CMS130DENEXNoRaceSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21d-CMS165NUMERNoEthnicitySDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21d-CMS165NUMERNoEthnicitySDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21e-CMS165IPOPNoPayerSDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21e-CMS165IPOPNoPayerSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21f-CMS130DENOMNoMaleSDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21f-CMS130DENOMNoMaleSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21g-CMS165NUMERNoAsianSDE_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-21g-CMS165NUMERNoAsianSDE_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22a-CMS122ReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22a-CMS122ReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22b-CMS165ReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22b-CMS165ReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22c-CMS130ReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22c-CMS130ReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22d-CMS122IPOPReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22d-CMS122IPOPReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22e-CMS130DENOMReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22e-CMS130DENOMReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22f-CMS165DENEXReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22f-CMS165DENEXReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22g-CMS165NUMERReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22g-CMS165NUMERReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22h-CMS130IPOPCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22h-CMS130IPOPCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22i-CMS122DENOMCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22i-CMS122DENOMCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22j-CMS165DENEXCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22j-CMS165DENEXCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22k-CMS130NUMERCountReportedTwice_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-22k-CMS130NUMERCountReportedTwice_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-23a-CMS122Missing_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-23a-CMS122Missing_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-23b-CMS165Missing_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-23b-CMS165Missing_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-23c-CMS130Missing_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-23c-CMS130Missing_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24d-CMS165v9IncorrectDENOM_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24d-CMS165v9IncorrectDENOM_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24e-CMS122v9IncorrectNUMERforPR_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24e-CMS122v9IncorrectNUMERforPR_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24f-CMS122v9IncorrectNUMER_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24f-CMS122v9IncorrectNUMER_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24g-CMS165v9IncorrectDENEX_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24g-CMS165v9IncorrectDENEX_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24h-CMS130v9IncorrectIPOP_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-24h-CMS130v9IncorrectIPOP_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-25a-IncorrectQRDAIIIMsrSectionTempID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-25a-IncorrectQRDAIIIMsrSectionTempID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-25b-IncorrectCMSQRDAIIIMsrSecTempID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-25b-IncorrectCMSQRDAIIIMsrSecTempID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-28a-InvalidCMSEHRCertID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-28a-InvalidCMSEHRCertID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-28b-MissingCMSEHRCertID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-28b-MissingCMSEHRCertID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-28c-MultipleCMSEHRCertID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-28c-MultipleCMSEHRCertID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2a-NullNPI_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2a-NullNPI_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2b-NoNPISection_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2b-NoNPISection_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2c-NullNPI-2_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2c-NullNPI-2_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2d-NullTIN_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2d-NullTIN_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2e-MissingTIN_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2e-MissingTIN_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2f-MultiTINandNPISinglePerformer_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-2f-MultiTINandNPISinglePerformer_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-3a-NullPCFID_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-3a-NullPCFID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-3b-NoPCFID_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-3b-NoPCFID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4a-ImproperPCFID_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4a-ImproperPCFID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4b-ImproperPCFID-2_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4b-ImproperPCFID-2_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4c-ImproperPCFID-3_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4c-ImproperPCFID-3_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4d-LowerCasePCFID_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-4d-LowerCasePCFID_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-5a-PracticeSiteAddressNotProvided_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-5a-PracticeSiteAddressNotProvided_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-6a-InvalidTIN_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-6a-InvalidTIN_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-6b-InvalidTIN-2_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-6b-InvalidTIN-2_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-6c-NullFlavorTIN_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-6c-NullFlavorTIN_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7a-ImproperNPIFormat_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7a-ImproperNPIFormat_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7b-ImproperNPIFormat-2_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7b-ImproperNPIFormat-2_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7c-ImproperNPIFormat-3_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7c-ImproperNPIFormat-3_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7d-ImproperNPIFormat-4_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7d-ImproperNPIFormat-4_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7e-NullFlavorNPI_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-7e-NullFlavorNPI_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/failure/PCF-8a-NoQualityCategory_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/failure/PCF-8a-NoQualityCategory_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-11d-CMS122v9UpperCaseUUID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-11d-CMS122v9UpperCaseUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-11e-CMS165v9UpperCaseUUID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-11e-CMS165v9UpperCaseUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-11f-CMS130v9UpperCaseUUID_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-11f-CMS130v9UpperCaseUUID_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-11g-CMS165v9LowerCaseUUID_06222021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-11g-CMS165v9LowerCaseUUID_06222021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-15a-CMS122ValidNA-PR_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-15a-CMS122ValidNA-PR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-15b-CMS130ValidNA-PR_06292021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-15b-CMS130ValidNA-PR_06292021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-1b-LowerCaseProgramName_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-1b-LowerCaseProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-1d-MixedCaseProgramName_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-1d-MixedCaseProgramName_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-1e-MIPS_INDIV_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-1e-MIPS_INDIV_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-1f-MIPS_GROUP_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-1f-MIPS_GROUP_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-1g-MIPS_VIRTUALGROUP_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-1g-MIPS_VIRTUALGROUP_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-23d-AdditionalMeasureReported_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-23d-AdditionalMeasureReported_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-24a-CMS122v9LowerCaseNUMERforPR_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-24a-CMS122v9LowerCaseNUMERforPR_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-24b-CMS165v9LowercaseIPOP_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-24b-CMS165v9LowercaseIPOP_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-24c-CMS130v9LowerCaseDENOM_UUID_06282021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-24c-CMS130v9LowerCaseDENOM_UUID_06282021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-5b-AddressProvided_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-5b-AddressProvided_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-5c-PracticeSiteAddressBlank_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-5c-PracticeSiteAddressBlank_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/success/PCF-5d-PracticeSiteAddressNullFlavor_06162021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/success/PCF-5d-PracticeSiteAddressNullFlavor_06162021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/acceptance2021/warning/PCF-9a-IASectionAdded_06182021.xml
+++ b/converter/src/test/resources/pcf/acceptance2021/warning/PCF-9a-IASectionAdded_06182021.xml
@@ -6,7 +6,7 @@
    <realmCode code="US"/>
    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
    <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+   <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
    <id root="ad68c6aa-5e6a-41d1-afae-ba02a7303baa"/>
    <code code="55184-6"
          codeSystem="2.16.840.1.113883.6.1"

--- a/converter/src/test/resources/pcf/failure/2021/Y5_Negative_PCF_Sample_QRDA-III.xml
+++ b/converter/src/test/resources/pcf/failure/2021/Y5_Negative_PCF_Sample_QRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/pcf/success/2021/Y5_PCF_Sample_QRDA-III.xml
+++ b/converter/src/test/resources/pcf/success/2021/Y5_PCF_Sample_QRDA-III.xml
@@ -3,7 +3,7 @@
   <realmCode code="US" />
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
   <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
-  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
   <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
   <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
   <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>

--- a/converter/src/test/resources/valid-QRDA-III-abridged.xml
+++ b/converter/src/test/resources/valid-QRDA-III-abridged.xml
@@ -30,7 +30,7 @@ CDA Header
 	<!-- QRDA Category III Report (QRDA III) -->
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
 	<!-- QRDA Category III Report - CMS EP -->
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<!-- SHALL contain exactly one [1..1] id (CONF:17236).  This id SHALL be a globally unique identifier for the document (CONF:17242). -->
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<!-- SHALL contain exactly one [1..1] code (CodeSystem: LOINC 2.16.840.1.113883.6.1 STATIC) (CONF:17210).

--- a/qrda-files/valid-QRDA-III-latest.xml
+++ b/qrda-files/valid-QRDA-III-latest.xml
@@ -63,7 +63,7 @@ CDA Header
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
 	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
 	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
 		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>

--- a/sample-files/2022/App1-ApmEntity-Qrda-III.xml
+++ b/sample-files/2022/App1-ApmEntity-Qrda-III.xml
@@ -1,0 +1,3482 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US" />
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+  <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
+  <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>
+  <effectiveTime value="20170311061231" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" />
+  <languageCode code="en" />
+  <setId root="D5E68223-5760-11E7-1256-09173F13E4C5" />
+  <versionNumber value="1" />
+  <recordTarget>
+    <patientRole>
+      <id nullFlavor="NA" />
+    </patientRole>
+  </recordTarget>
+  <!--Device Author Example-->
+  <author>
+    <time value="20170311061231" />
+    <assignedAuthor>
+      <id root="D5E68225-5760-11E7-1256-09173F13E4C5" />
+      <assignedAuthoringDevice>
+        <softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+      </assignedAuthoringDevice>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <!--Person Author Example-->
+  <author>
+    <time value="20180311061231" />
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.4.6" extension="2567891421" assigningAuthorityName="NPI" />
+      <assignedPerson>
+        <name>
+          <given>Trevor</given>
+          <family>Phillips</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!--Program for which data is being submitted-->
+  <informationRecipient>
+    <intendedRecipient>
+      <id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_APMENTITY" />
+    </intendedRecipient>
+  </informationRecipient>
+  <legalAuthenticator>
+    <time value="20170312153222" />
+    <signatureCode code="S" />
+    <assignedEntity>
+      <id root="D5E68226-5760-11E7-1256-09173F13E4C5" />
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.4" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <participant typeCode="DEV">
+    <associatedEntity classCode="RGPR">
+      <id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX" />
+      <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    </associatedEntity>
+  </participant>
+  <!--Practice Site-->
+  <participant typeCode="LOC">
+    <associatedEntity classCode="SDLOC">
+      <id root="2.16.840.1.113883.3.249.5.1" extension="TestApmEntityId" assigningAuthorityName="CMS-CMMI" />
+      <code code="394730007" displayName="healthcare related organization" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <addr>
+        <streetAddressLine>123 Healthcare St</streetAddressLine>
+        <city>Norman</city>
+        <state>OK</state>
+        <postalCode>73019</postalCode>
+      </addr>
+    </associatedEntity>
+  </participant>
+  <!--Providers in Practice Site for which data is being submitted-->
+  <documentationOf typeCode="DOC">
+    <serviceEvent classCode="PCPR">
+      <effectiveTime>
+        <low value="20170101" />
+        <high value="20171231" />
+      </effectiveTime>
+      <performer typeCode="PRF">
+        <time>
+          <low value="20170101" />
+          <high value="20171231" />
+        </time>
+        <assignedEntity>
+          <representedOrganization>
+            <id root="2.16.840.1.113883.3.249.5.4" extension="TEST_APM" />
+            <name>Good Health Clinic</name>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <authorization>
+    <consent>
+      <id root="D5E68227-5760-11E7-1256-09173F13E4C5" />
+      <code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <statusCode code="completed" />
+    </consent>
+  </authorization>
+  <!--
+********************************************************
+CDA Body
+********************************************************
+-->
+  <component>
+    <structuredBody>
+      <!--
+********************************************************
+QRDA Category III Measure Section (CMS EP)
+********************************************************
+-->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01" />
+          <templateId root="2.16.840.1.113883.10.20.24.2.2" />
+          <templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01" />
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1" displayName="measure document" />
+          <title>Measure Section</title>
+          <!--Performance Period-->
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.17.3.8" />
+              <id root="D5E68228-5760-11E7-1256-09173F13E4C5" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters" />
+              <effectiveTime>
+                <low value="20220101" />
+                <high value="20221231" />
+              </effectiveTime>
+            </act>
+          </entry>
+          <!--Measure Entry for CMS122v8-->
+      		<entry>
+      			<organizer classCode="CLUSTER" moodCode="EVN">
+      				<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+      				<!-- Measure Reference Template -->
+      				<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+      				<!-- Measure Reference & Results Template -->
+      				<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+      				<!-- CMS Measure Reference & Results Template -->
+      				<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+      				<statusCode code="completed"/>
+      				<!--Measure Reference and Results-->
+      				<reference typeCode="REFR">
+      					<externalDocument classCode="DOC" moodCode="EVN">
+      						<id root="2.16.840.1.113883.4.738"
+      							extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
+      						<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+      							  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+      						<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+      					</externalDocument>
+      				</reference>
+      				<!--Performance Rate-->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+      						<!-- Performance Rate Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+      						<!-- Performance Rate for Proportion Measure Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+      						<!-- CMS Performance Rate for Proportion Measure Template -->
+      						<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+      							  codeSystemName="LOINC" displayName="Performance Rate"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="REAL" value=".888889"/>
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+      								<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="Numerator"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!--IPOP Population-->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--IPOP Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="1000"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6822A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6822B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6822C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6822D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6822E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6822F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68230-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68231-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68232-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68233-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68234-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68235-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+      						<!--IPOP Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!-- DENOM Population -->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--DENOM Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="1000"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68236-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68237-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68238-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68239-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6823D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6823E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6823F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68240-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68241-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+      						<!--DENOM Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!-- DENEX Population -->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--DENEX Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="100"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68267-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68268-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68269-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6826A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6826E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6826F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68270-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68271-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68272-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>c
+      						<!--DENEX Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      				<!-- NUMER Population -->
+      				<component>
+      					<observation classCode="OBS" moodCode="EVN">
+      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+      						<!-- Measure Data Template -->
+      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+      						<!-- CMS Measure Data Template -->
+      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+      							  codeSystemName="ActCode" displayName="Assertion"/>
+      						<statusCode code="completed"/>
+      						<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+      							   codeSystemName="ActCode"/>
+      						<!--NUMER Count-->
+      						<entryRelationship typeCode="SUBJ" inversionInd="true">
+      							<observation classCode="OBS" moodCode="EVN">
+      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+      									  codeSystemName="ActCode" displayName="rate aggregation"/>
+      								<statusCode code="completed"/>
+      								<value xsi:type="INT" value="800"/>
+      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+      											codeSystemName="ObservationMethod" displayName="Count"/>
+      							</observation>
+      						</entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68242-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68243-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68244-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68245-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68246-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68247-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68248-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68249-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6824D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+      						<!--NUMER Population ID from eCQM-->
+      						<reference typeCode="REFR">
+      							<externalObservation classCode="OBS" moodCode="EVN">
+      								<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+      							</externalObservation>
+      						</reference>
+      					</observation>
+      				</component>
+      			</organizer>
+      		</entry>
+          <!--Measure Entry for CMS165v7-->
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
+              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
+              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01" />
+              <id root="D5E68474-5760-11E7-1256-09173F13E4C5" />
+              <statusCode code="completed" />
+              <!--Measure Reference and Results-->
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab" />
+                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
+                  <text>Controlling High Blood Pressure</text>
+                </externalDocument>
+              </reference>
+              <!--Performance Rate-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Performance Rate" />
+                  <statusCode code="completed" />
+                  <value xsi:type="REAL" value=".888889" />
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748" />
+                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Numerator" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--IPOP Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--IPOP Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1000" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68475-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68476-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68477-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68478-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68479-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6847A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6847B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6847C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6847D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6847E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6847F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68480-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--IPOP Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="87338BA5-170B-4264-9E59-6A4A3A57C785" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENOM Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--DENOM Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="1000" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68481-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68482-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68483-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68484-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="500" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68485-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68486-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68487-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68488-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68489-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6848A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6848B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E6848C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="250" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--DENOM Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="B2E2AA67-26CD-48CB-9536-094F1D047149" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--DENEX Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--DENEX Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="100" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6848D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6848E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6848F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E68490-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="50" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68491-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68492-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68493-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68494-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68495-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68496-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68497-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E68498-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="25" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--DENEX Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="9B6EDB4C-A390-4833-A135-2A2AC6334126" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <!--NUMER Population-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
+                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
+                  <statusCode code="completed" />
+                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+                  <!--NUMER Count-->
+                  <entryRelationship typeCode="SUBJ" inversionInd="true">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                      <statusCode code="completed" />
+                      <value xsi:type="INT" value="800" />
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Male-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E68499-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Gender Supplemental Data Element - Female-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
+                      <id root="D5E6849A-5760-11E7-1256-09173F13E4C5" />
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6849B-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
+                      <id root="D5E6849C-5760-11E7-1256-09173F13E4C5" />
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="400" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Black or African American-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6849D-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - White-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6849E-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Asian-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E6849F-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E684A0-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Race Supplemental Data Element - Other Race-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
+                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="0" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicare-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A1-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Medicaid-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A2-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Private Health Insurance-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A3-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--Payer Supplemental Data Element - Other-->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
+                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
+                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+                      <id root="D5E684A4-5760-11E7-1256-09173F13E4C5" />
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20170101" />
+                        <high value="20171231" />
+                      </effectiveTime>
+                      <value xsi:type="CD" nullFlavor="OTH">
+                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
+                      </value>
+                      <!-- Count-->
+                      <entryRelationship typeCode="SUBJ" inversionInd="true">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
+                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
+                          <statusCode code="completed" />
+                          <value xsi:type="INT" value="200" />
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--NUMER Population ID from eMeasure-->
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748" />
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/sample-files/2022/App1-Group-QRDA-III.xml
+++ b/sample-files/2022/App1-Group-QRDA-III.xml
@@ -1,0 +1,4767 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
+********************************************************
+CDA Header
+********************************************************
+-->
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_GROUP"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+				<!-- NPI Not allowed-->
+				<!-- <id root="2.16.840.1.113883.4.6" extension="0777777777"/>-->
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+		<structuredBody>
+			<!--
+			********************************************************
+			QRDA Category III Measure Section - CMS (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- QRDA Category III Measure Section (V4) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+					<!-- QRDA Category III Measure Section - CMS (V2) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="measure section"/>
+					<title>Measure Section</title>
+					<text>
+						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Controlling High Blood Pressure</td>
+									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+									<td>40280381-51f0-825b-0152-22b98cff181a</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>:0.842105
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:50
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>30
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>10
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
+									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+									<td>40280381-51f0-825b-0152-229afff616ee</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.947368
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:900
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>598
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>50
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Documentation of Current Medications in the Medical Record</td>
+									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
+									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.816327
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exceptions</content>:20
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>12
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>8
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>18
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>5
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>2
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+
+						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Depression Utilization of the PHQ-9 Tool</td>
+									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
+									<td>40280381-503f-a1fc-0150-afe320c01761</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.860177
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:35
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:486
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.921052
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:700
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.962963
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:520
+							</item>
+						</list>
+					</text>
+
+					<!--Measure Entry for CMS165v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="87338BA5-170B-4264-9E59-6A4A3A57C785"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="B2E2AA67-26CD-48CB-9536-094F1D047149"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9B6EDB4C-A390-4833-A135-2A2AC6334126"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!--Measure Entry for CMS122v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Measure Reference Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<!-- Measure Reference & Results Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+							<!-- CMS Measure Reference & Results Template -->
+							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738"
+										extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<!-- Performance Rate Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<!-- Performance Rate for Proportion Measure Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+									<!-- CMS Performance Rate for Proportion Measure Template -->
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENOM Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENEX Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- NUMER Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20220101"/>
+								<high value="20221231"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+			<!--
+		  	********************************************************
+		  	Promoting Interoperability Section (V2)
+		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
+		  	********************************************************
+		  	-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Advancing Care Information Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>PI Measure Title</th>
+									<th>Measure Identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Provide Patient Access</td>
+									<td>PI_PEA_1</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Denominator:</content>800
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator:</content>600
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate:
+								</content>0.75
+							</item>
+						</list>
+						<list>
+							<item>
+								<content styleCode="Bold">Measure Answer (Yes/No):
+								</content>Yes
+							</item>
+						</list>
+					</text>
+					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
+					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.28"
+										extension="2017-06-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
+									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
+									<!-- PI measure title -->
+									<text>Provide Patient Access</text>
+								</externalDocument>
+							</reference>
+							<!-- Performance Rate for PI is optional -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Performance Rate templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.30"
+												extension="2016-09-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value="0.75"/>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.31"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Numerator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="600"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.32"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Denominator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20220201"/>
+								<high value="20220531"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!--
+			********************************************************
+			Improvement Activity Section (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Improvement Activity Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>Improvement Activity Name</th>
+									<th>Activity ID</th>
+									<th>Question Answer Code</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Collection and use of patient experience and satisfaction data on access</td>
+									<td>IA_EPA_3</td>
+									<td>Y</td>
+								</tr>
+
+								<tr>
+									<td>Care transition documentation practice improvements</td>
+									<td>IA_CC_10</td>
+									<td>Y</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
+					<!-- IA_EPA_3 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Collection and use of patient experience and satisfaction data on access</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- IA_CC_10 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33"
+										extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Care transition documentation practice improvements</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20220101"/>
+								<high value="20220430"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+		</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/sample-files/2022/App1-Indv-QRDA-III.xml
+++ b/sample-files/2022/App1-Indv-QRDA-III.xml
@@ -1,0 +1,4766 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
+********************************************************
+CDA Header
+********************************************************
+-->
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_INDIV"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+					<id root="2.16.840.1.113883.4.6" extension="0777777777"/>
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+		<structuredBody>
+			<!--
+			********************************************************
+			QRDA Category III Measure Section - CMS (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- QRDA Category III Measure Section (V4) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+					<!-- QRDA Category III Measure Section - CMS (V2) -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="measure section"/>
+					<title>Measure Section</title>
+					<text>
+						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Controlling High Blood Pressure</td>
+									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+									<td>40280381-51f0-825b-0152-22b98cff181a</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>:0.842105
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:50
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>30
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African American</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>20
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicare</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Medicaid</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health Insurance</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>10
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
+									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+									<td>40280381-51f0-825b-0152-229afff616ee</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.947368
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:950
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:900
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>598
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>50
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Documentation of Current Medications in the Medical Record</td>
+									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
+									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.816327
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exceptions</content>:20
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>12
+									</item>
+									<item>
+										<content styleCode="Bold">Gender - Female</content>8
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>18
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>15
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>2
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>10
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>3
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>5
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>2
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator</content>:1000
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>400
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>600
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>650
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>350
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:800
+								<list>
+									<item>
+										<content styleCode="Bold">Gender - Male</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Gender -
+											Female</content>500
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Not Hispanic or
+											Latino</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Ethnicity - Hispanic or
+											Latino</content>550
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Black or African
+											American</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - White</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Race - Asian</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Race - American Indian or Alaska
+											Native</content>0
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicare</content>300
+									</item>
+									<item>
+										<content styleCode="Bold">Payer -
+											Medicaid</content>200
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Private Health
+											Insurance</content>250
+									</item>
+									<item>
+										<content styleCode="Bold">Payer - Other</content>50
+									</item>
+								</list>
+							</item>
+						</list>
+
+
+						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>eMeasure Title</th>
+									<th>Version neutral identifier</th>
+									<th>Version specific identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Depression Utilization of the PHQ-9 Tool</td>
+									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
+									<td>40280381-503f-a1fc-0150-afe320c01761</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.860177
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:600
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:35
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:486
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.921052
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:800
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:700
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate</content>0.962963
+							</item>
+							<item>
+								<content styleCode="Bold">Initial Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Population</content>:580
+							</item>
+							<item>
+								<content styleCode="Bold">Denominator Exclusions</content>:40
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator</content>:520
+							</item>
+						</list>
+					</text>
+
+					<!--Measure Entry for CMS165v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
+							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Health Quality Measure Document"/>
+									<text>Controlling High Blood Pressure</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+										  displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="87338BA5-170B-4264-9E59-6A4A3A57C785"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENOM Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="B2E2AA67-26CD-48CB-9536-094F1D047149"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--DENEX Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="9B6EDB4C-A390-4833-A135-2A2AC6334126"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--NUMER Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+										  displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
+											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
+											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Race"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
+											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+												  displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<effectiveTime>
+												<low value="20170101"/>
+												<high value="20171231"/>
+											</effectiveTime>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eMeasure-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!--Measure Entry for CMS122v8-->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Measure Reference Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+							<!-- Measure Reference & Results Template -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
+							<!-- CMS Measure Reference & Results Template -->
+							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
+							<statusCode code="completed"/>
+							<!--Measure Reference and Results-->
+							<reference typeCode="REFR">
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<id root="2.16.840.1.113883.4.738"
+										extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
+									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
+									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
+								</externalDocument>
+							</reference>
+							<!--Performance Rate-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+									<!-- Performance Rate Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+									<!-- Performance Rate for Proportion Measure Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
+									<!-- CMS Performance Rate for Proportion Measure Template -->
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value=".888889"/>
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="Numerator"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!--IPOP Population-->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--IPOP Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--IPOP Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENOM Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENOM Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="1000"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="500"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="250"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENOM Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- DENEX Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--DENEX Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="100"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="50"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="25"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--DENEX Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+							<!-- NUMER Population -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+									<!-- Measure Data Template -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
+									<!-- CMS Measure Data Template -->
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+										   codeSystemName="ActCode"/>
+									<!--NUMER Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode" displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod" displayName="Count"/>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Male-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Gender Supplemental Data Element - Female-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.6"
+														extension="2016-09-01"/>
+											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
+											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
+												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2186-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Not Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.7"
+														extension="2016-09-01"/>
+											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
+											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Ethnicity"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2135-2"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Hispanic or Latino"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="400"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Black or African American-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2054-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Black or African American"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - White-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2106-3"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Asian-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2028-9"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="1002-5"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="American Indian or Alaska Native"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2076-8"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Native Hawaiian or Other Pacific Islander"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Race Supplemental Data Element - Other Race-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.8"
+														extension="2016-09-01"/>
+											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
+											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Race"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="2131-1"
+												   codeSystem="2.16.840.1.113883.6.238"
+												   codeSystemName="Race &amp; Ethnicity - CDC"
+												   displayName="Other Race"/>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="0"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicare-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Medicaid-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Private Health Insurance-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes"
+															 displayName="Private Health Insurance"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--Payer Supplemental Data Element - Other-->
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.9"
+														extension="2016-02-01"/>
+											<templateId root="2.16.840.1.113883.10.20.27.3.18"
+														extension="2018-05-01"/>
+											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
+											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+												  codeSystemName="LOINC" displayName="Payment Source"/>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" nullFlavor="OTH">
+												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
+															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
+											</value>
+											<!-- Count-->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+														  codeSystemName="ActCode" displayName="rate aggregation"/>
+													<statusCode code="completed"/>
+													<value xsi:type="INT" value="200"/>
+													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
+																codeSystemName="ObservationMethod" displayName="Count"/>
+												</observation>
+											</entryRelationship>
+										</observation>
+									</entryRelationship>
+									<!--NUMER Population ID from eCQM-->
+									<reference typeCode="REFR">
+										<externalObservation classCode="OBS" moodCode="EVN">
+											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
+										</externalObservation>
+									</reference>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20220101"/>
+								<high value="20221231"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+			<!--
+		  	********************************************************
+		  	Promoting Interoperability Section (V2)
+		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
+		  	********************************************************
+		  	-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Advancing Care Information Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>PI Measure Title</th>
+									<th>Measure Identifier</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Provide Patient Access</td>
+									<td>PI_PEA_1</td>
+								</tr>
+							</tbody>
+						</table>
+						<list>
+							<item>
+								<content styleCode="Bold">Denominator:</content>800
+							</item>
+							<item>
+								<content styleCode="Bold">Numerator:</content>600
+							</item>
+							<item>
+								<content styleCode="Bold">Performance Rate:
+								</content>0.75
+							</item>
+						</list>
+						<list>
+							<item>
+								<content styleCode="Bold">Measure Answer (Yes/No):
+								</content>Yes
+							</item>
+						</list>
+					</text>
+					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
+					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.28"
+										extension="2017-06-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
+									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
+									<!-- PI measure title -->
+									<text>Provide Patient Access</text>
+								</externalDocument>
+							</reference>
+							<!-- Performance Rate for PI is optional -->
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Performance Rate templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.30"
+												extension="2016-09-01"/>
+									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+										  codeSystemName="LOINC" displayName="Performance Rate"/>
+									<statusCode code="completed"/>
+									<value xsi:type="REAL" value="0.75"/>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.31"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="NUMER"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Numerator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="600"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.32"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="DENOM"
+										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+									<!-- Denominator Count-->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+												  codeSystemName="ActCode"
+												  displayName="rate aggregation"/>
+											<statusCode code="completed"/>
+											<value xsi:type="INT" value="800"/>
+											<methodCode code="COUNT"
+														codeSystem="2.16.840.1.113883.5.84"
+														codeSystemName="ObservationMethod"
+														displayName="Count"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20220201"/>
+								<high value="20220531"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!--
+			********************************************************
+			Improvement Activity Section (V2)
+			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
+			********************************************************
+			-->
+			<component>
+				<section>
+					<!-- Measure Section -->
+					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+					<!-- Improvement Activity Section templateId -->
+					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
+					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
+						  displayName="Measure Section"/>
+					<title>Measure Section</title>
+					<text>
+						<table border="1" width="100%">
+							<thead>
+								<tr>
+									<th>Improvement Activity Name</th>
+									<th>Activity ID</th>
+									<th>Question Answer Code</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Collection and use of patient experience and satisfaction data on access</td>
+									<td>IA_EPA_3</td>
+									<td>Y</td>
+								</tr>
+
+								<tr>
+									<td>Care transition documentation practice improvements</td>
+									<td>IA_CC_10</td>
+									<td>Y</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
+					<!-- IA_EPA_3 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Collection and use of patient experience and satisfaction data on access</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- IA_CC_10 -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Implied template Measure Reference templateId -->
+							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+							<!-- Improvement Activity Performed Reference and Results templateId -->
+							<templateId root="2.16.840.1.113883.10.20.27.3.33"
+										extension="2016-09-01"/>
+							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
+							<statusCode code="completed"/>
+							<reference typeCode="REFR">
+								<!-- Reference to a particular PI measure's unique identifier. -->
+								<externalDocument classCode="DOC" moodCode="EVN">
+									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
+									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
+									<!-- Improvement activity narrative text (for reference) -->
+									<text>Care transition documentation practice improvements</text>
+								</externalDocument>
+							</reference>
+							<component>
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Measure Performed templateId -->
+									<templateId root="2.16.840.1.113883.10.20.27.3.27"
+												extension="2016-09-01"/>
+									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+										  codeSystemName="ActCode" displayName="Assertion"/>
+									<statusCode code="completed"/>
+									<value xsi:type="CD" code="Y" displayName="Yes"
+										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
+										   codeSystem="2.16.840.1.113883.12.136"/>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+					<!-- Reporting Parameters Act -->
+					<entry typeCode="DRIV">
+						<act classCode="ACT" moodCode="EVN">
+							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
+							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+								  displayName="Observation Parameters"/>
+							<effectiveTime>
+								<low value="20220101"/>
+								<high value="20220430"/>
+							</effectiveTime>
+						</act>
+					</entry>
+				</section>
+			</component>
+		</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/valid-QRDA-III-latest-qpp.json
+++ b/valid-QRDA-III-latest-qpp.json
@@ -1,0 +1,62 @@
+{
+  "performanceYear" : 2022,
+  "entityType" : "individual",
+  "nationalProviderIdentifier" : "0777777777",
+  "taxpayerIdentificationNumber" : "000777777",
+  "measurementSets" : [ {
+    "category" : "quality",
+    "submissionMethod" : "electronicHealthRecord",
+    "measurements" : [ {
+      "measureId" : "236",
+      "value" : {
+        "isEndToEndReported" : true,
+        "performanceMet" : 800,
+        "eligiblePopulationExclusion" : 100,
+        "performanceNotMet" : 100,
+        "eligiblePopulation" : 1000
+      }
+    }, {
+      "measureId" : "001",
+      "value" : {
+        "isEndToEndReported" : true,
+        "performanceMet" : 800,
+        "eligiblePopulationExclusion" : 100,
+        "performanceNotMet" : 100,
+        "eligiblePopulation" : 1000
+      }
+    } ],
+    "programName" : "mips",
+    "performanceStart" : "2022-01-01",
+    "performanceEnd" : "2022-12-31",
+    "source" : "qrda3"
+  }, {
+    "category" : "pi",
+    "submissionMethod" : "electronicHealthRecord",
+    "cehrtId" : "XX15EXXXXXXXXXX",
+    "measurements" : [ {
+      "measureId" : "PI_PEA_1",
+      "value" : {
+        "numerator" : 600,
+        "denominator" : 800
+      }
+    } ],
+    "programName" : "mips",
+    "performanceStart" : "2022-02-01",
+    "performanceEnd" : "2022-05-31",
+    "source" : "qrda3"
+  }, {
+    "category" : "ia",
+    "submissionMethod" : "electronicHealthRecord",
+    "measurements" : [ {
+      "measureId" : "IA_EPA_3",
+      "value" : true
+    }, {
+      "measureId" : "IA_CC_10",
+      "value" : true
+    } ],
+    "programName" : "mips",
+    "performanceStart" : "2022-01-01",
+    "performanceEnd" : "2022-04-30",
+    "source" : "qrda3"
+  } ]
+}


### PR DESCRIPTION
### Information
- Updates the Clinical Document Template ID Extension to '2021-07-01'
- Updates Tests and Test Files to use the new extension

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
