### PR TITLE
QPPSF-11183- log retention period set for CloudWatch and S3

### DIFF
--- a/infrastructure/terraform/modules/ecs.tf
+++ b/infrastructure/terraform/modules/ecs.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_service" "conversion-tool-service" {
 
 resource "aws_cloudwatch_log_group" "conversion-tool" {
   name              = "/qppsf/conversion-tool-${var.environment}"
-  retention_in_days = 30
+  retention_in_days = 365
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "cw-kinesis-subscription-filter" {

--- a/infrastructure/terraform/modules/s3.tf
+++ b/infrastructure/terraform/modules/s3.tf
@@ -22,6 +22,11 @@ resource "aws_s3_bucket" "log_bucket" {
       days          = 120
       storage_class = "GLACIER"
     }
+
+    expiration {
+      days                         = 365
+      expired_object_delete_marker = true
+    }
   }
 
   lifecycle {

--- a/infrastructure/terraform/modules/s3.tf
+++ b/infrastructure/terraform/modules/s3.tf
@@ -14,12 +14,12 @@ resource "aws_s3_bucket" "log_bucket" {
     enabled = true
 
     transition {
-      days          = 90
+      days          = 60
       storage_class = "STANDARD_IA"
     }
 
     transition {
-      days          = 120
+      days          = 90
       storage_class = "GLACIER"
     }
 


### PR DESCRIPTION
### Information
- Fixes #_.
QPPSF-11183

As part of [QPPPM-2442] archiving strategy discussions we identified that the log files can be archived after 365 days. 
AU-11 Audit Record Retention (High, Moderate, Low)
The organization retains audit records for ninety (90) days and archive old records for one (1) year to provide support for after-the-fact investigations of security incidents and to meet regulatory and CMS information retention requirements

### Changes proposed in this PR:
- *Change Cloudwatch Log Retention period to 365 days and Cloudwatch *
- *Update s3 lifecycle to remove objects after year*


### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
