### PR TITLE
QPPSF-10587: Remove unnecessary dependency

### DIFF
--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -33,6 +33,12 @@
 			<groupId>gov.cms.qpp.conversion</groupId>
 			<artifactId>rest-api</artifactId>
 			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-beans</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>gov.cms.qpp.conversion</groupId>


### PR DESCRIPTION
### Information
- Adds a filter to the test-coverage pom to ignore spring-bean v5.2.2.RELEASE
   - This dependency was not being used but was added by maven transient dependencies.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
