### PR TITLE
QPPSF-11741: APP1 CEHRT Identifier fix

### DIFF
--- a/commons/src/main/resources/measures-data.json
+++ b/commons/src/main/resources/measures-data.json
@@ -4772,9 +4772,11 @@
     "isRegistryMeasure": false,
     "isRiskAdjusted": false,
     "icdImpacted": [],
-    "isClinicalGuidelineChanged": false,
+    "isClinicalGuidelineChanged": true,
     "isIcdImpacted": false,
-    "clinicalGuidelineChanged": [],
+    "clinicalGuidelineChanged": [
+      "registry"
+    ],
     "metricType": "multiPerformanceRate",
     "allowedPrograms": [
       "mips",
@@ -10434,7 +10436,7 @@
     "isClinicalGuidelineChanged": false,
     "isIcdImpacted": false,
     "clinicalGuidelineChanged": [],
-    "metricType": "singlePerformanceRate",
+    "metricType": "nonProportion",
     "allowedPrograms": [
       "mips",
       "pcf"
@@ -10463,7 +10465,7 @@
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "firstPerformanceYear": 2022,
     "lastPerformanceYear": null,
-    "isInverse": false,
+    "isInverse": true,
     "category": "quality",
     "isRegistryMeasure": false,
     "isRiskAdjusted": false,
@@ -17301,9 +17303,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IRIS23",
@@ -18093,9 +18093,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS12",
@@ -18158,9 +18156,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS13",
@@ -18223,9 +18219,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS14",
@@ -18288,9 +18282,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS16",
@@ -18353,9 +18345,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS17",
@@ -18418,9 +18408,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS18",
@@ -18483,9 +18471,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS19",
@@ -18548,9 +18534,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS20",
@@ -18613,9 +18597,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "KEET01",

--- a/converter/src/main/java/gov/cms/qpp/conversion/encode/PiSectionEncoder.java
+++ b/converter/src/main/java/gov/cms/qpp/conversion/encode/PiSectionEncoder.java
@@ -53,7 +53,8 @@ public class PiSectionEncoder extends QppOutputEncoder {
 	private void encodeTopLevelValues(JsonWrapper wrapper, Node node) {
 		wrapper.put("category", node.getValue("category"));
 		wrapper.put(SUBMISSION_METHOD, "electronicHealthRecord");
-		if (TemplateId.PI_SECTION_V2 == node.getType() && Program.isMips(node.getParent())) {
+		Node topLevelParent = node.getParent();
+		if (TemplateId.PI_SECTION_V2 == node.getType() && (Program.isMips(topLevelParent) || Program.isApp(topLevelParent))) {
 			wrapper.put(ClinicalDocumentDecoder.CEHRT, node.getParent().getValue(ClinicalDocumentDecoder.CEHRT));
 		}
 	}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/PiSectionRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/PiSectionRoundTripTest.java
@@ -14,6 +14,7 @@ import gov.cms.qpp.conversion.model.error.Detail;
 import gov.cms.qpp.conversion.model.error.ProblemCode;
 import gov.cms.qpp.conversion.model.error.TransformException;
 import gov.cms.qpp.conversion.model.error.correspondence.DetailsErrorEquals;
+import gov.cms.qpp.conversion.util.JsonHelper;
 import gov.cms.qpp.conversion.xml.XmlException;
 import gov.cms.qpp.conversion.xml.XmlUtils;
 import java.io.BufferedWriter;
@@ -22,6 +23,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.jayway.jsonpath.TypeRef;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -30,6 +33,13 @@ class PiSectionRoundTripTest {
 
 	private static final Path PI_RESTRICTED_MEASURES =
 		Paths.get("src/test/resources/negative/mipsInvalidPIMeasureIds.xml");
+	private static final Path APP1_APM_ENTITY_CEHRT =
+		Paths.get("src/test/resources/app/2022/App1-ApmEntity-Qrda-III.xml");
+	private static final Path APP1_GROUP_CEHRT =
+		Paths.get("src/test/resources/app/2022/App1-Group-QRDA-III.xml");
+	private static final Path APP1_INDIVIDUAL_CEHRT =
+		Paths.get("src/test/resources/app/2022/App1-Indv-QRDA-III.xml");
+
 
 	@Test
 	void parseSparsePiSectionAsNode() throws XmlException {
@@ -173,6 +183,75 @@ class PiSectionRoundTripTest {
 		}
 		assertThat(details).comparingElementsUsing(DetailsErrorEquals.INSTANCE)
 			.contains(ProblemCode.PI_RESTRICTED_MEASURES);
+	}
+
+	@Test
+	void testAppApmCehrtIsEncoded() {
+		Converter converter = new Converter(new PathSource(APP1_APM_ENTITY_CEHRT));
+		AllErrors errors = null;
+		List<Detail> warnings = null;
+		JsonWrapper qppWrapper = null;
+
+
+		List<Detail> details = new ArrayList<>();
+		try {
+			qppWrapper = converter.transform();
+		} catch (TransformException failure) {
+			errors = failure.getDetails();
+			warnings = failure.getConversionReport().getWarnings();
+		}
+
+		assertThat(errors).isNull();
+		assertThat(warnings).isNull();
+		List<String> cehrtIdList = JsonHelper.readJsonAtJsonPath(qppWrapper.toString(),
+			"$.measurementSets[?(@.category=='pi')].cehrtId", new TypeRef<List<String>>() { });
+		assertThat(cehrtIdList.get(0)).isEqualTo("XX15EXXXXXXXXXX");
+	}
+
+	@Test
+	void testAppGroupCehrtIsEncoded() {
+		Converter converter = new Converter(new PathSource(APP1_GROUP_CEHRT));
+		AllErrors errors = null;
+		List<Detail> warnings = null;
+		JsonWrapper qppWrapper = null;
+
+
+		List<Detail> details = new ArrayList<>();
+		try {
+			qppWrapper = converter.transform();
+		} catch (TransformException failure) {
+			errors = failure.getDetails();
+			warnings = failure.getConversionReport().getWarnings();
+		}
+
+		assertThat(errors).isNull();
+		assertThat(warnings).isNull();
+		List<String> cehrtIdList = JsonHelper.readJsonAtJsonPath(qppWrapper.toString(),
+			"$.measurementSets[?(@.category=='pi')].cehrtId", new TypeRef<List<String>>() { });
+		assertThat(cehrtIdList.get(0)).isEqualTo("XX15EXXXXXXXXXX");
+	}
+
+	@Test
+	void testAppIndividualCehrtIsEncoded() {
+		Converter converter = new Converter(new PathSource(APP1_INDIVIDUAL_CEHRT));
+		AllErrors errors = null;
+		List<Detail> warnings = null;
+		JsonWrapper qppWrapper = null;
+
+
+		List<Detail> details = new ArrayList<>();
+		try {
+			qppWrapper = converter.transform();
+		} catch (TransformException failure) {
+			errors = failure.getDetails();
+			warnings = failure.getConversionReport().getWarnings();
+		}
+
+		assertThat(errors).isNull();
+		assertThat(warnings).isNull();
+		List<String> cehrtIdList = JsonHelper.readJsonAtJsonPath(qppWrapper.toString(),
+			"$.measurementSets[?(@.category=='pi')].cehrtId", new TypeRef<List<String>>() { });
+		assertThat(cehrtIdList.get(0)).isEqualTo("XX15EXXXXXXXXXX");
 	}
 
 	private void assertAciSectionHasSingleQedNode(Node aciSectionNode) {

--- a/converter/src/test/resources/app/2022/App1-ApmEntity-Qrda-III.xml
+++ b/converter/src/test/resources/app/2022/App1-ApmEntity-Qrda-III.xml
@@ -1,0 +1,7607 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US" />
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01" />
+  <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+  <id root="D5E68223-5760-11E7-1256-09173F13E4C5" />
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report" />
+  <title>Comprehensive Primary Care Plus (CPC+) Sample QRDA-III Report</title>
+  <effectiveTime value="20170311061231" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" />
+  <languageCode code="en" />
+  <setId root="D5E68223-5760-11E7-1256-09173F13E4C5" />
+  <versionNumber value="1" />
+  <recordTarget>
+    <patientRole>
+      <id nullFlavor="NA" />
+    </patientRole>
+  </recordTarget>
+  <!--Device Author Example-->
+  <author>
+    <time value="20170311061231" />
+    <assignedAuthor>
+      <id root="D5E68225-5760-11E7-1256-09173F13E4C5" />
+      <assignedAuthoringDevice>
+        <softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+      </assignedAuthoringDevice>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <!--Person Author Example-->
+  <author>
+    <time value="20180311061231" />
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.4.6" extension="2567891421" assigningAuthorityName="NPI" />
+      <assignedPerson>
+        <name>
+          <given>Trevor</given>
+          <family>Phillips</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!--Program for which data is being submitted-->
+  <informationRecipient>
+    <intendedRecipient>
+      <id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_APMENTITY" />
+    </intendedRecipient>
+  </informationRecipient>
+  <legalAuthenticator>
+    <time value="20170312153222" />
+    <signatureCode code="S" />
+    <assignedEntity>
+      <id root="D5E68226-5760-11E7-1256-09173F13E4C5" />
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.4" extension="223344" />
+        <name>Good Health Clinic</name>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <participant typeCode="DEV">
+    <associatedEntity classCode="RGPR">
+      <id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX" />
+      <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    </associatedEntity>
+  </participant>
+  <!--Practice Site-->
+  <participant typeCode="LOC">
+    <associatedEntity classCode="SDLOC">
+      <id root="2.16.840.1.113883.3.249.5.1" extension="TestApmEntityId" assigningAuthorityName="CMS-CMMI" />
+      <code code="394730007" displayName="healthcare related organization" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <addr>
+        <streetAddressLine>123 Healthcare St</streetAddressLine>
+        <city>Norman</city>
+        <state>OK</state>
+        <postalCode>73019</postalCode>
+      </addr>
+    </associatedEntity>
+  </participant>
+  <!--Providers in Practice Site for which data is being submitted-->
+  <documentationOf typeCode="DOC">
+    <serviceEvent classCode="PCPR">
+      <effectiveTime>
+        <low value="20170101" />
+        <high value="20171231" />
+      </effectiveTime>
+      <performer typeCode="PRF">
+        <time>
+          <low value="20170101" />
+          <high value="20171231" />
+        </time>
+        <assignedEntity>
+          <representedOrganization>
+            <id root="2.16.840.1.113883.3.249.5.4" extension="TEST_APM" />
+            <name>Good Health Clinic</name>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <authorization>
+    <consent>
+      <id root="D5E68227-5760-11E7-1256-09173F13E4C5" />
+      <code code="425691002" displayName="consent given for electronic record sharing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <statusCode code="completed" />
+    </consent>
+  </authorization>
+  <component>
+      <structuredBody>
+          <component>
+              <section>
+                  <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+                  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+                  <templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
+                  <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+                  <title>Measure section</title>
+                  <text>
+                      <content>eMeasure Entries</content>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Reporting Parameter</th>
+                                  <th>Value</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Reporting period</td>
+                                  <td>Jan 1, 2022 - Dec 31, 2022</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table border="1" width="100%">
+                          <colgroup>
+                              <col width="30%"/>
+                              <col width="25%"/>
+                              <col width="5%"/>
+                              <col width="5%"/>
+                              <col width="25%"/>
+                          </colgroup>
+                          <thead>
+                              <tr>
+                                  <th>eMeasure Title</th>
+                                  <th>Version Neutral ID</th>
+                                  <th>eMeasure Version Number</th>
+                                  <th>NQF Measure Number</th>
+                                  <th>Version Specific ID</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</td>
+                                  <td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+                                  <td>10.0.000</td>
+                                  <td/>
+                                  <td>2c928082-74c2-3313-0174-c60bd07b02a6</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <content>Member of Measure Set: NONE - eMeasure
+                          ID:f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</content>
+                      <list>
+                          <item>Initial Patient Population:
+                                              52890<list><item>Sex<list><item>Female:
+                                              27982</item><item>Male:
+                                  24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1466</item><item>Not Hispanic or Latino:
+                                              50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              20800</item><item>Medicaid: 8033</item><item>Private
+                                              Health Insurance: 22443</item><item>Other:
+                                              1614</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 135</item><item>Asian:
+                                              1187</item><item>Black or African American:
+                                              10540</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 77</item><item>White:
+                                              38959</item><item>Other Race:
+                                      1201</item></list></item></list></item>
+                          <item>Denominator: 52890<list><item>Sex<list><item>Female:
+                                              27982</item><item>Male:
+                                  24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1466</item><item>Not Hispanic or Latino:
+                                              50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              20800</item><item>Medicaid: 8033</item><item>Private
+                                              Health Insurance: 22443</item><item>Other:
+                                              1614</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 135</item><item>Asian:
+                                              1187</item><item>Black or African American:
+                                              10540</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 77</item><item>White:
+                                              38959</item><item>Other Race:
+                                      1201</item></list></item></list></item>
+                          <item>Numerator: 16515<list><item>Sex<list><item>Female:
+                                              8959</item><item>Male:
+                                  7511</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 512</item><item>Not Hispanic or Latino:
+                                              15602</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              5621</item><item>Medicaid: 3471</item><item>Private
+                                              Health Insurance: 6808</item><item>Other:
+                                          615</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 33</item><item>Asian:
+                                              271</item><item>Black or African American:
+                                              3610</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 35</item><item>White:
+                                              11845</item><item>Other Race:
+                                      413</item></list></item></list></item>
+                          <item>Performance Rate: .336026</item>
+                          <item>Denominator Exclusions: 3742<list><item>Sex<list><item>Female:
+                                              1926</item><item>Male:
+                                  1804</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 36</item><item>Not Hispanic or Latino:
+                                              3639</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              3338</item><item>Medicaid: 117</item><item>Private
+                                              Health Insurance: 247</item><item>Other:
+                                          40</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 8</item><item>Asian:
+                                              19</item><item>Black or African American:
+                                              669</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 2</item><item>White:
+                                              2972</item><item>Other Race:
+                                  37</item></list></item></list></item>
+                      </list>
+                      <table border="1" width="100%">
+                          <colgroup>
+                              <col width="30%"/>
+                              <col width="25%"/>
+                              <col width="5%"/>
+                              <col width="5%"/>
+                              <col width="25%"/>
+                          </colgroup>
+                          <thead>
+                              <tr>
+                                  <th>eMeasure Title</th>
+                                  <th>Version Neutral ID</th>
+                                  <th>eMeasure Version Number</th>
+                                  <th>NQF Measure Number</th>
+                                  <th>Version Specific ID</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Controlling High Blood Pressure</td>
+                                  <td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+                                  <td>10.0.000</td>
+                                  <td/>
+                                  <td>2c928082-7505-caf9-0175-2382d1bd06b1</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <content>Member of Measure Set: NONE - eMeasure
+                          ID:abdc37cc-bac6-4156-9b91-d1be2c8b7268</content>
+                      <list>
+                          <item>Initial Patient Population:
+                                              137515<list><item>Sex<list><item>Female:
+                                              75071</item><item>Male:
+                                  62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 2322</item><item>Not Hispanic or Latino:
+                                              132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              63996</item><item>Medicaid:
+                                              15536</item><item>Private Health Insurance:
+                                              53791</item><item>Other:
+                                  4192</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 259</item><item>Asian:
+                                              2192</item><item>Black or African American:
+                                              24323</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 136</item><item>White:
+                                              106905</item><item>Other Race:
+                                      1963</item></list></item></list></item>
+                          <item>Denominator: 137515<list><item>Sex<list><item>Female:
+                                              75071</item><item>Male:
+                                  62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 2322</item><item>Not Hispanic or Latino:
+                                              132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              63996</item><item>Medicaid:
+                                              15536</item><item>Private Health Insurance:
+                                              53791</item><item>Other:
+                                  4192</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 259</item><item>Asian:
+                                              2192</item><item>Black or African American:
+                                              24323</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 136</item><item>White:
+                                              106905</item><item>Other Race:
+                                      1963</item></list></item></list></item>
+                          <item>Numerator: 79062<list><item>Sex<list><item>Female:
+                                              43441</item><item>Male:
+                                  35441</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1373</item><item>Not Hispanic or Latino:
+                                              76145</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              32876</item><item>Medicaid: 8805</item><item>Private
+                                              Health Insurance: 34866</item><item>Other:
+                                              2515</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 143</item><item>Asian:
+                                              1442</item><item>Black or African American:
+                                              12388</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 79</item><item>White:
+                                              62938</item><item>Other Race:
+                                      1102</item></list></item></list></item>
+                          <item>Performance Rate: .663806</item>
+                          <item>Denominator Exclusions: 18411<list><item>Sex<list><item>Female:
+                                              10945</item><item>Male:
+                                  7418</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 229</item><item>Not Hispanic or Latino:
+                                              17848</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              15125</item><item>Medicaid: 1362</item><item>Private
+                                              Health Insurance: 1728</item><item>Other:
+                                          196</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 38</item><item>Asian:
+                                              177</item><item>Black or African American:
+                                              3322</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 9</item><item>White:
+                                              14499</item><item>Other Race:
+                                      194</item></list></item></list></item>
+                      </list>
+                      <table border="1" width="100%">
+                          <colgroup>
+                              <col width="30%"/>
+                              <col width="25%"/>
+                              <col width="5%"/>
+                              <col width="5%"/>
+                              <col width="25%"/>
+                          </colgroup>
+                          <thead>
+                              <tr>
+                                  <th>eMeasure Title</th>
+                                  <th>Version Neutral ID</th>
+                                  <th>eMeasure Version Number</th>
+                                  <th>NQF Measure Number</th>
+                                  <th>Version Specific ID</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Preventive Care and Screening: Screening for Depression and
+                                      Follow-Up Plan</td>
+                                  <td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
+                                  <td>11.0.000</td>
+                                  <td/>
+                                  <td>2c928082-7505-caf9-0175-1e6f57410551</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <content>Member of Measure Set: PREVENTIVE CARE AND SCREENING - eMeasure
+                          ID:9a031e24-3d9b-11e1-8634-00237d5bf174</content>
+                      <list>
+                          <item>Initial Patient Population:
+                                              470376<list><item>Sex<list><item>Female:
+                                              287905</item><item>Male:
+                                  181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 14065</item><item>Not Hispanic or Latino:
+                                              446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              114944</item><item>Medicaid:
+                                              82205</item><item>Private Health Insurance:
+                                              253927</item><item>Other:
+                                  19298</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 822</item><item>Asian:
+                                              11314</item><item>Black or African American:
+                                              71638</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 610</item><item>White:
+                                              364169</item><item>Other Race:
+                                      13343</item></list></item></list></item>
+                          <item>Denominator: 470376<list><item>Sex<list><item>Female:
+                                              287905</item><item>Male:
+                                  181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 14065</item><item>Not Hispanic or Latino:
+                                              446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              114944</item><item>Medicaid:
+                                              82205</item><item>Private Health Insurance:
+                                              253927</item><item>Other:
+                                  19298</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 822</item><item>Asian:
+                                              11314</item><item>Black or African American:
+                                              71638</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 610</item><item>White:
+                                              364169</item><item>Other Race:
+                                      13343</item></list></item></list></item>
+                          <item>Numerator: 54746<list><item>Sex<list><item>Female:
+                                              27933</item><item>Male:
+                                  26716</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1354</item><item>Not Hispanic or Latino:
+                                              52341</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              21893</item><item>Medicaid: 4526</item><item>Private
+                                              Health Insurance: 26530</item><item>Other:
+                                              1797</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 94</item><item>Asian:
+                                              2252</item><item>Black or African American:
+                                              8405</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 76</item><item>White:
+                                              41717</item><item>Other Race:
+                                      1323</item></list></item></list></item>
+                          <item>Performance Rate: .17507</item>
+                          <item>Denominator Exclusions: 157128<list><item>Sex<list><item>Female:
+                                              114970</item><item>Male:
+                                  41822</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 3781</item><item>Not Hispanic or Latino:
+                                              150919</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              43328</item><item>Medicaid:
+                                              33374</item><item>Private Health Insurance:
+                                              74673</item><item>Other:
+                                  5752</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 282</item><item>Asian:
+                                              1360</item><item>Black or African American:
+                                              20705</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 131</item><item>White:
+                                              129643</item><item>Other Race:
+                                      3340</item></list></item></list></item>
+                          <item>Denominator Exceptions: 538<list><item>Sex<list><item>Female:
+                                              402</item><item>Male:
+                                  135</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 20</item><item>Not Hispanic or Latino:
+                                              499</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              152</item><item>Medicaid: 58</item><item>Private
+                                              Health Insurance: 303</item><item>Other:
+                                          25</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 0</item><item>Asian:
+                                              26</item><item>Black or African American:
+                                              97</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 0</item><item>White: 377</item><item>Other
+                                              Race: 18</item></list></item></list></item>
+                      </list>
+                  </text>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+                          <templateId extension="2019-05-01"
+                              root="2.16.840.1.113883.10.20.27.3.17"/>
+                          <id root="72B98C12-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="2c928082-74c2-3313-0174-c60bd07b02a6"
+                                      root="2.16.840.1.113883.4.738"/>
+                                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Health Quality Measure Document"
+                                      codeSystemName="LOINC"/>
+                                  <text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;
+                                      9%)</text>
+                                  <setId root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+                              </externalDocument>
+                          </reference>
+                          <reference typeCode="REFR">
+                              <externalObservation>
+                                  <id root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+                                  <code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Measure Set" codeSystemName="LOINC"/>
+                                  <text>NONE</text>
+                              </externalObservation>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.14"/>
+                                  <templateId extension="2018-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.25"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".336026"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <reference typeCode="REFR">
+                                      <externalObservation classCode="OBS" moodCode="EVN">
+                                          <id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+                                          <code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="Numerator"
+                                              codeSystemName="ObservationValue"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="IPOP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="initial population"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="52890"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="27982"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24770"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1466"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="50374"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="135"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1187"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="10540"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="77"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="38959"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1201"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20800"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8033"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="22443"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1614"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="D0F9A8EF-6C52-429A-A522-B568269EF39A"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="52890"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="27982"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24770"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1466"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="50374"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="135"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1187"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="10540"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="77"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="38959"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1201"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20800"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8033"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="22443"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1614"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="0A5B121A-16A0-41A1-8749-58BD992813C1"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEX"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exclusions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="3742"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1926"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1804"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="36"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3639"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="19"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="669"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2972"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="37"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3338"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="117"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="247"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="40"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="F4F7D899-682A-43D0-9506-75C0D7C08A76"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="16515"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8959"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="7511"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="512"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15602"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="33"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="271"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3610"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="35"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="11845"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="413"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="5621"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3471"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="6808"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="615"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+                          <templateId extension="2019-05-01"
+                              root="2.16.840.1.113883.10.20.27.3.17"/>
+                          <id root="72BDD61E-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="2c928082-7505-caf9-0175-2382d1bd06b1"
+                                      root="2.16.840.1.113883.4.738"/>
+                                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Health Quality Measure Document"
+                                      codeSystemName="LOINC"/>
+                                  <text>Controlling High Blood Pressure</text>
+                                  <setId root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+                              </externalDocument>
+                          </reference>
+                          <reference typeCode="REFR">
+                              <externalObservation>
+                                  <id root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+                                  <code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Measure Set" codeSystemName="LOINC"/>
+                                  <text>NONE</text>
+                              </externalObservation>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.14"/>
+                                  <templateId extension="2018-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.25"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".663806"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <reference typeCode="REFR">
+                                      <externalObservation classCode="OBS" moodCode="EVN">
+                                          <id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+                                          <code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="Numerator"
+                                              codeSystemName="ObservationValue"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="IPOP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="initial population"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="137515"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="75071"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="62118"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2322"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="132459"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="259"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24323"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="136"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="106905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1963"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="63996"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15536"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="53791"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="4192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="947E37E4-7BC7-4BF0-985F-D8A3F83140D6"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="137515"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="75071"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="62118"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2322"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="132459"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="259"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24323"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="136"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="106905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1963"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="63996"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15536"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="53791"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="4192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="98174296-AE1D-4245-A8B3-C690B00ADD72"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEX"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exclusions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="18411"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="10945"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="7418"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="229"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="17848"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="38"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="177"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3322"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="9"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="14499"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="194"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15125"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1362"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1728"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="196"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="B1176EC6-38FD-4134-865F-65D69C056518"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="79062"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="43441"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="35441"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1373"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="76145"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="143"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1442"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="12388"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="79"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="62938"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1102"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="32876"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8805"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="34866"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2515"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+                          <templateId extension="2019-05-01"
+                              root="2.16.840.1.113883.10.20.27.3.17"/>
+                          <id root="72C21C92-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="2c928082-7505-caf9-0175-1e6f57410551"
+                                      root="2.16.840.1.113883.4.738"/>
+                                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Health Quality Measure Document"
+                                      codeSystemName="LOINC"/>
+                                  <text>Preventive Care and Screening: Screening for Depression
+                                      and Follow-Up Plan</text>
+                                  <setId root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+                              </externalDocument>
+                          </reference>
+                          <reference typeCode="REFR">
+                              <externalObservation>
+                                  <id root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+                                  <code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Measure Set" codeSystemName="LOINC"/>
+                                  <text>PREVENTIVE CARE AND SCREENING</text>
+                              </externalObservation>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.14"/>
+                                  <templateId extension="2018-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.25"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".17507"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <reference typeCode="REFR">
+                                      <externalObservation classCode="OBS" moodCode="EVN">
+                                          <id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+                                          <code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="Numerator"
+                                              codeSystemName="ObservationValue"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="IPOP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="initial population"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="470376"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="287905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="181639"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="14065"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="446425"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="822"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="11314"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="71638"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="610"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="364169"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="13343"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="114944"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="82205"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="253927"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="19298"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="DD0526C9-DAB8-46C7-B169-ECD268E8E291"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="470376"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="287905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="181639"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="14065"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="446425"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="822"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="11314"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="71638"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="610"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="364169"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="13343"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="114944"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="82205"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="253927"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="19298"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="EBB00435-8DB2-4958-90B2-AC0FA76A5281"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEX"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exclusions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="157128"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="114970"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="41822"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3781"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="150919"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="282"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1360"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20705"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="131"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="129643"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3340"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="43328"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="33374"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="74673"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="5752"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="F6DBBAC9-8089-432A-8DE2-BF19F9BED2AA"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEXCEP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exceptions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="538"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="402"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="135"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="499"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="0"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="26"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="97"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="0"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="377"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="18"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="152"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="58"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="303"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="25"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="7B8F391D-444D-4872-BEEC-1F59F4AB5ABF"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="54746"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="27933"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="26716"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1354"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="52341"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="94"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2252"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8405"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="76"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="41717"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1323"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="21893"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="4526"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="26530"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1797"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+                          <id root="72C77D2C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+                              displayName="Observation Parameters"/>
+                          <effectiveTime>
+                              <low value="20220101"/>
+                              <high value="20221231"/>
+                          </effectiveTime>
+                      </act>
+                  </entry>
+              </section>
+          </component>
+          <component>
+              <section>
+                  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.4"/>
+                  <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+                  <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+                  <title>Measure section</title>
+                  <text>
+                      <content>Improvement Activity Entries</content>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Reporting Parameter</th>
+                                  <th>Value</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Reporting period</td>
+                                  <td>Sep 27, 2022 - Dec 25, 2022</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Improvement Activity Title</th>
+                                  <th>Improvement Activity ID</th>
+                                  <th>Details</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Engagement of patients through implementation of
+                                      improvements in patient portal</td>
+                                  <td>IA_BE_4</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Engagement of patients, family and caregivers in developing
+                                      a plan of care</td>
+                                  <td>IA_BE_15</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Implementation of improvements that contribute to more
+                                      timely communication of test results</td>
+                                  <td>IA_CC_2</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Practice improvements for bilateral exchange of patient
+                                      information</td>
+                                  <td>IA_CC_13</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+                                      Who Have Real-Time Access to Patient's Medical Record</td>
+                                  <td>IA_EPA_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </text>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7C7B4-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_BE_4" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Engagement of patients through implementation of
+                                      improvements in patient portal</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7D63C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_BE_15" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Engagement of patients, family and caregivers in
+                                      developing a plan of care</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7E438-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_CC_2" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Implementation of improvements that contribute to more
+                                      timely communication of test results</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7F216-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_CC_13" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Practice improvements for bilateral exchange of patient
+                                      information</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7FF4A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_EPA_1" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+                                      Who Have Real-Time Access to Patient's Medical Record</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+                          <id root="72C80E0E-AE3D-11ED-A1C0-640339ACF087"/>
+                          <code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+                              displayName="Observation Parameters"/>
+                          <effectiveTime>
+                              <low value="20220927"/>
+                              <high value="20221225"/>
+                          </effectiveTime>
+                      </act>
+                  </entry>
+              </section>
+          </component>
+          <component>
+              <section>
+                  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.5"/>
+                  <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+                  <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+                  <title>Measure section</title>
+                  <text>
+                      <content>Promoting Interoperability Entries</content>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Reporting Parameter</th>
+                                  <th>Value</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Reporting period</td>
+                                  <td>Sep 27, 2022 - Dec 25, 2022</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Promoting Interoperability Measure Title</th>
+                                  <th>Promoting Interoperability Measure ID</th>
+                                  <th>Details</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>E-Prescribing</td>
+                                  <td>PI_EP_1</td>
+                                  <td>
+                                      <list>
+                                          <item>Performance Rate: .987514</item>
+                                          <item>Numerator: 752879</item>
+                                          <item>Denominator: 762398</item>
+                                      </list>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>Patient Electronic Access (Provided Within 4 Business
+                                      Days)</td>
+                                  <td>PI_PEA_1</td>
+                                  <td>
+                                      <list>
+                                          <item>Performance Rate: .97764</item>
+                                          <item>Numerator: 277373</item>
+                                          <item>Denominator: 283717</item>
+                                      </list>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>Protect Patient Health Information</td>
+                                  <td>PI_PPHI_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Query of Prescription Drug Monitoring Program</td>
+                                  <td>PI_EP_2</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Health Information Exchange (HIE) Bi-Directional
+                                      Exchange</td>
+                                  <td>PI_HIE_5</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Safety Assurance Factors for EHR Resilience Guides</td>
+                                  <td>PI_PPHI_2</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Immunization Registry Reporting</td>
+                                  <td>PI_PHCDRR_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Case Reporting</td>
+                                  <td>PI_PHCDRR_3</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Public Health Registry Reporting</td>
+                                  <td>PI_PHCDRR_4</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Clinical Data Registry Reporting</td>
+                                  <td>PI_PHCDRR_5</td>
+                                  <td>Measure Performed: No</td>
+                              </tr>
+                              <tr>
+                                  <td>Prevention of Information Blocking Attestation</td>
+                                  <td>PI_INFBLO_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>ONC-ACB Surveillance Attestation</td>
+                                  <td>PI_ONCACB_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>ONC Direct Review Attestation</td>
+                                  <td>PI_ONCDIR_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </text>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2017-06-01"
+                              root="2.16.840.1.113883.10.20.27.3.28"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C85436-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_EP_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>E-Prescribing</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".987514"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.31"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="752879"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.32"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="762398"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2017-06-01"
+                              root="2.16.840.1.113883.10.20.27.3.28"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C87E02-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PEA_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Patient Electronic Access (Provided Within 4 Business
+                                      Days)</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".97764"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.31"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="277373"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.32"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="283717"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8A5F8-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PPHI_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Protect Patient Health Information</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8B444-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_EP_2" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Query of Prescription Drug Monitoring Program</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8C33A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_HIE_5" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Health Information Exchange (HIE) Bi-Directional
+                                      Exchange</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8D17C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PPHI_2" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Safety Assurance Factors for EHR Resilience Guides</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8E02C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Immunization Registry Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8EE64-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_3" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Case Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8FC6A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_4" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Public Health Registry Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C90ACA-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_5" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Clinical Data Registry Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="N"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="No"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C91876-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_INFBLO_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Prevention of Information Blocking Attestation</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C92618-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_ONCACB_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>ONC-ACB Surveillance Attestation</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C93428-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_ONCDIR_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>ONC Direct Review Attestation</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+                          <id root="72C9430A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+                              displayName="Observation Parameters"/>
+                          <effectiveTime>
+                              <low value="20220927"/>
+                              <high value="20221225"/>
+                          </effectiveTime>
+                      </act>
+                  </entry>
+              </section>
+          </component>
+      </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/converter/src/test/resources/app/2022/App1-Group-QRDA-III.xml
+++ b/converter/src/test/resources/app/2022/App1-Group-QRDA-III.xml
@@ -1,0 +1,7671 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
+********************************************************
+CDA Header
+********************************************************
+-->
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_GROUP"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+				<!-- NPI Not allowed-->
+				<!-- <id root="2.16.840.1.113883.4.6" extension="0777777777"/>-->
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+			<structuredBody>
+					<component>
+							<section>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+									<templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>eMeasure Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Jan 1, 2022 - Dec 31, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</td>
+																	<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-74c2-3313-0174-c60bd07b02a6</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</content>
+											<list>
+													<item>Initial Patient Population:
+																							52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Denominator: 52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Numerator: 16515<list><item>Sex<list><item>Female:
+																							8959</item><item>Male:
+																	7511</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 512</item><item>Not Hispanic or Latino:
+																							15602</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							5621</item><item>Medicaid: 3471</item><item>Private
+																							Health Insurance: 6808</item><item>Other:
+																					615</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 33</item><item>Asian:
+																							271</item><item>Black or African American:
+																							3610</item><item>Native Hawaiian or Other Pacific
+																							Islander: 35</item><item>White:
+																							11845</item><item>Other Race:
+																			413</item></list></item></list></item>
+													<item>Performance Rate: .336026</item>
+													<item>Denominator Exclusions: 3742<list><item>Sex<list><item>Female:
+																							1926</item><item>Male:
+																	1804</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 36</item><item>Not Hispanic or Latino:
+																							3639</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							3338</item><item>Medicaid: 117</item><item>Private
+																							Health Insurance: 247</item><item>Other:
+																					40</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 8</item><item>Asian:
+																							19</item><item>Black or African American:
+																							669</item><item>Native Hawaiian or Other Pacific
+																							Islander: 2</item><item>White:
+																							2972</item><item>Other Race:
+																	37</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Controlling High Blood Pressure</td>
+																	<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-2382d1bd06b1</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:abdc37cc-bac6-4156-9b91-d1be2c8b7268</content>
+											<list>
+													<item>Initial Patient Population:
+																							137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Denominator: 137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Numerator: 79062<list><item>Sex<list><item>Female:
+																							43441</item><item>Male:
+																	35441</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1373</item><item>Not Hispanic or Latino:
+																							76145</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							32876</item><item>Medicaid: 8805</item><item>Private
+																							Health Insurance: 34866</item><item>Other:
+																							2515</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 143</item><item>Asian:
+																							1442</item><item>Black or African American:
+																							12388</item><item>Native Hawaiian or Other Pacific
+																							Islander: 79</item><item>White:
+																							62938</item><item>Other Race:
+																			1102</item></list></item></list></item>
+													<item>Performance Rate: .663806</item>
+													<item>Denominator Exclusions: 18411<list><item>Sex<list><item>Female:
+																							10945</item><item>Male:
+																	7418</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 229</item><item>Not Hispanic or Latino:
+																							17848</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							15125</item><item>Medicaid: 1362</item><item>Private
+																							Health Insurance: 1728</item><item>Other:
+																					196</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 38</item><item>Asian:
+																							177</item><item>Black or African American:
+																							3322</item><item>Native Hawaiian or Other Pacific
+																							Islander: 9</item><item>White:
+																							14499</item><item>Other Race:
+																			194</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Preventive Care and Screening: Screening for Depression and
+																			Follow-Up Plan</td>
+																	<td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
+																	<td>11.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-1e6f57410551</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: PREVENTIVE CARE AND SCREENING - eMeasure
+													ID:9a031e24-3d9b-11e1-8634-00237d5bf174</content>
+											<list>
+													<item>Initial Patient Population:
+																							470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Denominator: 470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Numerator: 54746<list><item>Sex<list><item>Female:
+																							27933</item><item>Male:
+																	26716</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1354</item><item>Not Hispanic or Latino:
+																							52341</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							21893</item><item>Medicaid: 4526</item><item>Private
+																							Health Insurance: 26530</item><item>Other:
+																							1797</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 94</item><item>Asian:
+																							2252</item><item>Black or African American:
+																							8405</item><item>Native Hawaiian or Other Pacific
+																							Islander: 76</item><item>White:
+																							41717</item><item>Other Race:
+																			1323</item></list></item></list></item>
+													<item>Performance Rate: .17507</item>
+													<item>Denominator Exclusions: 157128<list><item>Sex<list><item>Female:
+																							114970</item><item>Male:
+																	41822</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 3781</item><item>Not Hispanic or Latino:
+																							150919</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							43328</item><item>Medicaid:
+																							33374</item><item>Private Health Insurance:
+																							74673</item><item>Other:
+																	5752</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 282</item><item>Asian:
+																							1360</item><item>Black or African American:
+																							20705</item><item>Native Hawaiian or Other Pacific
+																							Islander: 131</item><item>White:
+																							129643</item><item>Other Race:
+																			3340</item></list></item></list></item>
+													<item>Denominator Exceptions: 538<list><item>Sex<list><item>Female:
+																							402</item><item>Male:
+																	135</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 20</item><item>Not Hispanic or Latino:
+																							499</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							152</item><item>Medicaid: 58</item><item>Private
+																							Health Insurance: 303</item><item>Other:
+																					25</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 0</item><item>Asian:
+																							26</item><item>Black or African American:
+																							97</item><item>Native Hawaiian or Other Pacific
+																							Islander: 0</item><item>White: 377</item><item>Other
+																							Race: 18</item></list></item></list></item>
+											</list>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72B98C12-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-74c2-3313-0174-c60bd07b02a6"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;
+																			9%)</text>
+																	<setId root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".336026"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="D0F9A8EF-6C52-429A-A522-B568269EF39A"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0A5B121A-16A0-41A1-8749-58BD992813C1"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="3742"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1926"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1804"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="36"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="669"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2972"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="37"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3338"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="117"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="247"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="40"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F4F7D899-682A-43D0-9506-75C0D7C08A76"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="16515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7511"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="512"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15602"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="271"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11845"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="413"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5621"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3471"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="6808"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="615"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72BDD61E-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-2382d1bd06b1"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Controlling High Blood Pressure</text>
+																	<setId root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".663806"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="947E37E4-7BC7-4BF0-985F-D8A3F83140D6"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="98174296-AE1D-4245-A8B3-C690B00ADD72"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="18411"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10945"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7418"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="229"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="17848"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="177"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="9"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="194"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15125"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1362"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1728"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="196"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="B1176EC6-38FD-4134-865F-65D69C056518"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="79062"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1373"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76145"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="143"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1442"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="12388"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="79"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62938"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1102"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="32876"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8805"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="34866"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2515"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72C21C92-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-1e6f57410551"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Preventive Care and Screening: Screening for Depression
+																			and Follow-Up Plan</text>
+																	<setId root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>PREVENTIVE CARE AND SCREENING</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".17507"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DD0526C9-DAB8-46C7-B169-ECD268E8E291"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="EBB00435-8DB2-4958-90B2-AC0FA76A5281"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="157128"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114970"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3781"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="150919"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="282"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1360"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20705"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="131"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="129643"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3340"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43328"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="74673"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5752"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F6DBBAC9-8089-432A-8DE2-BF19F9BED2AA"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEXCEP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exceptions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="538"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="402"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="97"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="377"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="18"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="152"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="58"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="303"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="25"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="7B8F391D-444D-4872-BEEC-1F59F4AB5ABF"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="54746"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27933"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26716"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1354"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="52341"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="94"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2252"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8405"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41717"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="21893"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4526"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26530"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1797"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C77D2C-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220101"/>
+															<high value="20221231"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.4"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Improvement Activity Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Improvement Activity Title</th>
+																	<th>Improvement Activity ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Engagement of patients through implementation of
+																			improvements in patient portal</td>
+																	<td>IA_BE_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Engagement of patients, family and caregivers in developing
+																			a plan of care</td>
+																	<td>IA_BE_15</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Implementation of improvements that contribute to more
+																			timely communication of test results</td>
+																	<td>IA_CC_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Practice improvements for bilateral exchange of patient
+																			information</td>
+																	<td>IA_CC_13</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</td>
+																	<td>IA_EPA_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7C7B4-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_4" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients through implementation of
+																			improvements in patient portal</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7D63C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_15" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients, family and caregivers in
+																			developing a plan of care</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7E438-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_2" root="2.16.840.1.113883.3.7034"/>
+																	<text>Implementation of improvements that contribute to more
+																			timely communication of test results</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7F216-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_13" root="2.16.840.1.113883.3.7034"/>
+																	<text>Practice improvements for bilateral exchange of patient
+																			information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7FF4A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_EPA_1" root="2.16.840.1.113883.3.7034"/>
+																	<text>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C80E0E-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.5"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Promoting Interoperability Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Promoting Interoperability Measure Title</th>
+																	<th>Promoting Interoperability Measure ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>E-Prescribing</td>
+																	<td>PI_EP_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .987514</item>
+																					<item>Numerator: 752879</item>
+																					<item>Denominator: 762398</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Patient Electronic Access (Provided Within 4 Business
+																			Days)</td>
+																	<td>PI_PEA_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .97764</item>
+																					<item>Numerator: 277373</item>
+																					<item>Denominator: 283717</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Protect Patient Health Information</td>
+																	<td>PI_PPHI_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Query of Prescription Drug Monitoring Program</td>
+																	<td>PI_EP_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</td>
+																	<td>PI_HIE_5</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Safety Assurance Factors for EHR Resilience Guides</td>
+																	<td>PI_PPHI_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Immunization Registry Reporting</td>
+																	<td>PI_PHCDRR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Case Reporting</td>
+																	<td>PI_PHCDRR_3</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Public Health Registry Reporting</td>
+																	<td>PI_PHCDRR_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Clinical Data Registry Reporting</td>
+																	<td>PI_PHCDRR_5</td>
+																	<td>Measure Performed: No</td>
+															</tr>
+															<tr>
+																	<td>Prevention of Information Blocking Attestation</td>
+																	<td>PI_INFBLO_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC-ACB Surveillance Attestation</td>
+																	<td>PI_ONCACB_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC Direct Review Attestation</td>
+																	<td>PI_ONCDIR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C85436-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>E-Prescribing</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".987514"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="752879"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="762398"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C87E02-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PEA_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Patient Electronic Access (Provided Within 4 Business
+																			Days)</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".97764"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="277373"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="283717"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8A5F8-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Protect Patient Health Information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8B444-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Query of Prescription Drug Monitoring Program</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8C33A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_HIE_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8D17C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Safety Assurance Factors for EHR Resilience Guides</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8E02C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Immunization Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8EE64-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_3" root="2.16.840.1.113883.3.7031"/>
+																	<text>Case Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8FC6A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_4" root="2.16.840.1.113883.3.7031"/>
+																	<text>Public Health Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C90ACA-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Clinical Data Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="N"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="No"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C91876-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_INFBLO_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Prevention of Information Blocking Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C92618-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCACB_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC-ACB Surveillance Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C93428-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCDIR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC Direct Review Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C9430A-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+			</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/converter/src/test/resources/app/2022/App1-Indv-QRDA-III.xml
+++ b/converter/src/test/resources/app/2022/App1-Indv-QRDA-III.xml
@@ -1,0 +1,7670 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="qrda.xsl"?>
+<!--
+Sample 2020 QRDA-III file for QPP Conversion.
+The file contains data for the following measures and improvement activities:
+*Quality*
+1.  CMS165v8/NQF0018/Quality ID:236
+    Measure title: Controlling High Blood Pressure
+    A high priority measure
+
+2.  CMS122v8/NQF0018/Quality ID:001
+    Measure Title: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)
+	An outcome Measure
+
+3.  CMS68v9/NQF0419/Quality ID:130
+    Measure Title: Diabetes: Documentation of Current Medications in the Medical Record
+	A high priority measure
+
+4. CMS160v8/NQF0712/Quality ID: 371
+	Measure Title: Depression Utilization of the PHQ-9 Tool
+	This measure contains 3 sub-populations
+
+*Promoting Interoperability*
+1.  PI_PEA_1
+	Provide Patient Access
+	Reporting Metric: Numerator/Denominator
+
+*Improvement Activity*
+1. 	IA_EPA_3
+	Collection and use of patient experience and satisfaction data on access
+2.  IA_CC_10
+	Care transition documentation practice improvements
+-->
+<!-- Update 05/12/2017
+Add sample data for CMS160v5
+-->
+<!-- Update 05/17/2017
+Changed the CMS Program Name to "MIPS_INDIV", which indicates MIPS individual reporting.
+For individual reporting, TIN and NPI are required.
+Removed comments from the header.
+-->
+<!-- Update 06/09/2017
+Updated to conform to the 2017 CMS QRDA III IG for EC and EP Programs based on HL7 QRDA-III STU R2.1
+Summary of the main changes:
+1. Removed the Reporting Parameters Section - CMS
+2. Added Reporting Parameters Act template under QRDA Category III Measure Section - CMS (V2)
+3. Added Reporting Parameters Act template under Advancing Care Information Section (V2)
+4. Added Reporting Parameters Act template under Improvement Activity Section (V2)
+-->
+<!--Update 07/21/2020
+1. Update EHR CMS UUID's to use 2020 UUID's
+2. Remove CMS160 as it no longer exists.
+-->
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="urn:hl7-org:v3 ../CDA_Schema_Files/infrastructure/cda/CDA_SDTC.xsd"
+				  xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc">
+	<!--
+********************************************************
+CDA Header
+********************************************************
+-->
+	<realmCode code="US"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+	<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+	<id root="26a42253-99f5-48e7-9274-b467c6c7f623"/>
+	<code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+		  displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+	<title>2017 Eligible Clinicians (EC) and Eligible Professionals (EP) Sample QRDA-III</title>
+	<effectiveTime value="20170311061231"/>
+	<confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+	<languageCode code="en"/>
+	<setId root="ae23711d-783d-4f5e-b942-4084b467848b"/>
+	<versionNumber value="1"/>
+	<recordTarget>
+		<patientRole>
+			<id nullFlavor="NA"/>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="20170131061231"/>
+		<assignedAuthor>
+			<id root="3d0a32f3-5164-4a6f-8922-de3badf83de4"/>
+			<assignedAuthoringDevice>
+				<softwareName>SOME Data Aggregator Transform Tool AS00016dev</softwareName>
+			</assignedAuthoringDevice>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<author>
+		<time value="20170131114411"/>
+		<assignedAuthor>
+			<id root="2.16.840.1.113883.4.6" extension="1234567893" assigningAuthorityName="NPI"/>
+			<assignedPerson>
+				<name>
+					<given>Trevor</given>
+					<family>Philips</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<informationRecipient>
+		<intendedRecipient>
+			<id root="2.16.840.1.113883.3.249.7" extension="MIPS_APP1_INDIV"/>
+		</intendedRecipient>
+	</informationRecipient>
+	<legalAuthenticator>
+		<time value="20170312153222"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5" extension="223344"/>
+				<name>Good Health Clinic</name>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<participant typeCode="LOC">
+		<associatedEntity classCode="SDLOC">
+			<id root="2.16.840.1.113883.3.249.5.1"
+				extension="AR000000"
+				assigningAuthorityName="CMS-CMMI"/>
+			<id root="2.16.840.1.113883.3.2074.1" extension="XX15EXXXXXXXXXX"/>
+			<code code="394730007"
+				  displayName="healthcare related organization"
+				  codeSystem="2.16.840.1.113883.6.96"
+				  codeSystemName="SNOMED-CT"/>
+			<addr>
+				<streetAddressLine>123 Healthcare St</streetAddressLine>
+				<city>Norman</city>
+				<state>OK</state>
+				<postalCode>73019</postalCode>
+			</addr>
+		</associatedEntity>
+	</participant>
+	<documentationOf typeCode="DOC">
+		<serviceEvent classCode="PCPR">
+			<effectiveTime>
+				<low value="20170101"/>
+				<high value="20171231"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<time>
+					<low value="20170101"/>
+					<high value="20171231"/>
+				</time>
+				<assignedEntity>
+					<id root="2.16.840.1.113883.4.6" extension="0777777777"/>
+					<representedOrganization>
+						<id root="2.16.840.1.113883.4.2" extension="000777777"/>
+						<name>Good Health Clinic</name>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	<authorization>
+		<consent>
+			<id root="da2c8a32-d76b-4c37-a1f4-137485387650"/>
+			<code code="425691002" displayName="consent given for electronic record sharing"
+				  codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	<!--
+	********************************************************
+	CDA Body
+	********************************************************
+	-->
+	<component>
+			<structuredBody>
+					<component>
+							<section>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+									<templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>eMeasure Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Jan 1, 2022 - Dec 31, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</td>
+																	<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-74c2-3313-0174-c60bd07b02a6</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</content>
+											<list>
+													<item>Initial Patient Population:
+																							52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Denominator: 52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Numerator: 16515<list><item>Sex<list><item>Female:
+																							8959</item><item>Male:
+																	7511</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 512</item><item>Not Hispanic or Latino:
+																							15602</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							5621</item><item>Medicaid: 3471</item><item>Private
+																							Health Insurance: 6808</item><item>Other:
+																					615</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 33</item><item>Asian:
+																							271</item><item>Black or African American:
+																							3610</item><item>Native Hawaiian or Other Pacific
+																							Islander: 35</item><item>White:
+																							11845</item><item>Other Race:
+																			413</item></list></item></list></item>
+													<item>Performance Rate: .336026</item>
+													<item>Denominator Exclusions: 3742<list><item>Sex<list><item>Female:
+																							1926</item><item>Male:
+																	1804</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 36</item><item>Not Hispanic or Latino:
+																							3639</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							3338</item><item>Medicaid: 117</item><item>Private
+																							Health Insurance: 247</item><item>Other:
+																					40</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 8</item><item>Asian:
+																							19</item><item>Black or African American:
+																							669</item><item>Native Hawaiian or Other Pacific
+																							Islander: 2</item><item>White:
+																							2972</item><item>Other Race:
+																	37</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Controlling High Blood Pressure</td>
+																	<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-2382d1bd06b1</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:abdc37cc-bac6-4156-9b91-d1be2c8b7268</content>
+											<list>
+													<item>Initial Patient Population:
+																							137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Denominator: 137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Numerator: 79062<list><item>Sex<list><item>Female:
+																							43441</item><item>Male:
+																	35441</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1373</item><item>Not Hispanic or Latino:
+																							76145</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							32876</item><item>Medicaid: 8805</item><item>Private
+																							Health Insurance: 34866</item><item>Other:
+																							2515</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 143</item><item>Asian:
+																							1442</item><item>Black or African American:
+																							12388</item><item>Native Hawaiian or Other Pacific
+																							Islander: 79</item><item>White:
+																							62938</item><item>Other Race:
+																			1102</item></list></item></list></item>
+													<item>Performance Rate: .663806</item>
+													<item>Denominator Exclusions: 18411<list><item>Sex<list><item>Female:
+																							10945</item><item>Male:
+																	7418</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 229</item><item>Not Hispanic or Latino:
+																							17848</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							15125</item><item>Medicaid: 1362</item><item>Private
+																							Health Insurance: 1728</item><item>Other:
+																					196</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 38</item><item>Asian:
+																							177</item><item>Black or African American:
+																							3322</item><item>Native Hawaiian or Other Pacific
+																							Islander: 9</item><item>White:
+																							14499</item><item>Other Race:
+																			194</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Preventive Care and Screening: Screening for Depression and
+																			Follow-Up Plan</td>
+																	<td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
+																	<td>11.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-1e6f57410551</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: PREVENTIVE CARE AND SCREENING - eMeasure
+													ID:9a031e24-3d9b-11e1-8634-00237d5bf174</content>
+											<list>
+													<item>Initial Patient Population:
+																							470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Denominator: 470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Numerator: 54746<list><item>Sex<list><item>Female:
+																							27933</item><item>Male:
+																	26716</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1354</item><item>Not Hispanic or Latino:
+																							52341</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							21893</item><item>Medicaid: 4526</item><item>Private
+																							Health Insurance: 26530</item><item>Other:
+																							1797</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 94</item><item>Asian:
+																							2252</item><item>Black or African American:
+																							8405</item><item>Native Hawaiian or Other Pacific
+																							Islander: 76</item><item>White:
+																							41717</item><item>Other Race:
+																			1323</item></list></item></list></item>
+													<item>Performance Rate: .17507</item>
+													<item>Denominator Exclusions: 157128<list><item>Sex<list><item>Female:
+																							114970</item><item>Male:
+																	41822</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 3781</item><item>Not Hispanic or Latino:
+																							150919</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							43328</item><item>Medicaid:
+																							33374</item><item>Private Health Insurance:
+																							74673</item><item>Other:
+																	5752</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 282</item><item>Asian:
+																							1360</item><item>Black or African American:
+																							20705</item><item>Native Hawaiian or Other Pacific
+																							Islander: 131</item><item>White:
+																							129643</item><item>Other Race:
+																			3340</item></list></item></list></item>
+													<item>Denominator Exceptions: 538<list><item>Sex<list><item>Female:
+																							402</item><item>Male:
+																	135</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 20</item><item>Not Hispanic or Latino:
+																							499</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							152</item><item>Medicaid: 58</item><item>Private
+																							Health Insurance: 303</item><item>Other:
+																					25</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 0</item><item>Asian:
+																							26</item><item>Black or African American:
+																							97</item><item>Native Hawaiian or Other Pacific
+																							Islander: 0</item><item>White: 377</item><item>Other
+																							Race: 18</item></list></item></list></item>
+											</list>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72B98C12-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-74c2-3313-0174-c60bd07b02a6"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;
+																			9%)</text>
+																	<setId root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".336026"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="D0F9A8EF-6C52-429A-A522-B568269EF39A"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0A5B121A-16A0-41A1-8749-58BD992813C1"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="3742"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1926"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1804"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="36"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="669"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2972"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="37"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3338"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="117"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="247"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="40"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F4F7D899-682A-43D0-9506-75C0D7C08A76"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="16515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7511"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="512"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15602"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="271"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11845"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="413"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5621"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3471"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="6808"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="615"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72BDD61E-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-2382d1bd06b1"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Controlling High Blood Pressure</text>
+																	<setId root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".663806"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="947E37E4-7BC7-4BF0-985F-D8A3F83140D6"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="98174296-AE1D-4245-A8B3-C690B00ADD72"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="18411"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10945"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7418"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="229"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="17848"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="177"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="9"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="194"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15125"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1362"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1728"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="196"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="B1176EC6-38FD-4134-865F-65D69C056518"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="79062"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1373"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76145"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="143"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1442"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="12388"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="79"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62938"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1102"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="32876"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8805"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="34866"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2515"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72C21C92-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-1e6f57410551"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Preventive Care and Screening: Screening for Depression
+																			and Follow-Up Plan</text>
+																	<setId root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>PREVENTIVE CARE AND SCREENING</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".17507"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DD0526C9-DAB8-46C7-B169-ECD268E8E291"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="EBB00435-8DB2-4958-90B2-AC0FA76A5281"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="157128"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114970"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3781"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="150919"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="282"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1360"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20705"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="131"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="129643"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3340"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43328"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="74673"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5752"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F6DBBAC9-8089-432A-8DE2-BF19F9BED2AA"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEXCEP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exceptions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="538"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="402"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="97"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="377"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="18"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="152"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="58"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="303"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="25"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="7B8F391D-444D-4872-BEEC-1F59F4AB5ABF"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="54746"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27933"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26716"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1354"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="52341"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="94"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2252"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8405"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41717"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="21893"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4526"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26530"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1797"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C77D2C-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220101"/>
+															<high value="20221231"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.4"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Improvement Activity Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Improvement Activity Title</th>
+																	<th>Improvement Activity ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Engagement of patients through implementation of
+																			improvements in patient portal</td>
+																	<td>IA_BE_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Engagement of patients, family and caregivers in developing
+																			a plan of care</td>
+																	<td>IA_BE_15</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Implementation of improvements that contribute to more
+																			timely communication of test results</td>
+																	<td>IA_CC_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Practice improvements for bilateral exchange of patient
+																			information</td>
+																	<td>IA_CC_13</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</td>
+																	<td>IA_EPA_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7C7B4-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_4" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients through implementation of
+																			improvements in patient portal</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7D63C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_15" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients, family and caregivers in
+																			developing a plan of care</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7E438-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_2" root="2.16.840.1.113883.3.7034"/>
+																	<text>Implementation of improvements that contribute to more
+																			timely communication of test results</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7F216-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_13" root="2.16.840.1.113883.3.7034"/>
+																	<text>Practice improvements for bilateral exchange of patient
+																			information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7FF4A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_EPA_1" root="2.16.840.1.113883.3.7034"/>
+																	<text>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C80E0E-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.5"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Promoting Interoperability Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Promoting Interoperability Measure Title</th>
+																	<th>Promoting Interoperability Measure ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>E-Prescribing</td>
+																	<td>PI_EP_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .987514</item>
+																					<item>Numerator: 752879</item>
+																					<item>Denominator: 762398</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Patient Electronic Access (Provided Within 4 Business
+																			Days)</td>
+																	<td>PI_PEA_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .97764</item>
+																					<item>Numerator: 277373</item>
+																					<item>Denominator: 283717</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Protect Patient Health Information</td>
+																	<td>PI_PPHI_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Query of Prescription Drug Monitoring Program</td>
+																	<td>PI_EP_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</td>
+																	<td>PI_HIE_5</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Safety Assurance Factors for EHR Resilience Guides</td>
+																	<td>PI_PPHI_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Immunization Registry Reporting</td>
+																	<td>PI_PHCDRR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Case Reporting</td>
+																	<td>PI_PHCDRR_3</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Public Health Registry Reporting</td>
+																	<td>PI_PHCDRR_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Clinical Data Registry Reporting</td>
+																	<td>PI_PHCDRR_5</td>
+																	<td>Measure Performed: No</td>
+															</tr>
+															<tr>
+																	<td>Prevention of Information Blocking Attestation</td>
+																	<td>PI_INFBLO_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC-ACB Surveillance Attestation</td>
+																	<td>PI_ONCACB_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC Direct Review Attestation</td>
+																	<td>PI_ONCDIR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C85436-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>E-Prescribing</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".987514"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="752879"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="762398"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C87E02-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PEA_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Patient Electronic Access (Provided Within 4 Business
+																			Days)</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".97764"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="277373"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="283717"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8A5F8-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Protect Patient Health Information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8B444-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Query of Prescription Drug Monitoring Program</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8C33A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_HIE_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8D17C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Safety Assurance Factors for EHR Resilience Guides</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8E02C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Immunization Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8EE64-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_3" root="2.16.840.1.113883.3.7031"/>
+																	<text>Case Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8FC6A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_4" root="2.16.840.1.113883.3.7031"/>
+																	<text>Public Health Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C90ACA-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Clinical Data Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="N"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="No"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C91876-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_INFBLO_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Prevention of Information Blocking Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C92618-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCACB_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC-ACB Surveillance Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C93428-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCDIR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC Direct Review Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C9430A-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+			</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<requiredCodeCoverage>0.90</requiredCodeCoverage>
-		<tomcat.version>9.0.69</tomcat.version>
+		<tomcat.version>9.0.71</tomcat.version>
 		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test-coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 		<io.rest-assured.version>4.1.2</io.rest-assured.version>
 	</properties>

--- a/sample-files/2022/App1-ApmEntity-Qrda-III.xml
+++ b/sample-files/2022/App1-ApmEntity-Qrda-III.xml
@@ -120,3363 +120,7488 @@
       <statusCode code="completed" />
     </consent>
   </authorization>
-  <!--
-********************************************************
-CDA Body
-********************************************************
--->
   <component>
-    <structuredBody>
-      <!--
-********************************************************
-QRDA Category III Measure Section (CMS EP)
-********************************************************
--->
-      <component>
-        <section>
-          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01" />
-          <templateId root="2.16.840.1.113883.10.20.24.2.2" />
-          <templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2017-07-01" />
-          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1" displayName="measure document" />
-          <title>Measure Section</title>
-          <!--Performance Period-->
-          <entry>
-            <act classCode="ACT" moodCode="EVN">
-              <templateId root="2.16.840.1.113883.10.20.17.3.8" />
-              <id root="D5E68228-5760-11E7-1256-09173F13E4C5" />
-              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters" />
-              <effectiveTime>
-                <low value="20220101" />
-                <high value="20221231" />
-              </effectiveTime>
-            </act>
-          </entry>
-          <!--Measure Entry for CMS122v8-->
-      		<entry>
-      			<organizer classCode="CLUSTER" moodCode="EVN">
-      				<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-      				<!-- Measure Reference Template -->
-      				<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
-      				<!-- Measure Reference & Results Template -->
-      				<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
-      				<!-- CMS Measure Reference & Results Template -->
-      				<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
-      				<statusCode code="completed"/>
-      				<!--Measure Reference and Results-->
-      				<reference typeCode="REFR">
-      					<externalDocument classCode="DOC" moodCode="EVN">
-      						<id root="2.16.840.1.113883.4.738"
-      							extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
-      						<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
-      							  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
-      						<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
-      					</externalDocument>
-      				</reference>
-      				<!--Performance Rate-->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
-      						<!-- Performance Rate Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
-      						<!-- Performance Rate for Proportion Measure Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
-      						<!-- CMS Performance Rate for Proportion Measure Template -->
-      						<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
-      							  codeSystemName="LOINC" displayName="Performance Rate"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="REAL" value=".888889"/>
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
-      								<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="Numerator"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!--IPOP Population-->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--IPOP Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="1000"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6822A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6822B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6822C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6822D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6822E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6822F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68230-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68231-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68232-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68233-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68234-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68235-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-      						<!--IPOP Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!-- DENOM Population -->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--DENOM Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="1000"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68236-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68237-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68238-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68239-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6823D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6823E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6823F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68240-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68241-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-      						<!--DENOM Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!-- DENEX Population -->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--DENEX Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="100"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68267-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68268-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68269-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6826A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6826E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6826F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68270-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68271-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68272-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>c
-      						<!--DENEX Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      				<!-- NUMER Population -->
-      				<component>
-      					<observation classCode="OBS" moodCode="EVN">
-      						<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-      						<!-- Measure Data Template -->
-      						<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-      						<!-- CMS Measure Data Template -->
-      						<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-      							  codeSystemName="ActCode" displayName="Assertion"/>
-      						<statusCode code="completed"/>
-      						<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-      							   codeSystemName="ActCode"/>
-      						<!--NUMER Count-->
-      						<entryRelationship typeCode="SUBJ" inversionInd="true">
-      							<observation classCode="OBS" moodCode="EVN">
-      								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-      								<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-      									  codeSystemName="ActCode" displayName="rate aggregation"/>
-      								<statusCode code="completed"/>
-      								<value xsi:type="INT" value="800"/>
-      								<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-      											codeSystemName="ObservationMethod" displayName="Count"/>
-      							</observation>
-      						</entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68242-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68243-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68244-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68245-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68246-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68247-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68248-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68249-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6824D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-      						<!--NUMER Population ID from eCQM-->
-      						<reference typeCode="REFR">
-      							<externalObservation classCode="OBS" moodCode="EVN">
-      								<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
-      							</externalObservation>
-      						</reference>
-      					</observation>
-      				</component>
-      			</organizer>
-      		</entry>
-          <!--Measure Entry for CMS165v7-->
-          <entry>
-            <organizer classCode="CLUSTER" moodCode="EVN">
-              <templateId root="2.16.840.1.113883.10.20.24.3.98" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01" />
-              <templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01" />
-              <id root="D5E68474-5760-11E7-1256-09173F13E4C5" />
-              <statusCode code="completed" />
-              <!--Measure Reference and Results-->
-              <reference typeCode="REFR">
-                <externalDocument classCode="DOC" moodCode="EVN">
-                  <id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab" />
-                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Quality Measure Document" />
-                  <text>Controlling High Blood Pressure</text>
-                </externalDocument>
-              </reference>
-              <!--Performance Rate-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
-                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Performance Rate" />
-                  <statusCode code="completed" />
-                  <value xsi:type="REAL" value=".888889" />
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748" />
-                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Numerator" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--IPOP Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--IPOP Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68475-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68476-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68477-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68478-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68479-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6847C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6847D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6847E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6847F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68480-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--IPOP Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="87338BA5-170B-4264-9E59-6A4A3A57C785" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENOM Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENOM Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="1000" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68481-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68482-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68483-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68484-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="500" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68485-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68486-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68487-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68488-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68489-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6848A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6848B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E6848C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="250" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENOM Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="B2E2AA67-26CD-48CB-9536-094F1D047149" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--DENEX Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--DENEX Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="100" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6848E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6848F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E68490-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="50" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68491-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68492-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68493-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68494-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68495-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68496-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68497-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E68498-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="25" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--DENEX Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="9B6EDB4C-A390-4833-A135-2A2AC6334126" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-              <!--NUMER Population-->
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01" />
-                  <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion" />
-                  <statusCode code="completed" />
-                  <value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
-                  <!--NUMER Count-->
-                  <entryRelationship typeCode="SUBJ" inversionInd="true">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                      <statusCode code="completed" />
-                      <value xsi:type="INT" value="800" />
-                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Male-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E68499-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Male" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Gender Supplemental Data Element - Female-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01" />
-                      <id root="D5E6849A-5760-11E7-1256-09173F13E4C5" />
-                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex assigned at birth" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGenderCode" displayName="Female" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849B-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01" />
-                      <id root="D5E6849C-5760-11E7-1256-09173F13E4C5" />
-                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Ethnicity" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="400" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Black or African American-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849D-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Black or African American" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - White-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849E-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Asian-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E6849F-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - American Indian or Alaska Native-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E684A0-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="American Indian or Alaska Native" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Native Hawaiian or Other Pacific Islander" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Race Supplemental Data Element - Other Race-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01" />
-                      <id root="D5E68448-5760-11E7-1256-09173F13E4C5" />
-                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Race" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race" />
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="0" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicare-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A1-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="A" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicare" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Medicaid-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A2-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="B" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Medicaid" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Private Health Insurance-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A3-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="C" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Private Health Insurance" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--Payer Supplemental Data Element - Other-->
-                  <entryRelationship typeCode="COMP">
-                    <observation classCode="OBS" moodCode="EVN">
-                      <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01" />
-                      <templateId root="2.16.840.1.113883.10.20.24.3.55" />
-                      <templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-                      <id root="D5E684A4-5760-11E7-1256-09173F13E4C5" />
-                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Source" />
-                      <statusCode code="completed" />
-                      <effectiveTime>
-                        <low value="20170101" />
-                        <high value="20171231" />
-                      </effectiveTime>
-                      <value xsi:type="CD" nullFlavor="OTH">
-                        <translation code="D" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes" displayName="Other" />
-                      </value>
-                      <!-- Count-->
-                      <entryRelationship typeCode="SUBJ" inversionInd="true">
-                        <observation classCode="OBS" moodCode="EVN">
-                          <templateId root="2.16.840.1.113883.10.20.27.3.3" />
-                          <templateId root="2.16.840.1.113883.10.20.27.3.24" />
-                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation" />
-                          <statusCode code="completed" />
-                          <value xsi:type="INT" value="200" />
-                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count" />
-                        </observation>
-                      </entryRelationship>
-                    </observation>
-                  </entryRelationship>
-                  <!--NUMER Population ID from eMeasure-->
-                  <reference typeCode="REFR">
-                    <externalObservation classCode="OBS" moodCode="EVN">
-                      <id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748" />
-                    </externalObservation>
-                  </reference>
-                </observation>
-              </component>
-            </organizer>
-          </entry>
-        </section>
-      </component>
-    </structuredBody>
+      <structuredBody>
+          <component>
+              <section>
+                  <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+                  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+                  <templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
+                  <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+                  <title>Measure section</title>
+                  <text>
+                      <content>eMeasure Entries</content>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Reporting Parameter</th>
+                                  <th>Value</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Reporting period</td>
+                                  <td>Jan 1, 2022 - Dec 31, 2022</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table border="1" width="100%">
+                          <colgroup>
+                              <col width="30%"/>
+                              <col width="25%"/>
+                              <col width="5%"/>
+                              <col width="5%"/>
+                              <col width="25%"/>
+                          </colgroup>
+                          <thead>
+                              <tr>
+                                  <th>eMeasure Title</th>
+                                  <th>Version Neutral ID</th>
+                                  <th>eMeasure Version Number</th>
+                                  <th>NQF Measure Number</th>
+                                  <th>Version Specific ID</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</td>
+                                  <td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+                                  <td>10.0.000</td>
+                                  <td/>
+                                  <td>2c928082-74c2-3313-0174-c60bd07b02a6</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <content>Member of Measure Set: NONE - eMeasure
+                          ID:f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</content>
+                      <list>
+                          <item>Initial Patient Population:
+                                              52890<list><item>Sex<list><item>Female:
+                                              27982</item><item>Male:
+                                  24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1466</item><item>Not Hispanic or Latino:
+                                              50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              20800</item><item>Medicaid: 8033</item><item>Private
+                                              Health Insurance: 22443</item><item>Other:
+                                              1614</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 135</item><item>Asian:
+                                              1187</item><item>Black or African American:
+                                              10540</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 77</item><item>White:
+                                              38959</item><item>Other Race:
+                                      1201</item></list></item></list></item>
+                          <item>Denominator: 52890<list><item>Sex<list><item>Female:
+                                              27982</item><item>Male:
+                                  24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1466</item><item>Not Hispanic or Latino:
+                                              50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              20800</item><item>Medicaid: 8033</item><item>Private
+                                              Health Insurance: 22443</item><item>Other:
+                                              1614</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 135</item><item>Asian:
+                                              1187</item><item>Black or African American:
+                                              10540</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 77</item><item>White:
+                                              38959</item><item>Other Race:
+                                      1201</item></list></item></list></item>
+                          <item>Numerator: 16515<list><item>Sex<list><item>Female:
+                                              8959</item><item>Male:
+                                  7511</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 512</item><item>Not Hispanic or Latino:
+                                              15602</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              5621</item><item>Medicaid: 3471</item><item>Private
+                                              Health Insurance: 6808</item><item>Other:
+                                          615</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 33</item><item>Asian:
+                                              271</item><item>Black or African American:
+                                              3610</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 35</item><item>White:
+                                              11845</item><item>Other Race:
+                                      413</item></list></item></list></item>
+                          <item>Performance Rate: .336026</item>
+                          <item>Denominator Exclusions: 3742<list><item>Sex<list><item>Female:
+                                              1926</item><item>Male:
+                                  1804</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 36</item><item>Not Hispanic or Latino:
+                                              3639</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              3338</item><item>Medicaid: 117</item><item>Private
+                                              Health Insurance: 247</item><item>Other:
+                                          40</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 8</item><item>Asian:
+                                              19</item><item>Black or African American:
+                                              669</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 2</item><item>White:
+                                              2972</item><item>Other Race:
+                                  37</item></list></item></list></item>
+                      </list>
+                      <table border="1" width="100%">
+                          <colgroup>
+                              <col width="30%"/>
+                              <col width="25%"/>
+                              <col width="5%"/>
+                              <col width="5%"/>
+                              <col width="25%"/>
+                          </colgroup>
+                          <thead>
+                              <tr>
+                                  <th>eMeasure Title</th>
+                                  <th>Version Neutral ID</th>
+                                  <th>eMeasure Version Number</th>
+                                  <th>NQF Measure Number</th>
+                                  <th>Version Specific ID</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Controlling High Blood Pressure</td>
+                                  <td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+                                  <td>10.0.000</td>
+                                  <td/>
+                                  <td>2c928082-7505-caf9-0175-2382d1bd06b1</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <content>Member of Measure Set: NONE - eMeasure
+                          ID:abdc37cc-bac6-4156-9b91-d1be2c8b7268</content>
+                      <list>
+                          <item>Initial Patient Population:
+                                              137515<list><item>Sex<list><item>Female:
+                                              75071</item><item>Male:
+                                  62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 2322</item><item>Not Hispanic or Latino:
+                                              132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              63996</item><item>Medicaid:
+                                              15536</item><item>Private Health Insurance:
+                                              53791</item><item>Other:
+                                  4192</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 259</item><item>Asian:
+                                              2192</item><item>Black or African American:
+                                              24323</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 136</item><item>White:
+                                              106905</item><item>Other Race:
+                                      1963</item></list></item></list></item>
+                          <item>Denominator: 137515<list><item>Sex<list><item>Female:
+                                              75071</item><item>Male:
+                                  62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 2322</item><item>Not Hispanic or Latino:
+                                              132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              63996</item><item>Medicaid:
+                                              15536</item><item>Private Health Insurance:
+                                              53791</item><item>Other:
+                                  4192</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 259</item><item>Asian:
+                                              2192</item><item>Black or African American:
+                                              24323</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 136</item><item>White:
+                                              106905</item><item>Other Race:
+                                      1963</item></list></item></list></item>
+                          <item>Numerator: 79062<list><item>Sex<list><item>Female:
+                                              43441</item><item>Male:
+                                  35441</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1373</item><item>Not Hispanic or Latino:
+                                              76145</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              32876</item><item>Medicaid: 8805</item><item>Private
+                                              Health Insurance: 34866</item><item>Other:
+                                              2515</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 143</item><item>Asian:
+                                              1442</item><item>Black or African American:
+                                              12388</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 79</item><item>White:
+                                              62938</item><item>Other Race:
+                                      1102</item></list></item></list></item>
+                          <item>Performance Rate: .663806</item>
+                          <item>Denominator Exclusions: 18411<list><item>Sex<list><item>Female:
+                                              10945</item><item>Male:
+                                  7418</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 229</item><item>Not Hispanic or Latino:
+                                              17848</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              15125</item><item>Medicaid: 1362</item><item>Private
+                                              Health Insurance: 1728</item><item>Other:
+                                          196</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 38</item><item>Asian:
+                                              177</item><item>Black or African American:
+                                              3322</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 9</item><item>White:
+                                              14499</item><item>Other Race:
+                                      194</item></list></item></list></item>
+                      </list>
+                      <table border="1" width="100%">
+                          <colgroup>
+                              <col width="30%"/>
+                              <col width="25%"/>
+                              <col width="5%"/>
+                              <col width="5%"/>
+                              <col width="25%"/>
+                          </colgroup>
+                          <thead>
+                              <tr>
+                                  <th>eMeasure Title</th>
+                                  <th>Version Neutral ID</th>
+                                  <th>eMeasure Version Number</th>
+                                  <th>NQF Measure Number</th>
+                                  <th>Version Specific ID</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Preventive Care and Screening: Screening for Depression and
+                                      Follow-Up Plan</td>
+                                  <td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
+                                  <td>11.0.000</td>
+                                  <td/>
+                                  <td>2c928082-7505-caf9-0175-1e6f57410551</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <content>Member of Measure Set: PREVENTIVE CARE AND SCREENING - eMeasure
+                          ID:9a031e24-3d9b-11e1-8634-00237d5bf174</content>
+                      <list>
+                          <item>Initial Patient Population:
+                                              470376<list><item>Sex<list><item>Female:
+                                              287905</item><item>Male:
+                                  181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 14065</item><item>Not Hispanic or Latino:
+                                              446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              114944</item><item>Medicaid:
+                                              82205</item><item>Private Health Insurance:
+                                              253927</item><item>Other:
+                                  19298</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 822</item><item>Asian:
+                                              11314</item><item>Black or African American:
+                                              71638</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 610</item><item>White:
+                                              364169</item><item>Other Race:
+                                      13343</item></list></item></list></item>
+                          <item>Denominator: 470376<list><item>Sex<list><item>Female:
+                                              287905</item><item>Male:
+                                  181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 14065</item><item>Not Hispanic or Latino:
+                                              446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              114944</item><item>Medicaid:
+                                              82205</item><item>Private Health Insurance:
+                                              253927</item><item>Other:
+                                  19298</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 822</item><item>Asian:
+                                              11314</item><item>Black or African American:
+                                              71638</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 610</item><item>White:
+                                              364169</item><item>Other Race:
+                                      13343</item></list></item></list></item>
+                          <item>Numerator: 54746<list><item>Sex<list><item>Female:
+                                              27933</item><item>Male:
+                                  26716</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 1354</item><item>Not Hispanic or Latino:
+                                              52341</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              21893</item><item>Medicaid: 4526</item><item>Private
+                                              Health Insurance: 26530</item><item>Other:
+                                              1797</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 94</item><item>Asian:
+                                              2252</item><item>Black or African American:
+                                              8405</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 76</item><item>White:
+                                              41717</item><item>Other Race:
+                                      1323</item></list></item></list></item>
+                          <item>Performance Rate: .17507</item>
+                          <item>Denominator Exclusions: 157128<list><item>Sex<list><item>Female:
+                                              114970</item><item>Male:
+                                  41822</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 3781</item><item>Not Hispanic or Latino:
+                                              150919</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              43328</item><item>Medicaid:
+                                              33374</item><item>Private Health Insurance:
+                                              74673</item><item>Other:
+                                  5752</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 282</item><item>Asian:
+                                              1360</item><item>Black or African American:
+                                              20705</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 131</item><item>White:
+                                              129643</item><item>Other Race:
+                                      3340</item></list></item></list></item>
+                          <item>Denominator Exceptions: 538<list><item>Sex<list><item>Female:
+                                              402</item><item>Male:
+                                  135</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+                                              or Latino: 20</item><item>Not Hispanic or Latino:
+                                              499</item></list></item></list><list><item>Payer<list><item>Medicare:
+                                              152</item><item>Medicaid: 58</item><item>Private
+                                              Health Insurance: 303</item><item>Other:
+                                          25</item></list></item></list><list><item>Race<list><item>American
+                                              Indian or Alaska Native: 0</item><item>Asian:
+                                              26</item><item>Black or African American:
+                                              97</item><item>Native Hawaiian or Other Pacific
+                                              Islander: 0</item><item>White: 377</item><item>Other
+                                              Race: 18</item></list></item></list></item>
+                      </list>
+                  </text>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+                          <templateId extension="2019-05-01"
+                              root="2.16.840.1.113883.10.20.27.3.17"/>
+                          <id root="72B98C12-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="2c928082-74c2-3313-0174-c60bd07b02a6"
+                                      root="2.16.840.1.113883.4.738"/>
+                                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Health Quality Measure Document"
+                                      codeSystemName="LOINC"/>
+                                  <text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;
+                                      9%)</text>
+                                  <setId root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+                              </externalDocument>
+                          </reference>
+                          <reference typeCode="REFR">
+                              <externalObservation>
+                                  <id root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+                                  <code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Measure Set" codeSystemName="LOINC"/>
+                                  <text>NONE</text>
+                              </externalObservation>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.14"/>
+                                  <templateId extension="2018-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.25"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".336026"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <reference typeCode="REFR">
+                                      <externalObservation classCode="OBS" moodCode="EVN">
+                                          <id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+                                          <code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="Numerator"
+                                              codeSystemName="ObservationValue"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="IPOP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="initial population"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="52890"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="27982"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24770"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1466"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="50374"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="135"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1187"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="10540"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="77"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="38959"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1201"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20800"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8033"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="22443"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1614"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="D0F9A8EF-6C52-429A-A522-B568269EF39A"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="52890"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="27982"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24770"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1466"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="50374"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="135"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1187"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="10540"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="77"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="38959"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1201"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20800"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8033"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="22443"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1614"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="0A5B121A-16A0-41A1-8749-58BD992813C1"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEX"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exclusions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="3742"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1926"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1804"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="36"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3639"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="19"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="669"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2972"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="37"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3338"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="117"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="247"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="40"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="F4F7D899-682A-43D0-9506-75C0D7C08A76"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="16515"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8959"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="7511"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="512"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15602"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="33"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="271"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3610"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="35"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="11845"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="413"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="5621"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3471"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="6808"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="615"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+                          <templateId extension="2019-05-01"
+                              root="2.16.840.1.113883.10.20.27.3.17"/>
+                          <id root="72BDD61E-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="2c928082-7505-caf9-0175-2382d1bd06b1"
+                                      root="2.16.840.1.113883.4.738"/>
+                                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Health Quality Measure Document"
+                                      codeSystemName="LOINC"/>
+                                  <text>Controlling High Blood Pressure</text>
+                                  <setId root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+                              </externalDocument>
+                          </reference>
+                          <reference typeCode="REFR">
+                              <externalObservation>
+                                  <id root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+                                  <code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Measure Set" codeSystemName="LOINC"/>
+                                  <text>NONE</text>
+                              </externalObservation>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.14"/>
+                                  <templateId extension="2018-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.25"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".663806"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <reference typeCode="REFR">
+                                      <externalObservation classCode="OBS" moodCode="EVN">
+                                          <id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+                                          <code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="Numerator"
+                                              codeSystemName="ObservationValue"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="IPOP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="initial population"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="137515"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="75071"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="62118"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2322"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="132459"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="259"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24323"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="136"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="106905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1963"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="63996"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15536"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="53791"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="4192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="947E37E4-7BC7-4BF0-985F-D8A3F83140D6"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="137515"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="75071"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="62118"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2322"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="132459"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="259"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="24323"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="136"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="106905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1963"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="63996"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15536"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="53791"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="4192"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="98174296-AE1D-4245-A8B3-C690B00ADD72"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEX"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exclusions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="18411"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="10945"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="7418"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="229"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="17848"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="38"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="177"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3322"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="9"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="14499"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="194"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="15125"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1362"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1728"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="196"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="B1176EC6-38FD-4134-865F-65D69C056518"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="79062"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="43441"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="35441"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1373"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="76145"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="143"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1442"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="12388"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="79"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="62938"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1102"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="32876"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8805"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="34866"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2515"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+                          <templateId extension="2019-05-01"
+                              root="2.16.840.1.113883.10.20.27.3.17"/>
+                          <id root="72C21C92-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="2c928082-7505-caf9-0175-1e6f57410551"
+                                      root="2.16.840.1.113883.4.738"/>
+                                  <code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Health Quality Measure Document"
+                                      codeSystemName="LOINC"/>
+                                  <text>Preventive Care and Screening: Screening for Depression
+                                      and Follow-Up Plan</text>
+                                  <setId root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+                              </externalDocument>
+                          </reference>
+                          <reference typeCode="REFR">
+                              <externalObservation>
+                                  <id root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+                                  <code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Measure Set" codeSystemName="LOINC"/>
+                                  <text>PREVENTIVE CARE AND SCREENING</text>
+                              </externalObservation>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.14"/>
+                                  <templateId extension="2018-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.25"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".17507"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <reference typeCode="REFR">
+                                      <externalObservation classCode="OBS" moodCode="EVN">
+                                          <id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+                                          <code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="Numerator"
+                                              codeSystemName="ObservationValue"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="IPOP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="initial population"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="470376"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="287905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="181639"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="14065"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="446425"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="822"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="11314"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="71638"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="610"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="364169"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="13343"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="114944"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="82205"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="253927"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="19298"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="DD0526C9-DAB8-46C7-B169-ECD268E8E291"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="470376"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="287905"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="181639"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="14065"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="446425"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="822"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="11314"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="71638"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="610"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="364169"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="13343"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="114944"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="82205"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="253927"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="19298"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="EBB00435-8DB2-4958-90B2-AC0FA76A5281"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEX"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exclusions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="157128"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="114970"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="41822"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3781"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="150919"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="282"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1360"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20705"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="131"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="129643"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="3340"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="43328"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="33374"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="74673"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="5752"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="F6DBBAC9-8089-432A-8DE2-BF19F9BED2AA"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENEXCEP"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator Exceptions"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="538"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="402"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="135"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="20"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="499"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="0"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="26"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="97"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="0"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="377"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="18"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="152"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="58"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="303"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="25"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="7B8F391D-444D-4872-BEEC-1F59F4AB5ABF"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.5"/>
+                                  <templateId extension="2019-05-01"
+                                      root="2.16.840.1.113883.10.20.27.3.16"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="INT" value="54746"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="F"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Female"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="27933"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.6"/>
+                                          <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Sex assigned at birth"
+                                              codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="M"
+                                              codeSystem="2.16.840.1.113883.5.1"
+                                              displayName="Male"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="26716"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2135-2"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1354"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.7"/>
+                                          <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Ethnic" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2186-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Not Hispanic or Latino"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="52341"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="1002-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="American Indian or Alaska Native"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="94"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2028-9"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Asian"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="2252"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2054-5"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Black or African American"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="8405"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2076-8"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Native Hawaiian or Other Pacific Islander"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="76"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2106-3"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="White"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="41717"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId extension="2016-09-01"
+                                              root="2.16.840.1.113883.10.20.27.3.8"/>
+                                          <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Race" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <value xsi:type="CD" code="2131-1"
+                                              codeSystem="2.16.840.1.113883.6.238"
+                                              displayName="Other Race"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1323"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="A"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicare"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="21893"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="B"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Medicaid"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="4526"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="C"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Private Health Insurance"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="26530"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <entryRelationship typeCode="COMP">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                                          <templateId extension="2016-02-01"
+                                              root="2.16.840.1.113883.10.20.27.3.9"/>
+                                          <templateId extension="2018-05-01"
+                                              root="2.16.840.1.113883.10.20.27.3.18"/>
+                                          <id nullFlavor="NA"/>
+                                          <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+                                              displayName="Payment source" codeSystemName="LOINC"/>
+                                          <statusCode code="completed"/>
+                                          <effectiveTime>
+                                              <low nullFlavor="NA"/>
+                                          </effectiveTime>
+                                          <value xsi:type="CD" nullFlavor="OTH"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                                              <translation code="D"
+                                                codeSystem="2.16.840.1.113883.3.249.12"
+                                                displayName="Other"/>
+                                          </value>
+                                          <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                              <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                                <code code="MSRAGG"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                displayName="rate aggregation"
+                                                codeSystemName="ActCode"/>
+                                                <statusCode code="completed"/>
+                                                <value xsi:type="INT" value="1797"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                                <methodCode code="COUNT"
+                                                codeSystem="2.16.840.1.113883.5.84"
+                                                codeSystemName="ObservationMethod"
+                                                displayName="count"/>
+                                              </observation>
+                                          </entryRelationship>
+                                      </observation>
+                                  </entryRelationship>
+                                  <reference typeCode="REFR">
+                                      <externalObservation>
+                                          <id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+                                      </externalObservation>
+                                  </reference>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+                          <id root="72C77D2C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+                              displayName="Observation Parameters"/>
+                          <effectiveTime>
+                              <low value="20220101"/>
+                              <high value="20221231"/>
+                          </effectiveTime>
+                      </act>
+                  </entry>
+              </section>
+          </component>
+          <component>
+              <section>
+                  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.4"/>
+                  <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+                  <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+                  <title>Measure section</title>
+                  <text>
+                      <content>Improvement Activity Entries</content>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Reporting Parameter</th>
+                                  <th>Value</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Reporting period</td>
+                                  <td>Sep 27, 2022 - Dec 25, 2022</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Improvement Activity Title</th>
+                                  <th>Improvement Activity ID</th>
+                                  <th>Details</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Engagement of patients through implementation of
+                                      improvements in patient portal</td>
+                                  <td>IA_BE_4</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Engagement of patients, family and caregivers in developing
+                                      a plan of care</td>
+                                  <td>IA_BE_15</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Implementation of improvements that contribute to more
+                                      timely communication of test results</td>
+                                  <td>IA_CC_2</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Practice improvements for bilateral exchange of patient
+                                      information</td>
+                                  <td>IA_CC_13</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+                                      Who Have Real-Time Access to Patient's Medical Record</td>
+                                  <td>IA_EPA_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </text>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7C7B4-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_BE_4" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Engagement of patients through implementation of
+                                      improvements in patient portal</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7D63C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_BE_15" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Engagement of patients, family and caregivers in
+                                      developing a plan of care</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7E438-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_CC_2" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Implementation of improvements that contribute to more
+                                      timely communication of test results</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7F216-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_CC_13" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Practice improvements for bilateral exchange of patient
+                                      information</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.33"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C7FF4A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="IA_EPA_1" root="2.16.840.1.113883.3.7034"/>
+                                  <text>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+                                      Who Have Real-Time Access to Patient's Medical Record</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+                          <id root="72C80E0E-AE3D-11ED-A1C0-640339ACF087"/>
+                          <code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+                              displayName="Observation Parameters"/>
+                          <effectiveTime>
+                              <low value="20220927"/>
+                              <high value="20221225"/>
+                          </effectiveTime>
+                      </act>
+                  </entry>
+              </section>
+          </component>
+          <component>
+              <section>
+                  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.5"/>
+                  <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+                  <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+                  <title>Measure section</title>
+                  <text>
+                      <content>Promoting Interoperability Entries</content>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Reporting Parameter</th>
+                                  <th>Value</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>Reporting period</td>
+                                  <td>Sep 27, 2022 - Dec 25, 2022</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table border="1" width="100%">
+                          <thead>
+                              <tr>
+                                  <th>Promoting Interoperability Measure Title</th>
+                                  <th>Promoting Interoperability Measure ID</th>
+                                  <th>Details</th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>E-Prescribing</td>
+                                  <td>PI_EP_1</td>
+                                  <td>
+                                      <list>
+                                          <item>Performance Rate: .987514</item>
+                                          <item>Numerator: 752879</item>
+                                          <item>Denominator: 762398</item>
+                                      </list>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>Patient Electronic Access (Provided Within 4 Business
+                                      Days)</td>
+                                  <td>PI_PEA_1</td>
+                                  <td>
+                                      <list>
+                                          <item>Performance Rate: .97764</item>
+                                          <item>Numerator: 277373</item>
+                                          <item>Denominator: 283717</item>
+                                      </list>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>Protect Patient Health Information</td>
+                                  <td>PI_PPHI_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Query of Prescription Drug Monitoring Program</td>
+                                  <td>PI_EP_2</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Health Information Exchange (HIE) Bi-Directional
+                                      Exchange</td>
+                                  <td>PI_HIE_5</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Safety Assurance Factors for EHR Resilience Guides</td>
+                                  <td>PI_PPHI_2</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Immunization Registry Reporting</td>
+                                  <td>PI_PHCDRR_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Case Reporting</td>
+                                  <td>PI_PHCDRR_3</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Public Health Registry Reporting</td>
+                                  <td>PI_PHCDRR_4</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>Clinical Data Registry Reporting</td>
+                                  <td>PI_PHCDRR_5</td>
+                                  <td>Measure Performed: No</td>
+                              </tr>
+                              <tr>
+                                  <td>Prevention of Information Blocking Attestation</td>
+                                  <td>PI_INFBLO_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>ONC-ACB Surveillance Attestation</td>
+                                  <td>PI_ONCACB_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                              <tr>
+                                  <td>ONC Direct Review Attestation</td>
+                                  <td>PI_ONCDIR_1</td>
+                                  <td>Measure Performed: Yes</td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </text>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2017-06-01"
+                              root="2.16.840.1.113883.10.20.27.3.28"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C85436-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_EP_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>E-Prescribing</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".987514"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.31"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="752879"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.32"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="762398"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2017-06-01"
+                              root="2.16.840.1.113883.10.20.27.3.28"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C87E02-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PEA_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Patient Electronic Access (Provided Within 4 Business
+                                      Days)</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.30"/>
+                                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Performance Rate" codeSystemName="LOINC"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="REAL" value=".97764"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.31"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="NUMER"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Numerator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="277373"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.32"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="DENOM"
+                                      codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+                                      displayName="Denominator"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                      <observation classCode="OBS" moodCode="EVN">
+                                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+                                              displayName="rate aggregation"
+                                              codeSystemName="ActCode"/>
+                                          <value xsi:type="INT" value="283717"
+                                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                                          <methodCode code="COUNT"
+                                              codeSystem="2.16.840.1.113883.5.84"
+                                              codeSystemName="ObservationMethod"
+                                              displayName="count"/>
+                                      </observation>
+                                  </entryRelationship>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8A5F8-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PPHI_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Protect Patient Health Information</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8B444-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_EP_2" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Query of Prescription Drug Monitoring Program</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8C33A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_HIE_5" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Health Information Exchange (HIE) Bi-Directional
+                                      Exchange</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8D17C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PPHI_2" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Safety Assurance Factors for EHR Resilience Guides</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8E02C-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Immunization Registry Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8EE64-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_3" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Case Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C8FC6A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_4" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Public Health Registry Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C90ACA-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_PHCDRR_5" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Clinical Data Registry Reporting</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="N"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="No"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C91876-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_INFBLO_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>Prevention of Information Blocking Attestation</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C92618-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_ONCACB_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>ONC-ACB Surveillance Attestation</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry>
+                      <organizer classCode="CLUSTER" moodCode="EVN">
+                          <templateId extension="2016-09-01"
+                              root="2.16.840.1.113883.10.20.27.3.29"/>
+                          <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+                          <id root="72C93428-AE3D-11ED-A1C0-640339ACF087"/>
+                          <statusCode code="completed"/>
+                          <reference typeCode="REFR">
+                              <externalDocument classCode="DOC" moodCode="EVN">
+                                  <id extension="PI_ONCDIR_1" root="2.16.840.1.113883.3.7031"/>
+                                  <text>ONC Direct Review Attestation</text>
+                              </externalDocument>
+                          </reference>
+                          <component>
+                              <observation classCode="OBS" moodCode="EVN">
+                                  <templateId extension="2016-09-01"
+                                      root="2.16.840.1.113883.10.20.27.3.27"/>
+                                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+                                  <statusCode code="completed"/>
+                                  <value xsi:type="CD" code="Y"
+                                      codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                              </observation>
+                          </component>
+                      </organizer>
+                  </entry>
+                  <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+                          <id root="72C9430A-AE3D-11ED-A1C0-640339ACF087"/>
+                          <code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+                              displayName="Observation Parameters"/>
+                          <effectiveTime>
+                              <low value="20220927"/>
+                              <high value="20221225"/>
+                          </effectiveTime>
+                      </act>
+                  </entry>
+              </section>
+          </component>
+      </structuredBody>
   </component>
 </ClinicalDocument>

--- a/sample-files/2022/App1-Group-QRDA-III.xml
+++ b/sample-files/2022/App1-Group-QRDA-III.xml
@@ -185,4583 +185,7487 @@ CDA Header
 	********************************************************
 	-->
 	<component>
-		<structuredBody>
-			<!--
-			********************************************************
-			QRDA Category III Measure Section - CMS (V2)
-			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
-			********************************************************
-			-->
-			<component>
-				<section>
-					<!-- Measure Section -->
-					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
-					<!-- QRDA Category III Measure Section (V4) -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
-					<!-- QRDA Category III Measure Section - CMS (V2) -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
-					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
-						  displayName="measure section"/>
-					<title>Measure Section</title>
-					<text>
-						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Controlling High Blood Pressure</td>
-									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
-									<td>40280381-51f0-825b-0152-22b98cff181a</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>:0.842105
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-
-						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
-									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
-									<td>40280381-51f0-825b-0152-229afff616ee</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.947368
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:900
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>598
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>50
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>2
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-
-						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Documentation of Current Medications in the Medical Record</td>
-									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
-									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.816327
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:20
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>12
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>8
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>18
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>2
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>3
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>2
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>3
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>5
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>2
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-
-
-						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Depression Utilization of the PHQ-9 Tool</td>
-									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
-									<td>40280381-503f-a1fc-0150-afe320c01761</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.860177
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:600
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Population</content>:600
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:35
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:486
-							</item>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.921052
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:800
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Population</content>:800
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:40
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:700
-							</item>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.962963
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:580
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Population</content>:580
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:40
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:520
-							</item>
-						</list>
-					</text>
-
-					<!--Measure Entry for CMS165v8-->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
-							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
-							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
-							<statusCode code="completed"/>
-							<!--Measure Reference and Results-->
-							<reference typeCode="REFR">
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab"/>
-									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-										  displayName="Health Quality Measure Document"/>
-									<text>Controlling High Blood Pressure</text>
-								</externalDocument>
-							</reference>
-							<!--Performance Rate-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
-									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-										  displayName="Performance Rate"/>
-									<statusCode code="completed"/>
-									<value xsi:type="REAL" value=".888889"/>
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
-											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="Numerator"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--IPOP Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
-									<!--IPOP Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--IPOP Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="87338BA5-170B-4264-9E59-6A4A3A57C785"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--DENOM Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENOM Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENOM Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="B2E2AA67-26CD-48CB-9536-094F1D047149"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--DENEX Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENEX Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="100"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENEX Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="9B6EDB4C-A390-4833-A135-2A2AC6334126"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--NUMER Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--NUMER Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="800"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--NUMER Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-
-					<!--Measure Entry for CMS122v8-->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- Measure Reference Template -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
-							<!-- Measure Reference & Results Template -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
-							<!-- CMS Measure Reference & Results Template -->
-							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
-							<statusCode code="completed"/>
-							<!--Measure Reference and Results-->
-							<reference typeCode="REFR">
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<id root="2.16.840.1.113883.4.738"
-										extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
-									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
-										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
-									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
-								</externalDocument>
-							</reference>
-							<!--Performance Rate-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
-									<!-- Performance Rate Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
-									<!-- Performance Rate for Proportion Measure Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
-									<!-- CMS Performance Rate for Proportion Measure Template -->
-									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
-										  codeSystemName="LOINC" displayName="Performance Rate"/>
-									<statusCode code="completed"/>
-									<value xsi:type="REAL" value=".888889"/>
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
-											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="Numerator"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--IPOP Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--IPOP Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--IPOP Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!-- DENOM Population -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENOM Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENOM Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!-- DENEX Population -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENEX Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="100"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENEX Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!-- NUMER Population -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--NUMER Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="800"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--NUMER Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-
-					<!-- Reporting Parameters Act -->
-					<entry typeCode="DRIV">
-						<act classCode="ACT" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
-							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
-								  displayName="Observation Parameters"/>
-							<effectiveTime>
-								<low value="20220101"/>
-								<high value="20221231"/>
-							</effectiveTime>
-						</act>
-					</entry>
-				</section>
-			</component>
-			<!--
-		  	********************************************************
-		  	Promoting Interoperability Section (V2)
-		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
-		  	********************************************************
-		  	-->
-			<component>
-				<section>
-					<!-- Measure Section -->
-					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
-					<!-- Advancing Care Information Section templateId -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
-					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
-						  displayName="Measure Section"/>
-					<title>Measure Section</title>
-					<text>
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>PI Measure Title</th>
-									<th>Measure Identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Provide Patient Access</td>
-									<td>PI_PEA_1</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Denominator:</content>800
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator:</content>600
-							</item>
-							<item>
-								<content styleCode="Bold">Performance Rate:
-								</content>0.75
-							</item>
-						</list>
-						<list>
-							<item>
-								<content styleCode="Bold">Measure Answer (Yes/No):
-								</content>Yes
-							</item>
-						</list>
-					</text>
-					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
-					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<!-- Implied template Measure Reference templateId -->
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.28"
-										extension="2017-06-01"/>
-							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
-							<statusCode code="completed"/>
-							<reference typeCode="REFR">
-								<!-- Reference to a particular PI measure's unique identifier. -->
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
-									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
-									<!-- PI measure title -->
-									<text>Provide Patient Access</text>
-								</externalDocument>
-							</reference>
-							<!-- Performance Rate for PI is optional -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- Performance Rate templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.30"
-												extension="2016-09-01"/>
-									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
-										  codeSystemName="LOINC" displayName="Performance Rate"/>
-									<statusCode code="completed"/>
-									<value xsi:type="REAL" value="0.75"/>
-								</observation>
-							</component>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.31"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="NUMER"
-										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
-									<!-- Numerator Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="600"/>
-											<methodCode code="COUNT"
-														codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod"
-														displayName="Count"/>
-										</observation>
-									</entryRelationship>
-								</observation>
-							</component>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.32"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENOM"
-										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
-									<!-- Denominator Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="800"/>
-											<methodCode code="COUNT"
-														codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod"
-														displayName="Count"/>
-										</observation>
-									</entryRelationship>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-
-					<!-- Reporting Parameters Act -->
-					<entry typeCode="DRIV">
-						<act classCode="ACT" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
-							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
-								  displayName="Observation Parameters"/>
-							<effectiveTime>
-								<low value="20220201"/>
-								<high value="20220531"/>
-							</effectiveTime>
-						</act>
-					</entry>
-				</section>
-			</component>
-
-			<!--
-			********************************************************
-			Improvement Activity Section (V2)
-			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
-			********************************************************
-			-->
-			<component>
-				<section>
-					<!-- Measure Section -->
-					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
-					<!-- Improvement Activity Section templateId -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
-					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
-						  displayName="Measure Section"/>
-					<title>Measure Section</title>
-					<text>
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>Improvement Activity Name</th>
-									<th>Activity ID</th>
-									<th>Question Answer Code</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Collection and use of patient experience and satisfaction data on access</td>
-									<td>IA_EPA_3</td>
-									<td>Y</td>
-								</tr>
-
-								<tr>
-									<td>Care transition documentation practice improvements</td>
-									<td>IA_CC_10</td>
-									<td>Y</td>
-								</tr>
-							</tbody>
-						</table>
-					</text>
-					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
-					<!-- IA_EPA_3 -->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<!-- Implied template Measure Reference templateId -->
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- Improvement Activity Performed Reference and Results templateId -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
-							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
-							<statusCode code="completed"/>
-							<reference typeCode="REFR">
-								<!-- Reference to a particular PI measure's unique identifier. -->
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
-									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
-									<!-- Improvement activity narrative text (for reference) -->
-									<text>Collection and use of patient experience and satisfaction data on access</text>
-								</externalDocument>
-							</reference>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- Measure Performed templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.27"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="Y" displayName="Yes"
-										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
-										   codeSystem="2.16.840.1.113883.12.136"/>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-					<!-- IA_CC_10 -->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<!-- Implied template Measure Reference templateId -->
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- Improvement Activity Performed Reference and Results templateId -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.33"
-										extension="2016-09-01"/>
-							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
-							<statusCode code="completed"/>
-							<reference typeCode="REFR">
-								<!-- Reference to a particular PI measure's unique identifier. -->
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
-									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
-									<!-- Improvement activity narrative text (for reference) -->
-									<text>Care transition documentation practice improvements</text>
-								</externalDocument>
-							</reference>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- Measure Performed templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.27"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="Y" displayName="Yes"
-										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
-										   codeSystem="2.16.840.1.113883.12.136"/>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-					<!-- Reporting Parameters Act -->
-					<entry typeCode="DRIV">
-						<act classCode="ACT" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
-							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
-								  displayName="Observation Parameters"/>
-							<effectiveTime>
-								<low value="20220101"/>
-								<high value="20220430"/>
-							</effectiveTime>
-						</act>
-					</entry>
-				</section>
-			</component>
-		</structuredBody>
+			<structuredBody>
+					<component>
+							<section>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+									<templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>eMeasure Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Jan 1, 2022 - Dec 31, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</td>
+																	<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-74c2-3313-0174-c60bd07b02a6</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</content>
+											<list>
+													<item>Initial Patient Population:
+																							52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Denominator: 52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Numerator: 16515<list><item>Sex<list><item>Female:
+																							8959</item><item>Male:
+																	7511</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 512</item><item>Not Hispanic or Latino:
+																							15602</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							5621</item><item>Medicaid: 3471</item><item>Private
+																							Health Insurance: 6808</item><item>Other:
+																					615</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 33</item><item>Asian:
+																							271</item><item>Black or African American:
+																							3610</item><item>Native Hawaiian or Other Pacific
+																							Islander: 35</item><item>White:
+																							11845</item><item>Other Race:
+																			413</item></list></item></list></item>
+													<item>Performance Rate: .336026</item>
+													<item>Denominator Exclusions: 3742<list><item>Sex<list><item>Female:
+																							1926</item><item>Male:
+																	1804</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 36</item><item>Not Hispanic or Latino:
+																							3639</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							3338</item><item>Medicaid: 117</item><item>Private
+																							Health Insurance: 247</item><item>Other:
+																					40</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 8</item><item>Asian:
+																							19</item><item>Black or African American:
+																							669</item><item>Native Hawaiian or Other Pacific
+																							Islander: 2</item><item>White:
+																							2972</item><item>Other Race:
+																	37</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Controlling High Blood Pressure</td>
+																	<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-2382d1bd06b1</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:abdc37cc-bac6-4156-9b91-d1be2c8b7268</content>
+											<list>
+													<item>Initial Patient Population:
+																							137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Denominator: 137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Numerator: 79062<list><item>Sex<list><item>Female:
+																							43441</item><item>Male:
+																	35441</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1373</item><item>Not Hispanic or Latino:
+																							76145</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							32876</item><item>Medicaid: 8805</item><item>Private
+																							Health Insurance: 34866</item><item>Other:
+																							2515</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 143</item><item>Asian:
+																							1442</item><item>Black or African American:
+																							12388</item><item>Native Hawaiian or Other Pacific
+																							Islander: 79</item><item>White:
+																							62938</item><item>Other Race:
+																			1102</item></list></item></list></item>
+													<item>Performance Rate: .663806</item>
+													<item>Denominator Exclusions: 18411<list><item>Sex<list><item>Female:
+																							10945</item><item>Male:
+																	7418</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 229</item><item>Not Hispanic or Latino:
+																							17848</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							15125</item><item>Medicaid: 1362</item><item>Private
+																							Health Insurance: 1728</item><item>Other:
+																					196</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 38</item><item>Asian:
+																							177</item><item>Black or African American:
+																							3322</item><item>Native Hawaiian or Other Pacific
+																							Islander: 9</item><item>White:
+																							14499</item><item>Other Race:
+																			194</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Preventive Care and Screening: Screening for Depression and
+																			Follow-Up Plan</td>
+																	<td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
+																	<td>11.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-1e6f57410551</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: PREVENTIVE CARE AND SCREENING - eMeasure
+													ID:9a031e24-3d9b-11e1-8634-00237d5bf174</content>
+											<list>
+													<item>Initial Patient Population:
+																							470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Denominator: 470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Numerator: 54746<list><item>Sex<list><item>Female:
+																							27933</item><item>Male:
+																	26716</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1354</item><item>Not Hispanic or Latino:
+																							52341</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							21893</item><item>Medicaid: 4526</item><item>Private
+																							Health Insurance: 26530</item><item>Other:
+																							1797</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 94</item><item>Asian:
+																							2252</item><item>Black or African American:
+																							8405</item><item>Native Hawaiian or Other Pacific
+																							Islander: 76</item><item>White:
+																							41717</item><item>Other Race:
+																			1323</item></list></item></list></item>
+													<item>Performance Rate: .17507</item>
+													<item>Denominator Exclusions: 157128<list><item>Sex<list><item>Female:
+																							114970</item><item>Male:
+																	41822</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 3781</item><item>Not Hispanic or Latino:
+																							150919</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							43328</item><item>Medicaid:
+																							33374</item><item>Private Health Insurance:
+																							74673</item><item>Other:
+																	5752</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 282</item><item>Asian:
+																							1360</item><item>Black or African American:
+																							20705</item><item>Native Hawaiian or Other Pacific
+																							Islander: 131</item><item>White:
+																							129643</item><item>Other Race:
+																			3340</item></list></item></list></item>
+													<item>Denominator Exceptions: 538<list><item>Sex<list><item>Female:
+																							402</item><item>Male:
+																	135</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 20</item><item>Not Hispanic or Latino:
+																							499</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							152</item><item>Medicaid: 58</item><item>Private
+																							Health Insurance: 303</item><item>Other:
+																					25</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 0</item><item>Asian:
+																							26</item><item>Black or African American:
+																							97</item><item>Native Hawaiian or Other Pacific
+																							Islander: 0</item><item>White: 377</item><item>Other
+																							Race: 18</item></list></item></list></item>
+											</list>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72B98C12-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-74c2-3313-0174-c60bd07b02a6"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;
+																			9%)</text>
+																	<setId root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".336026"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="D0F9A8EF-6C52-429A-A522-B568269EF39A"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0A5B121A-16A0-41A1-8749-58BD992813C1"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="3742"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1926"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1804"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="36"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="669"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2972"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="37"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3338"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="117"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="247"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="40"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F4F7D899-682A-43D0-9506-75C0D7C08A76"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="16515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7511"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="512"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15602"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="271"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11845"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="413"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5621"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3471"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="6808"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="615"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72BDD61E-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-2382d1bd06b1"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Controlling High Blood Pressure</text>
+																	<setId root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".663806"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="947E37E4-7BC7-4BF0-985F-D8A3F83140D6"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="98174296-AE1D-4245-A8B3-C690B00ADD72"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="18411"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10945"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7418"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="229"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="17848"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="177"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="9"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="194"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15125"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1362"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1728"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="196"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="B1176EC6-38FD-4134-865F-65D69C056518"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="79062"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1373"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76145"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="143"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1442"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="12388"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="79"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62938"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1102"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="32876"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8805"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="34866"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2515"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72C21C92-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-1e6f57410551"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Preventive Care and Screening: Screening for Depression
+																			and Follow-Up Plan</text>
+																	<setId root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>PREVENTIVE CARE AND SCREENING</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".17507"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DD0526C9-DAB8-46C7-B169-ECD268E8E291"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="EBB00435-8DB2-4958-90B2-AC0FA76A5281"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="157128"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114970"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3781"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="150919"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="282"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1360"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20705"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="131"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="129643"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3340"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43328"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="74673"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5752"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F6DBBAC9-8089-432A-8DE2-BF19F9BED2AA"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEXCEP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exceptions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="538"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="402"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="97"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="377"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="18"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="152"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="58"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="303"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="25"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="7B8F391D-444D-4872-BEEC-1F59F4AB5ABF"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="54746"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27933"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26716"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1354"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="52341"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="94"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2252"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8405"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41717"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="21893"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4526"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26530"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1797"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C77D2C-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220101"/>
+															<high value="20221231"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.4"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Improvement Activity Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Improvement Activity Title</th>
+																	<th>Improvement Activity ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Engagement of patients through implementation of
+																			improvements in patient portal</td>
+																	<td>IA_BE_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Engagement of patients, family and caregivers in developing
+																			a plan of care</td>
+																	<td>IA_BE_15</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Implementation of improvements that contribute to more
+																			timely communication of test results</td>
+																	<td>IA_CC_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Practice improvements for bilateral exchange of patient
+																			information</td>
+																	<td>IA_CC_13</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</td>
+																	<td>IA_EPA_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7C7B4-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_4" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients through implementation of
+																			improvements in patient portal</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7D63C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_15" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients, family and caregivers in
+																			developing a plan of care</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7E438-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_2" root="2.16.840.1.113883.3.7034"/>
+																	<text>Implementation of improvements that contribute to more
+																			timely communication of test results</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7F216-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_13" root="2.16.840.1.113883.3.7034"/>
+																	<text>Practice improvements for bilateral exchange of patient
+																			information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7FF4A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_EPA_1" root="2.16.840.1.113883.3.7034"/>
+																	<text>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C80E0E-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.5"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Promoting Interoperability Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Promoting Interoperability Measure Title</th>
+																	<th>Promoting Interoperability Measure ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>E-Prescribing</td>
+																	<td>PI_EP_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .987514</item>
+																					<item>Numerator: 752879</item>
+																					<item>Denominator: 762398</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Patient Electronic Access (Provided Within 4 Business
+																			Days)</td>
+																	<td>PI_PEA_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .97764</item>
+																					<item>Numerator: 277373</item>
+																					<item>Denominator: 283717</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Protect Patient Health Information</td>
+																	<td>PI_PPHI_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Query of Prescription Drug Monitoring Program</td>
+																	<td>PI_EP_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</td>
+																	<td>PI_HIE_5</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Safety Assurance Factors for EHR Resilience Guides</td>
+																	<td>PI_PPHI_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Immunization Registry Reporting</td>
+																	<td>PI_PHCDRR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Case Reporting</td>
+																	<td>PI_PHCDRR_3</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Public Health Registry Reporting</td>
+																	<td>PI_PHCDRR_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Clinical Data Registry Reporting</td>
+																	<td>PI_PHCDRR_5</td>
+																	<td>Measure Performed: No</td>
+															</tr>
+															<tr>
+																	<td>Prevention of Information Blocking Attestation</td>
+																	<td>PI_INFBLO_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC-ACB Surveillance Attestation</td>
+																	<td>PI_ONCACB_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC Direct Review Attestation</td>
+																	<td>PI_ONCDIR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C85436-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>E-Prescribing</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".987514"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="752879"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="762398"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C87E02-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PEA_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Patient Electronic Access (Provided Within 4 Business
+																			Days)</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".97764"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="277373"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="283717"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8A5F8-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Protect Patient Health Information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8B444-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Query of Prescription Drug Monitoring Program</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8C33A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_HIE_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8D17C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Safety Assurance Factors for EHR Resilience Guides</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8E02C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Immunization Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8EE64-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_3" root="2.16.840.1.113883.3.7031"/>
+																	<text>Case Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8FC6A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_4" root="2.16.840.1.113883.3.7031"/>
+																	<text>Public Health Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C90ACA-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Clinical Data Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="N"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="No"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C91876-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_INFBLO_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Prevention of Information Blocking Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C92618-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCACB_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC-ACB Surveillance Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C93428-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCDIR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC Direct Review Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C9430A-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+			</structuredBody>
 	</component>
 </ClinicalDocument>

--- a/sample-files/2022/App1-Indv-QRDA-III.xml
+++ b/sample-files/2022/App1-Indv-QRDA-III.xml
@@ -184,4583 +184,7487 @@ CDA Header
 	********************************************************
 	-->
 	<component>
-		<structuredBody>
-			<!--
-			********************************************************
-			QRDA Category III Measure Section - CMS (V2)
-			urn:hl7ii:2.16.840.1.113883.10.20.27.2.3:2017-07-01
-			********************************************************
-			-->
-			<component>
-				<section>
-					<!-- Measure Section -->
-					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
-					<!-- QRDA Category III Measure Section (V4) -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
-					<!-- QRDA Category III Measure Section - CMS (V2) -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.3" extension="2019-05-01"/>
-					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
-						  displayName="measure section"/>
-					<title>Measure Section</title>
-					<text>
-						<!--CMS165v8/NQF0018: Controlling High Blood Pressure -->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Controlling High Blood Pressure</td>
-									<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
-									<td>40280381-51f0-825b-0152-22b98cff181a</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>:0.842105
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:50
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>30
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or Latino</content>40
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or Latino</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African American</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>20
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicare</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Medicaid</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health Insurance</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>10
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-
-						<!-- CMS122v5/NQF0059: Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)-->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (> 9%)</td>
-									<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
-									<td>40280381-51f0-825b-0152-229afff616ee</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.947368
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:950
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:900
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>598
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>50
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>2
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-
-						<!-- CMS68v6/NQF0419: Documentation of Current Medications in the Medical Record -->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Documentation of Current Medications in the Medical Record</td>
-									<td>9a032d9c-3d9b-11e1-8634-00237d5bf174</td>
-									<td>40280381-52fc-3a32-0153-3d64af97147b</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.816327
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exceptions</content>:20
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>12
-									</item>
-									<item>
-										<content styleCode="Bold">Gender - Female</content>8
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>18
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>2
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>3
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>15
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>2
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>10
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>3
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>5
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>2
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator</content>:1000
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>400
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>600
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>650
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>350
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:800
-								<list>
-									<item>
-										<content styleCode="Bold">Gender - Male</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Gender -
-											Female</content>500
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Not Hispanic or
-											Latino</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Ethnicity - Hispanic or
-											Latino</content>550
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Black or African
-											American</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - White</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Race - Asian</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Race - American Indian or Alaska
-											Native</content>0
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicare</content>300
-									</item>
-									<item>
-										<content styleCode="Bold">Payer -
-											Medicaid</content>200
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Private Health
-											Insurance</content>250
-									</item>
-									<item>
-										<content styleCode="Bold">Payer - Other</content>50
-									</item>
-								</list>
-							</item>
-						</list>
-
-
-						<!-- CMS160v5/NQF0712: Depression Utilization of the PHQ-9 Tool -->
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>eMeasure Title</th>
-									<th>Version neutral identifier</th>
-									<th>Version specific identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Depression Utilization of the PHQ-9 Tool</td>
-									<td>a4b9763c-847e-4e02-bb7e-acc596e90e2c</td>
-									<td>40280381-503f-a1fc-0150-afe320c01761</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.860177
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:600
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Population</content>:600
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:35
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:486
-							</item>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.921052
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:800
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Population</content>:800
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:40
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:700
-							</item>
-							<item>
-								<content styleCode="Bold">Performance Rate</content>0.962963
-							</item>
-							<item>
-								<content styleCode="Bold">Initial Population</content>:580
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Population</content>:580
-							</item>
-							<item>
-								<content styleCode="Bold">Denominator Exclusions</content>:40
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator</content>:520
-							</item>
-						</list>
-					</text>
-
-					<!--Measure Entry for CMS165v8-->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
-							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2016-11-01"/>
-							<id root="D5E68474-5760-11E7-1256-09173F13E4C5"/>
-							<statusCode code="completed"/>
-							<!--Measure Reference and Results-->
-							<reference typeCode="REFR">
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<id root="2.16.840.1.113883.4.738" extension="2c928085-7198-38ee-0171-9da6456007ab"/>
-									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-										  displayName="Health Quality Measure Document"/>
-									<text>Controlling High Blood Pressure</text>
-								</externalDocument>
-							</reference>
-							<!--Performance Rate-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2016-11-01"/>
-									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-										  displayName="Performance Rate"/>
-									<statusCode code="completed"/>
-									<value xsi:type="REAL" value=".888889"/>
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
-											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="Numerator"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--IPOP Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
-									<!--IPOP Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68475-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68476-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68477-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68478-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68479-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6847A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6847B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6847C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6847D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6847E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6847F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68480-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--IPOP Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="87338BA5-170B-4264-9E59-6A4A3A57C785"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--DENOM Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENOM Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68481-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68482-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68483-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68484-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68485-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68486-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68487-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68488-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68489-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6848A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6848B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E6848C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENOM Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="B2E2AA67-26CD-48CB-9536-094F1D047149"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--DENEX Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENEX Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="100"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E6848D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E6848E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E6848F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E68490-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68491-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68492-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68493-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68494-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68495-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68496-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68497-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E68498-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENEX Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="9B6EDB4C-A390-4833-A135-2A2AC6334126"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--NUMER Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-										  displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--NUMER Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="800"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E68499-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.21" extension="2016-11-01"/>
-											<id root="D5E6849A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E6849B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2186-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.22" extension="2016-11-01"/>
-											<id root="D5E6849C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2135-2" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6849D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2054-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6849E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2106-3" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E6849F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2028-9" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E684A0-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="1002-5" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2076-8" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.19" extension="2016-11-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Race"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" code="2131-1" codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A1-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A2-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A3-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18" extension="2018-05-01"/>
-											<id root="D5E684A4-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-												  displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<effectiveTime>
-												<low value="20170101"/>
-												<high value="20171231"/>
-											</effectiveTime>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<templateId root="2.16.840.1.113883.10.20.27.3.24"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--NUMER Population ID from eMeasure-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="63DAFD4E-CBD5-4BEE-BE19-E64337356748"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-
-					<!--Measure Entry for CMS122v8-->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- Measure Reference Template -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
-							<!-- Measure Reference & Results Template -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.17" extension="2018-05-01"/>
-							<!-- CMS Measure Reference & Results Template -->
-							<id root="D5E68229-5760-11E7-1256-09173F13E4C5"/>
-							<statusCode code="completed"/>
-							<!--Measure Reference and Results-->
-							<reference typeCode="REFR">
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<id root="2.16.840.1.113883.4.738"
-										extension="2c928085-7198-38ee-0171-9d78a0d406b3"/>
-									<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
-										  codeSystemName="LOINC" displayName="Health Quality Measure Document"/>
-									<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</text>
-								</externalDocument>
-							</reference>
-							<!--Performance Rate-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
-									<!-- Performance Rate Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
-									<!-- Performance Rate for Proportion Measure Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.25" extension="2018-05-01"/>
-									<!-- CMS Performance Rate for Proportion Measure Template -->
-									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
-										  codeSystemName="LOINC" displayName="Performance Rate"/>
-									<statusCode code="completed"/>
-									<value xsi:type="REAL" value=".888889"/>
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
-											<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="Numerator"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!--IPOP Population-->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="IPOP" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--IPOP Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--IPOP Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="C7396995-408E-4254-BF40-D2CD2A97E858"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!-- DENOM Population -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENOM" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENOM Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="1000"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="500"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="250"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENOM Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="02793E57-2555-4145-BECF-1BE0F6CAED62"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!-- DENEX Population -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENEX" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--DENEX Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="100"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="50"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="25"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--DENEX Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="3FAC8D80-C279-47FC-B001-5E41407757AF"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-							<!-- NUMER Population -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
-									<!-- Measure Data Template -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2018-05-01"/>
-									<!-- CMS Measure Data Template -->
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="NUMER" codeSystem="2.16.840.1.113883.5.4"
-										   codeSystemName="ActCode"/>
-									<!--NUMER Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode" displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="800"/>
-											<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod" displayName="Count"/>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Male-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822A-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="M" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Male"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Gender Supplemental Data Element - Female-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.6"
-														extension="2016-09-01"/>
-											<id root="D5E6822B-5760-11E7-1256-09173F13E4C5"/>
-											<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Sex assigned at birth"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1"
-												   codeSystemName="AdministrativeGenderCode" displayName="Female"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Not Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822C-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2186-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Not Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Ethnicity Supplemental Data Element - Hispanic or Latino-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.7"
-														extension="2016-09-01"/>
-											<id root="D5E6822D-5760-11E7-1256-09173F13E4C5"/>
-											<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Ethnicity"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2135-2"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Hispanic or Latino"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="400"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Black or African American-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822E-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2054-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Black or African American"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - White-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E6822F-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2106-3"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="White"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Asian-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68230-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2028-9"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC" displayName="Asian"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - American Indian or Alaska Native-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68231-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="1002-5"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="American Indian or Alaska Native"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Native Hawaiian or Other Pacific Islander-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2076-8"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Native Hawaiian or Other Pacific Islander"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Race Supplemental Data Element - Other Race-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.8"
-														extension="2016-09-01"/>
-											<id root="D5E68448-5760-11E7-1256-09173F13E4C5"/>
-											<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Race"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" code="2131-1"
-												   codeSystem="2.16.840.1.113883.6.238"
-												   codeSystemName="Race &amp; Ethnicity - CDC"
-												   displayName="Other Race"/>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="0"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicare-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68232-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="A" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicare"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Medicaid-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68233-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="B" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Medicaid"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Private Health Insurance-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68234-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="C" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes"
-															 displayName="Private Health Insurance"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--Payer Supplemental Data Element - Other-->
-									<entryRelationship typeCode="COMP">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.9"
-														extension="2016-02-01"/>
-											<templateId root="2.16.840.1.113883.10.20.27.3.18"
-														extension="2018-05-01"/>
-											<id root="D5E68235-5760-11E7-1256-09173F13E4C5"/>
-											<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
-												  codeSystemName="LOINC" displayName="Payment Source"/>
-											<statusCode code="completed"/>
-											<value xsi:type="CD" nullFlavor="OTH">
-												<translation code="D" codeSystem="2.16.840.1.113883.3.249.12"
-															 codeSystemName="CMS Clinical Codes" displayName="Other"/>
-											</value>
-											<!-- Count-->
-											<entryRelationship typeCode="SUBJ" inversionInd="true">
-												<observation classCode="OBS" moodCode="EVN">
-													<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-													<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-														  codeSystemName="ActCode" displayName="rate aggregation"/>
-													<statusCode code="completed"/>
-													<value xsi:type="INT" value="200"/>
-													<methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84"
-																codeSystemName="ObservationMethod" displayName="Count"/>
-												</observation>
-											</entryRelationship>
-										</observation>
-									</entryRelationship>
-									<!--NUMER Population ID from eCQM-->
-									<reference typeCode="REFR">
-										<externalObservation classCode="OBS" moodCode="EVN">
-											<id root="44E72F3A-B3EC-42E6-85DB-928A9515255C"/>
-										</externalObservation>
-									</reference>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-
-					<!-- Reporting Parameters Act -->
-					<entry typeCode="DRIV">
-						<act classCode="ACT" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
-							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
-								  displayName="Observation Parameters"/>
-							<effectiveTime>
-								<low value="20220101"/>
-								<high value="20221231"/>
-							</effectiveTime>
-						</act>
-					</entry>
-				</section>
-			</component>
-			<!--
-		  	********************************************************
-		  	Promoting Interoperability Section (V2)
-		  	urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01
-		  	********************************************************
-		  	-->
-			<component>
-				<section>
-					<!-- Measure Section -->
-					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
-					<!-- Advancing Care Information Section templateId -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.5" extension="2017-06-01"/>
-					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
-						  displayName="Measure Section"/>
-					<title>Measure Section</title>
-					<text>
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>PI Measure Title</th>
-									<th>Measure Identifier</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Provide Patient Access</td>
-									<td>PI_PEA_1</td>
-								</tr>
-							</tbody>
-						</table>
-						<list>
-							<item>
-								<content styleCode="Bold">Denominator:</content>800
-							</item>
-							<item>
-								<content styleCode="Bold">Numerator:</content>600
-							</item>
-							<item>
-								<content styleCode="Bold">Performance Rate:
-								</content>0.75
-							</item>
-						</list>
-						<list>
-							<item>
-								<content styleCode="Bold">Measure Answer (Yes/No):
-								</content>Yes
-							</item>
-						</list>
-					</text>
-					<!-- PI_PEA_1	Reporting Metric: Numerator/Denominator -->
-					<!-- Advancing Care Information Numerator Denominator Type Measure Reference and Results -->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<!-- Implied template Measure Reference templateId -->
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- PI Numerator Denominator Type Measure Reference and Results templateId -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.28"
-										extension="2017-06-01"/>
-							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
-							<statusCode code="completed"/>
-							<reference typeCode="REFR">
-								<!-- Reference to a particular PI measure's unique identifier. -->
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<!-- This is a temporary root OID that indicates this is an PI measure identifier -->
-									<id root="2.16.840.1.113883.3.7031" extension="PI_PEA_1"/>
-									<!-- PI measure title -->
-									<text>Provide Patient Access</text>
-								</externalDocument>
-							</reference>
-							<!-- Performance Rate for PI is optional -->
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- Performance Rate templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.30"
-												extension="2016-09-01"/>
-									<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
-										  codeSystemName="LOINC" displayName="Performance Rate"/>
-									<statusCode code="completed"/>
-									<value xsi:type="REAL" value="0.75"/>
-								</observation>
-							</component>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- PI Numerator Denominator Type Measure Numerator Data templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.31"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="NUMER"
-										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
-									<!-- Numerator Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="600"/>
-											<methodCode code="COUNT"
-														codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod"
-														displayName="Count"/>
-										</observation>
-									</entryRelationship>
-								</observation>
-							</component>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- PI Numerator Denominator Type Measure Denominator Data templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.32"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="DENOM"
-										   codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
-									<!-- Denominator Count-->
-									<entryRelationship typeCode="SUBJ" inversionInd="true">
-										<observation classCode="OBS" moodCode="EVN">
-											<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
-											<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
-												  codeSystemName="ActCode"
-												  displayName="rate aggregation"/>
-											<statusCode code="completed"/>
-											<value xsi:type="INT" value="800"/>
-											<methodCode code="COUNT"
-														codeSystem="2.16.840.1.113883.5.84"
-														codeSystemName="ObservationMethod"
-														displayName="Count"/>
-										</observation>
-									</entryRelationship>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-
-					<!-- Reporting Parameters Act -->
-					<entry typeCode="DRIV">
-						<act classCode="ACT" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
-							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
-								  displayName="Observation Parameters"/>
-							<effectiveTime>
-								<low value="20220201"/>
-								<high value="20220531"/>
-							</effectiveTime>
-						</act>
-					</entry>
-				</section>
-			</component>
-
-			<!--
-			********************************************************
-			Improvement Activity Section (V2)
-			urn:hl7ii:2.16.840.1.113883.10.20.27.2.4:2017-06-01
-			********************************************************
-			-->
-			<component>
-				<section>
-					<!-- Measure Section -->
-					<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
-					<!-- Improvement Activity Section templateId -->
-					<templateId root="2.16.840.1.113883.10.20.27.2.4" extension="2017-06-01"/>
-					<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"
-						  displayName="Measure Section"/>
-					<title>Measure Section</title>
-					<text>
-						<table border="1" width="100%">
-							<thead>
-								<tr>
-									<th>Improvement Activity Name</th>
-									<th>Activity ID</th>
-									<th>Question Answer Code</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Collection and use of patient experience and satisfaction data on access</td>
-									<td>IA_EPA_3</td>
-									<td>Y</td>
-								</tr>
-
-								<tr>
-									<td>Care transition documentation practice improvements</td>
-									<td>IA_CC_10</td>
-									<td>Y</td>
-								</tr>
-							</tbody>
-						</table>
-					</text>
-					<!-- Must have at least one entry with a Measure Performed Reference and Result -->
-					<!-- IA_EPA_3 -->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<!-- Implied template Measure Reference templateId -->
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- Improvement Activity Performed Reference and Results templateId -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.33" extension="2016-09-01"/>
-							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
-							<statusCode code="completed"/>
-							<reference typeCode="REFR">
-								<!-- Reference to a particular PI measure's unique identifier. -->
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
-									<id root="2.16.840.1.113883.3.7034" extension="IA_EPA_3"/>
-									<!-- Improvement activity narrative text (for reference) -->
-									<text>Collection and use of patient experience and satisfaction data on access</text>
-								</externalDocument>
-							</reference>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- Measure Performed templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.27"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="Y" displayName="Yes"
-										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
-										   codeSystem="2.16.840.1.113883.12.136"/>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-					<!-- IA_CC_10 -->
-					<entry>
-						<organizer classCode="CLUSTER" moodCode="EVN">
-							<!-- Implied template Measure Reference templateId -->
-							<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
-							<!-- Improvement Activity Performed Reference and Results templateId -->
-							<templateId root="2.16.840.1.113883.10.20.27.3.33"
-										extension="2016-09-01"/>
-							<id root="ac575aef-7062-4ea2-b723-df517cfa470a"/>
-							<statusCode code="completed"/>
-							<reference typeCode="REFR">
-								<!-- Reference to a particular PI measure's unique identifier. -->
-								<externalDocument classCode="DOC" moodCode="EVN">
-									<!-- This is a temporary root OID that indicates this is an improvement activity identifier -->
-									<id root="2.16.840.1.113883.3.7034" extension="IA_CC_10"/>
-									<!-- Improvement activity narrative text (for reference) -->
-									<text>Care transition documentation practice improvements</text>
-								</externalDocument>
-							</reference>
-							<component>
-								<observation classCode="OBS" moodCode="EVN">
-									<!-- Measure Performed templateId -->
-									<templateId root="2.16.840.1.113883.10.20.27.3.27"
-												extension="2016-09-01"/>
-									<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
-										  codeSystemName="ActCode" displayName="Assertion"/>
-									<statusCode code="completed"/>
-									<value xsi:type="CD" code="Y" displayName="Yes"
-										   codeSystemName="Yes/no indicator (HL7 Table 0136)"
-										   codeSystem="2.16.840.1.113883.12.136"/>
-								</observation>
-							</component>
-						</organizer>
-					</entry>
-					<!-- Reporting Parameters Act -->
-					<entry typeCode="DRIV">
-						<act classCode="ACT" moodCode="EVN">
-							<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-							<id root="00b669fd-fa4d-4f5c-b109-65c6bbbf73ae"/>
-							<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
-								  displayName="Observation Parameters"/>
-							<effectiveTime>
-								<low value="20220101"/>
-								<high value="20220430"/>
-							</effectiveTime>
-						</act>
-					</entry>
-				</section>
-			</component>
-		</structuredBody>
+			<structuredBody>
+					<component>
+							<section>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+									<templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>eMeasure Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Jan 1, 2022 - Dec 31, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt; 9%)</td>
+																	<td>f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-74c2-3313-0174-c60bd07b02a6</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:f2986519-5a4e-4149-a8f2-af0a1dc7f6bc</content>
+											<list>
+													<item>Initial Patient Population:
+																							52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Denominator: 52890<list><item>Sex<list><item>Female:
+																							27982</item><item>Male:
+																	24770</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1466</item><item>Not Hispanic or Latino:
+																							50374</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							20800</item><item>Medicaid: 8033</item><item>Private
+																							Health Insurance: 22443</item><item>Other:
+																							1614</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 135</item><item>Asian:
+																							1187</item><item>Black or African American:
+																							10540</item><item>Native Hawaiian or Other Pacific
+																							Islander: 77</item><item>White:
+																							38959</item><item>Other Race:
+																			1201</item></list></item></list></item>
+													<item>Numerator: 16515<list><item>Sex<list><item>Female:
+																							8959</item><item>Male:
+																	7511</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 512</item><item>Not Hispanic or Latino:
+																							15602</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							5621</item><item>Medicaid: 3471</item><item>Private
+																							Health Insurance: 6808</item><item>Other:
+																					615</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 33</item><item>Asian:
+																							271</item><item>Black or African American:
+																							3610</item><item>Native Hawaiian or Other Pacific
+																							Islander: 35</item><item>White:
+																							11845</item><item>Other Race:
+																			413</item></list></item></list></item>
+													<item>Performance Rate: .336026</item>
+													<item>Denominator Exclusions: 3742<list><item>Sex<list><item>Female:
+																							1926</item><item>Male:
+																	1804</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 36</item><item>Not Hispanic or Latino:
+																							3639</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							3338</item><item>Medicaid: 117</item><item>Private
+																							Health Insurance: 247</item><item>Other:
+																					40</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 8</item><item>Asian:
+																							19</item><item>Black or African American:
+																							669</item><item>Native Hawaiian or Other Pacific
+																							Islander: 2</item><item>White:
+																							2972</item><item>Other Race:
+																	37</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Controlling High Blood Pressure</td>
+																	<td>abdc37cc-bac6-4156-9b91-d1be2c8b7268</td>
+																	<td>10.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-2382d1bd06b1</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: NONE - eMeasure
+													ID:abdc37cc-bac6-4156-9b91-d1be2c8b7268</content>
+											<list>
+													<item>Initial Patient Population:
+																							137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Denominator: 137515<list><item>Sex<list><item>Female:
+																							75071</item><item>Male:
+																	62118</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 2322</item><item>Not Hispanic or Latino:
+																							132459</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							63996</item><item>Medicaid:
+																							15536</item><item>Private Health Insurance:
+																							53791</item><item>Other:
+																	4192</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 259</item><item>Asian:
+																							2192</item><item>Black or African American:
+																							24323</item><item>Native Hawaiian or Other Pacific
+																							Islander: 136</item><item>White:
+																							106905</item><item>Other Race:
+																			1963</item></list></item></list></item>
+													<item>Numerator: 79062<list><item>Sex<list><item>Female:
+																							43441</item><item>Male:
+																	35441</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1373</item><item>Not Hispanic or Latino:
+																							76145</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							32876</item><item>Medicaid: 8805</item><item>Private
+																							Health Insurance: 34866</item><item>Other:
+																							2515</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 143</item><item>Asian:
+																							1442</item><item>Black or African American:
+																							12388</item><item>Native Hawaiian or Other Pacific
+																							Islander: 79</item><item>White:
+																							62938</item><item>Other Race:
+																			1102</item></list></item></list></item>
+													<item>Performance Rate: .663806</item>
+													<item>Denominator Exclusions: 18411<list><item>Sex<list><item>Female:
+																							10945</item><item>Male:
+																	7418</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 229</item><item>Not Hispanic or Latino:
+																							17848</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							15125</item><item>Medicaid: 1362</item><item>Private
+																							Health Insurance: 1728</item><item>Other:
+																					196</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 38</item><item>Asian:
+																							177</item><item>Black or African American:
+																							3322</item><item>Native Hawaiian or Other Pacific
+																							Islander: 9</item><item>White:
+																							14499</item><item>Other Race:
+																			194</item></list></item></list></item>
+											</list>
+											<table border="1" width="100%">
+													<colgroup>
+															<col width="30%"/>
+															<col width="25%"/>
+															<col width="5%"/>
+															<col width="5%"/>
+															<col width="25%"/>
+													</colgroup>
+													<thead>
+															<tr>
+																	<th>eMeasure Title</th>
+																	<th>Version Neutral ID</th>
+																	<th>eMeasure Version Number</th>
+																	<th>NQF Measure Number</th>
+																	<th>Version Specific ID</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Preventive Care and Screening: Screening for Depression and
+																			Follow-Up Plan</td>
+																	<td>9a031e24-3d9b-11e1-8634-00237d5bf174</td>
+																	<td>11.0.000</td>
+																	<td/>
+																	<td>2c928082-7505-caf9-0175-1e6f57410551</td>
+															</tr>
+													</tbody>
+											</table>
+											<content>Member of Measure Set: PREVENTIVE CARE AND SCREENING - eMeasure
+													ID:9a031e24-3d9b-11e1-8634-00237d5bf174</content>
+											<list>
+													<item>Initial Patient Population:
+																							470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Denominator: 470376<list><item>Sex<list><item>Female:
+																							287905</item><item>Male:
+																	181639</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 14065</item><item>Not Hispanic or Latino:
+																							446425</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							114944</item><item>Medicaid:
+																							82205</item><item>Private Health Insurance:
+																							253927</item><item>Other:
+																	19298</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 822</item><item>Asian:
+																							11314</item><item>Black or African American:
+																							71638</item><item>Native Hawaiian or Other Pacific
+																							Islander: 610</item><item>White:
+																							364169</item><item>Other Race:
+																			13343</item></list></item></list></item>
+													<item>Numerator: 54746<list><item>Sex<list><item>Female:
+																							27933</item><item>Male:
+																	26716</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 1354</item><item>Not Hispanic or Latino:
+																							52341</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							21893</item><item>Medicaid: 4526</item><item>Private
+																							Health Insurance: 26530</item><item>Other:
+																							1797</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 94</item><item>Asian:
+																							2252</item><item>Black or African American:
+																							8405</item><item>Native Hawaiian or Other Pacific
+																							Islander: 76</item><item>White:
+																							41717</item><item>Other Race:
+																			1323</item></list></item></list></item>
+													<item>Performance Rate: .17507</item>
+													<item>Denominator Exclusions: 157128<list><item>Sex<list><item>Female:
+																							114970</item><item>Male:
+																	41822</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 3781</item><item>Not Hispanic or Latino:
+																							150919</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							43328</item><item>Medicaid:
+																							33374</item><item>Private Health Insurance:
+																							74673</item><item>Other:
+																	5752</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 282</item><item>Asian:
+																							1360</item><item>Black or African American:
+																							20705</item><item>Native Hawaiian or Other Pacific
+																							Islander: 131</item><item>White:
+																							129643</item><item>Other Race:
+																			3340</item></list></item></list></item>
+													<item>Denominator Exceptions: 538<list><item>Sex<list><item>Female:
+																							402</item><item>Male:
+																	135</item></list></item></list><list><item>Ethnicity<list><item>Hispanic
+																							or Latino: 20</item><item>Not Hispanic or Latino:
+																							499</item></list></item></list><list><item>Payer<list><item>Medicare:
+																							152</item><item>Medicaid: 58</item><item>Private
+																							Health Insurance: 303</item><item>Other:
+																					25</item></list></item></list><list><item>Race<list><item>American
+																							Indian or Alaska Native: 0</item><item>Asian:
+																							26</item><item>Black or African American:
+																							97</item><item>Native Hawaiian or Other Pacific
+																							Islander: 0</item><item>White: 377</item><item>Other
+																							Race: 18</item></list></item></list></item>
+											</list>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72B98C12-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-74c2-3313-0174-c60bd07b02a6"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;
+																			9%)</text>
+																	<setId root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="f2986519-5a4e-4149-a8f2-af0a1dc7f6bc"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".336026"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="D0F9A8EF-6C52-429A-A522-B568269EF39A"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="52890"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27982"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24770"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1466"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="50374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1187"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10540"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="77"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1201"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20800"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8033"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="22443"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1614"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0A5B121A-16A0-41A1-8749-58BD992813C1"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="3742"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1926"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1804"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="36"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="669"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2972"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="37"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3338"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="117"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="247"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="40"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F4F7D899-682A-43D0-9506-75C0D7C08A76"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="16515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8959"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7511"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="512"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15602"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="271"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11845"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="413"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5621"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3471"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="6808"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="615"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="0E994FD7-399A-46AE-84F3-D4286EB35AD8"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72BDD61E-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-2382d1bd06b1"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Controlling High Blood Pressure</text>
+																	<setId root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="abdc37cc-bac6-4156-9b91-d1be2c8b7268"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>NONE</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".663806"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="947E37E4-7BC7-4BF0-985F-D8A3F83140D6"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="137515"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="75071"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62118"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="132459"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="259"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="24323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="136"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="106905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1963"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="63996"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15536"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="53791"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4192"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="98174296-AE1D-4245-A8B3-C690B00ADD72"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="18411"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="10945"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="7418"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="229"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="17848"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="38"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="177"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3322"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="9"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="194"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="15125"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1362"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1728"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="196"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="B1176EC6-38FD-4134-865F-65D69C056518"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="79062"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="35441"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1373"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76145"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="143"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1442"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="12388"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="79"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="62938"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1102"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="32876"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8805"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="34866"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2515"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DA4AB896-88EF-4F3E-8F44-15165CEEAA0E"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+													<templateId extension="2019-05-01"
+															root="2.16.840.1.113883.10.20.27.3.17"/>
+													<id root="72C21C92-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="2c928082-7505-caf9-0175-1e6f57410551"
+																			root="2.16.840.1.113883.4.738"/>
+																	<code code="57024-2" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Health Quality Measure Document"
+																			codeSystemName="LOINC"/>
+																	<text>Preventive Care and Screening: Screening for Depression
+																			and Follow-Up Plan</text>
+																	<setId root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+															</externalDocument>
+													</reference>
+													<reference typeCode="REFR">
+															<externalObservation>
+																	<id root="9a031e24-3d9b-11e1-8634-00237d5bf174"/>
+																	<code code="55185-3" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Measure Set" codeSystemName="LOINC"/>
+																	<text>PREVENTIVE CARE AND SCREENING</text>
+															</externalObservation>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.14"/>
+																	<templateId extension="2018-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.25"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".17507"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<reference typeCode="REFR">
+																			<externalObservation classCode="OBS" moodCode="EVN">
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																					<code code="NUMER" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="Numerator"
+																							codeSystemName="ObservationValue"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="IPOP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="initial population"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="DD0526C9-DAB8-46C7-B169-ECD268E8E291"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="470376"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="287905"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="181639"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="14065"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="446425"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="11314"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="71638"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="610"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="364169"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="13343"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114944"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="82205"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="253927"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="19298"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="EBB00435-8DB2-4958-90B2-AC0FA76A5281"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEX"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exclusions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="157128"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="114970"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41822"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3781"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="150919"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="282"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1360"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20705"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="131"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="129643"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="3340"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="43328"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="33374"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="74673"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="5752"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="F6DBBAC9-8089-432A-8DE2-BF19F9BED2AA"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENEXCEP"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator Exceptions"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="538"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="402"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="135"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="20"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="499"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="97"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="0"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="377"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="18"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="152"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="58"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="303"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="25"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="7B8F391D-444D-4872-BEEC-1F59F4AB5ABF"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.5"/>
+																	<templateId extension="2019-05-01"
+																			root="2.16.840.1.113883.10.20.27.3.16"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="INT" value="54746"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="F"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Female"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="27933"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.6"/>
+																					<code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Sex assigned at birth"
+																							codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="M"
+																							codeSystem="2.16.840.1.113883.5.1"
+																							displayName="Male"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26716"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2135-2"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1354"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.7"/>
+																					<code code="69490-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Ethnic" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2186-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Not Hispanic or Latino"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="52341"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="1002-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="American Indian or Alaska Native"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="94"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2028-9"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Asian"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="2252"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2054-5"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Black or African American"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="8405"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2076-8"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Native Hawaiian or Other Pacific Islander"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="76"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2106-3"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="White"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="41717"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId extension="2016-09-01"
+																							root="2.16.840.1.113883.10.20.27.3.8"/>
+																					<code code="72826-1" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Race" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<value xsi:type="CD" code="2131-1"
+																							codeSystem="2.16.840.1.113883.6.238"
+																							displayName="Other Race"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1323"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="A"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicare"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="21893"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="B"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Medicaid"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="4526"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="C"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Private Health Insurance"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="26530"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<entryRelationship typeCode="COMP">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+																					<templateId extension="2016-02-01"
+																							root="2.16.840.1.113883.10.20.27.3.9"/>
+																					<templateId extension="2018-05-01"
+																							root="2.16.840.1.113883.10.20.27.3.18"/>
+																					<id nullFlavor="NA"/>
+																					<code code="48768-6" codeSystem="2.16.840.1.113883.6.1"
+																							displayName="Payment source" codeSystemName="LOINC"/>
+																					<statusCode code="completed"/>
+																					<effectiveTime>
+																							<low nullFlavor="NA"/>
+																					</effectiveTime>
+																					<value xsi:type="CD" nullFlavor="OTH"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+																							<translation code="D"
+																								codeSystem="2.16.840.1.113883.3.249.12"
+																								displayName="Other"/>
+																					</value>
+																					<entryRelationship inversionInd="true" typeCode="SUBJ">
+																							<observation classCode="OBS" moodCode="EVN">
+																								<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																								<code code="MSRAGG"
+																								codeSystem="2.16.840.1.113883.5.4"
+																								displayName="rate aggregation"
+																								codeSystemName="ActCode"/>
+																								<statusCode code="completed"/>
+																								<value xsi:type="INT" value="1797"
+																								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																								<methodCode code="COUNT"
+																								codeSystem="2.16.840.1.113883.5.84"
+																								codeSystemName="ObservationMethod"
+																								displayName="count"/>
+																							</observation>
+																					</entryRelationship>
+																			</observation>
+																	</entryRelationship>
+																	<reference typeCode="REFR">
+																			<externalObservation>
+																					<id root="3807E4F3-1E84-4F57-B6D3-EDDE97E1481B"/>
+																			</externalObservation>
+																	</reference>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C77D2C-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220101"/>
+															<high value="20221231"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.4"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Improvement Activity Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Improvement Activity Title</th>
+																	<th>Improvement Activity ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Engagement of patients through implementation of
+																			improvements in patient portal</td>
+																	<td>IA_BE_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Engagement of patients, family and caregivers in developing
+																			a plan of care</td>
+																	<td>IA_BE_15</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Implementation of improvements that contribute to more
+																			timely communication of test results</td>
+																	<td>IA_CC_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Practice improvements for bilateral exchange of patient
+																			information</td>
+																	<td>IA_CC_13</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</td>
+																	<td>IA_EPA_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7C7B4-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_4" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients through implementation of
+																			improvements in patient portal</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7D63C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_BE_15" root="2.16.840.1.113883.3.7034"/>
+																	<text>Engagement of patients, family and caregivers in
+																			developing a plan of care</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7E438-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_2" root="2.16.840.1.113883.3.7034"/>
+																	<text>Implementation of improvements that contribute to more
+																			timely communication of test results</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7F216-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_CC_13" root="2.16.840.1.113883.3.7034"/>
+																	<text>Practice improvements for bilateral exchange of patient
+																			information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.33"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C7FF4A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="IA_EPA_1" root="2.16.840.1.113883.3.7034"/>
+																	<text>Provide 24/7 Access to MIPS Eligible Clinicians or Groups
+																			Who Have Real-Time Access to Patient's Medical Record</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C80E0E-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+					<component>
+							<section>
+									<templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.5"/>
+									<templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+									<code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+									<title>Measure section</title>
+									<text>
+											<content>Promoting Interoperability Entries</content>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Reporting Parameter</th>
+																	<th>Value</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>Reporting period</td>
+																	<td>Sep 27, 2022 - Dec 25, 2022</td>
+															</tr>
+													</tbody>
+											</table>
+											<table border="1" width="100%">
+													<thead>
+															<tr>
+																	<th>Promoting Interoperability Measure Title</th>
+																	<th>Promoting Interoperability Measure ID</th>
+																	<th>Details</th>
+															</tr>
+													</thead>
+													<tbody>
+															<tr>
+																	<td>E-Prescribing</td>
+																	<td>PI_EP_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .987514</item>
+																					<item>Numerator: 752879</item>
+																					<item>Denominator: 762398</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Patient Electronic Access (Provided Within 4 Business
+																			Days)</td>
+																	<td>PI_PEA_1</td>
+																	<td>
+																			<list>
+																					<item>Performance Rate: .97764</item>
+																					<item>Numerator: 277373</item>
+																					<item>Denominator: 283717</item>
+																			</list>
+																	</td>
+															</tr>
+															<tr>
+																	<td>Protect Patient Health Information</td>
+																	<td>PI_PPHI_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Query of Prescription Drug Monitoring Program</td>
+																	<td>PI_EP_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</td>
+																	<td>PI_HIE_5</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Safety Assurance Factors for EHR Resilience Guides</td>
+																	<td>PI_PPHI_2</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Immunization Registry Reporting</td>
+																	<td>PI_PHCDRR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Case Reporting</td>
+																	<td>PI_PHCDRR_3</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Public Health Registry Reporting</td>
+																	<td>PI_PHCDRR_4</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>Clinical Data Registry Reporting</td>
+																	<td>PI_PHCDRR_5</td>
+																	<td>Measure Performed: No</td>
+															</tr>
+															<tr>
+																	<td>Prevention of Information Blocking Attestation</td>
+																	<td>PI_INFBLO_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC-ACB Surveillance Attestation</td>
+																	<td>PI_ONCACB_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+															<tr>
+																	<td>ONC Direct Review Attestation</td>
+																	<td>PI_ONCDIR_1</td>
+																	<td>Measure Performed: Yes</td>
+															</tr>
+													</tbody>
+											</table>
+									</text>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C85436-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>E-Prescribing</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".987514"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="752879"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="762398"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2017-06-01"
+															root="2.16.840.1.113883.10.20.27.3.28"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C87E02-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PEA_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Patient Electronic Access (Provided Within 4 Business
+																			Days)</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.30"/>
+																	<code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+																			displayName="Performance Rate" codeSystemName="LOINC"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="REAL" value=".97764"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.31"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="NUMER"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Numerator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="277373"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.32"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="DENOM"
+																			codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"
+																			displayName="Denominator"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																	<entryRelationship inversionInd="true" typeCode="SUBJ">
+																			<observation classCode="OBS" moodCode="EVN">
+																					<templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+																					<code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4"
+																							displayName="rate aggregation"
+																							codeSystemName="ActCode"/>
+																					<value xsi:type="INT" value="283717"
+																							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+																					<methodCode code="COUNT"
+																							codeSystem="2.16.840.1.113883.5.84"
+																							codeSystemName="ObservationMethod"
+																							displayName="count"/>
+																			</observation>
+																	</entryRelationship>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8A5F8-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Protect Patient Health Information</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8B444-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_EP_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Query of Prescription Drug Monitoring Program</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8C33A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_HIE_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Health Information Exchange (HIE) Bi-Directional
+																			Exchange</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8D17C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PPHI_2" root="2.16.840.1.113883.3.7031"/>
+																	<text>Safety Assurance Factors for EHR Resilience Guides</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8E02C-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Immunization Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8EE64-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_3" root="2.16.840.1.113883.3.7031"/>
+																	<text>Case Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C8FC6A-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_4" root="2.16.840.1.113883.3.7031"/>
+																	<text>Public Health Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C90ACA-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_PHCDRR_5" root="2.16.840.1.113883.3.7031"/>
+																	<text>Clinical Data Registry Reporting</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="N"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="No"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C91876-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_INFBLO_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>Prevention of Information Blocking Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C92618-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCACB_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC-ACB Surveillance Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry>
+											<organizer classCode="CLUSTER" moodCode="EVN">
+													<templateId extension="2016-09-01"
+															root="2.16.840.1.113883.10.20.27.3.29"/>
+													<templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+													<id root="72C93428-AE3D-11ED-A1C0-640339ACF087"/>
+													<statusCode code="completed"/>
+													<reference typeCode="REFR">
+															<externalDocument classCode="DOC" moodCode="EVN">
+																	<id extension="PI_ONCDIR_1" root="2.16.840.1.113883.3.7031"/>
+																	<text>ONC Direct Review Attestation</text>
+															</externalDocument>
+													</reference>
+													<component>
+															<observation classCode="OBS" moodCode="EVN">
+																	<templateId extension="2016-09-01"
+																			root="2.16.840.1.113883.10.20.27.3.27"/>
+																	<code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+																	<statusCode code="completed"/>
+																	<value xsi:type="CD" code="Y"
+																			codeSystem="2.16.840.1.113883.12.136" displayName="Yes"
+																			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+															</observation>
+													</component>
+											</organizer>
+									</entry>
+									<entry typeCode="DRIV">
+											<act classCode="ACT" moodCode="EVN">
+													<templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+													<id root="72C9430A-AE3D-11ED-A1C0-640339ACF087"/>
+													<code code="252116004" codeSystem="2.16.840.1.113883.6.96"
+															displayName="Observation Parameters"/>
+													<effectiveTime>
+															<low value="20220927"/>
+															<high value="20221225"/>
+													</effectiveTime>
+											</act>
+									</entry>
+							</section>
+					</component>
+			</structuredBody>
 	</component>
 </ClinicalDocument>


### PR DESCRIPTION
### Information
- App1 now allows the CEHRT Identifier to be converted in it's PI Measurement Set Section when it is provided in the QRDA-III XML.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
