### PR TITLE
upgrades for new S3 resource attachments

### DIFF
--- a/infrastructure/terraform/modules/s3.tf
+++ b/infrastructure/terraform/modules/s3.tf
@@ -3,43 +3,67 @@
 ## Note this bucket is
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "qppsf-conversion-tool-logs"
-  acl    = "log-delivery-write"
+  # QPPSE-1211 correct warning:
+  # Warning: Argument is deprecated
+  # ...
+  # Use resource aws_s3_bucket_acl instead
+  #
+  # acl    = "log-delivery-write"
 
-  versioning {
-    enabled = true
-  }
+  # QPPSE-1211 correct warning:
+  # Warning: Argument is deprecated
+  # ...
+  # Use resource aws_s3_bucket_versioning instead
+  #
+  # versioning {
+  #   enabled = true
+  # }
+  # QPPSE-1211 correct warning:
+  # Warning: Argument is deprecated
+  # ... 
+  # Use the aws_s3_bucket_lifecycle_configuration resource instead
+  # ...
+  # lifecycle_rule {
+  #   id      = "default-lifecycle"
+  #   enabled = true
 
-  lifecycle_rule {
-    id      = "default-lifecycle"
-    enabled = true
+  #   transition {
+  #     days          = 60
+  #     storage_class = "STANDARD_IA"
+  #   }
 
-    transition {
-      days          = 60
-      storage_class = "STANDARD_IA"
-    }
+  #   transition {
+  #     days          = 90
+  #     storage_class = "GLACIER"
+  #   }
 
-    transition {
-      days          = 90
-      storage_class = "GLACIER"
-    }
-
-    expiration {
-      days                         = 365
-      expired_object_delete_marker = true
-    }
-  }
+  #   expiration {
+  #     days                         = 365
+  #     expired_object_delete_marker = true
+  #   }
+  # }
 
   lifecycle {
     prevent_destroy = true
+    # QPPSE-1211 for resource additions below
+    ignore_changes = [ grant ]
   }
-  # Require encryption at rest
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  # ...
+  # QPPSE-1211 correct warning:
+  # Warning: Argument is deprecated
+  # ... 
+  # Use the aws_s3_bucket_server_side_encryption_configuration resource instead
+  # ...
+  # Require encryption at rest 
+  # server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
+  #
+
   tags = {
     "Name"                = "${var.project_name}-s3-logs-bucket"
     "qpp:owner"           = var.owner
@@ -52,8 +76,120 @@ resource "aws_s3_bucket" "log_bucket" {
     "qpp:iac-repo-url"    = var.git-origin
   }
 
+
 }
 
+# QPPSE-1211
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+resource "aws_s3_bucket_versioning" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+resource "aws_s3_bucket_lifecycle_configuration" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+
+  rule {
+    id = "default-lifecycle"
+
+    expiration {
+      days                         = 365
+      expired_object_delete_marker = true
+    }
+
+    filter {}
+    #   and {
+    #     prefix = "/"
+
+    #     tags = {
+    #       rule      = "log"
+    #       autoclean = "true"
+    #     }
+    #   }
+    # }
+
+    status = "Enabled"
+
+    transition {
+      days          = 60
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+  }
+
+  # rule {
+  #   id = "prevent-destroy"
+  #   filter {}
+
+  # }
+  # rule {
+  #   id = "ignore-grant"
+  #   filter {}
+  #   ignore_changes = [
+  #     grant
+  #   ]
+  #   status = "Enabled"
+  # }
+}
+
+resource "aws_s3_bucket_ownership_controls" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "log_bucket" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket]
+
+  bucket = aws_s3_bucket.log_bucket.id
+
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+      }
+      permission = "READ_ACP"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+      }
+      permission = "WRITE"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+#
 
 # No public access
 resource "aws_s3_bucket_public_access_block" "log_bucket-public-access-block" {

--- a/infrastructure/terraform/modules/s3.tf
+++ b/infrastructure/terraform/modules/s3.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "log_bucket" {
   #
   # acl    = "log-delivery-write"
 
-  # QPPSE-1211 correct warning:
+  # QPPSE-1211 correct warning: 
   # Warning: Argument is deprecated
   # ...
   # Use resource aws_s3_bucket_versioning instead


### PR DESCRIPTION
### Information
- Fixes #_.
- JIRA story _.

Terraform will perform the following actions:

  # module.conversion-tool.aws_iam_policy.conversiontool_ecs_task_exec_policy will be updated in-place
  ~ resource "aws_iam_policy" "conversiontool_ecs_task_exec_policy" {
        id        = "arn:aws:iam::003384571330:policy/delegatedadmin/developer/qppsf-dev-conversiontool-ecsTaskExecutionRole-role-policy"
        name      = "qppsf-dev-conversiontool-ecsTaskExecutionRole-role-policy"
      ~ policy    = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = [
                            "s3:GetAccessPoint",
                            "ssm:DescribeDocument",
                            "kms:GenerateRandom",
                            "ec2messages:GetEndpoint",
                            "ssmmessages:OpenControlChannel",
                            "ec2messages:GetMessages",
                            "ssm:PutConfigurePackageResult",
                            "ssm:ListInstanceAssociations",
                            "ssm:GetParameter",
                            "ssm:UpdateAssociationStatus",
                            "ssm:GetManifest",
                            "kms:DescribeCustomKeyStores",
                            "kms:DeleteCustomKeyStore",
                            "ec2messages:DeleteMessage",
                            "ssm:UpdateInstanceInformation",
                            "kms:UpdateCustomKeyStore",
                            "ec2messages:FailMessage",
                            "ssmmessages:OpenDataChannel",
                            "ssm:GetDocument",
                            "kms:CreateKey",
                            "kms:ConnectCustomKeyStore",
                            "s3:HeadBucket",
                            "ssm:PutComplianceItems",
                            "ssm:DescribeAssociation",
                            "s3:PutAccountPublicAccessBlock",
                            "ssm:GetDeployablePatchSnapshotForInstance",
                            "s3:ListAccessPoints",
                            "s3:ListJobs",
                            "ec2messages:AcknowledgeMessage",
                            "ssm:GetParameters",
                            "ssmmessages:CreateControlChannel",
                            "kms:CreateCustomKeyStore",
                            "ssmmessages:CreateDataChannel",
                            "kms:ListKeys",
                            "ssm:PutInventory",
                            "s3:GetAccountPublicAccessBlock",
                            "s3:ListAllMyBuckets",
                            "kms:ListAliases",
                            "kms:DisconnectCustomKeyStore",
                            "ec2messages:SendReply",
                            "s3:CreateJob",
                            "ssm:ListAssociations",
                            "ssm:UpdateInstanceAssociationStatus",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = "VisualEditor0"
                    },
                  ~ {
                      ~ Resource = "arn:aws:kms:*:*:key/*" -> jsonencode(
                            [
                              + "arn:aws:kms:us-east-1:003384571330:key/0a3c2556-c064-4722-b535-3401b749d379",
                              + "arn:aws:kms:us-east-1:003384571330:key/1072c994-32bd-44c6-9df9-2ed7fa7955c3",
                              + "arn:aws:kms:us-east-1:003384571330:key/17832f75-0975-4bfc-b80c-6813b232663a",
                              + "arn:aws:kms:us-east-1:003384571330:key/1863d256-47dd-4875-ac19-b744853f3609",
                              + "arn:aws:kms:us-east-1:003384571330:key/1e39f989-5255-4717-b805-59fa75cd4ab3",
                              + "arn:aws:kms:us-east-1:003384571330:key/2223cd12-3fa4-4aa6-83fd-95da5d58a61b",
                              + "arn:aws:kms:us-east-1:003384571330:key/22a9f939-0653-4a99-a15b-56f88d12e010",
                              + "arn:aws:kms:us-east-1:003384571330:key/319189d1-6591-4d46-82c7-1e0669d6630e",
                              + "arn:aws:kms:us-east-1:003384571330:key/320a1f44-7ffd-4ede-817b-a738375514b6",
                              + "arn:aws:kms:us-east-1:003384571330:key/356ce591-213c-4f84-b82b-71f412141fed",
                              + "arn:aws:kms:us-east-1:003384571330:key/3b5689a4-c353-4207-8fe8-35afc33f5e25",
                              + "arn:aws:kms:us-east-1:003384571330:key/3d304faf-359a-4e84-9767-996fe06adb92",
                              + "arn:aws:kms:us-east-1:003384571330:key/3ec56e10-90b4-4f43-a661-9173b6a162ad",
                              + "arn:aws:kms:us-east-1:003384571330:key/3f32fbb4-f735-48fd-bb02-1804f3d8f45a",
                              + "arn:aws:kms:us-east-1:003384571330:key/416fcc53-dee0-4563-a8db-b858e11d3e2b",
                              + "arn:aws:kms:us-east-1:003384571330:key/44c8f3c1-474e-4fb9-a7c2-9170619025f6",
                              + "arn:aws:kms:us-east-1:003384571330:key/4a47e056-74ff-47cc-a963-afe55e5c3b1a",
                              + "arn:aws:kms:us-east-1:003384571330:key/4d9c8e8f-eee7-410a-a325-7c6a79bdbc31",
                              + "arn:aws:kms:us-east-1:003384571330:key/52ca823a-e310-497b-9595-0ec3f9bd8e99",
                              + "arn:aws:kms:us-east-1:003384571330:key/5b21e015-3105-46aa-aa9a-0cefee0fb872",
                              + "arn:aws:kms:us-east-1:003384571330:key/5f5f5cbc-7e96-4651-8830-444e6dc5af50",
                              + "arn:aws:kms:us-east-1:003384571330:key/614af79d-61f9-4a3f-b9ba-81906854a3b2",
                              + "arn:aws:kms:us-east-1:003384571330:key/625e4f6b-d017-4bea-bf97-ac261b971029",
                              + "arn:aws:kms:us-east-1:003384571330:key/673149ab-155d-44d4-8699-8fe7827dd26d",
                              + "arn:aws:kms:us-east-1:003384571330:key/69b6b063-a2a1-40a0-a846-d3e2f20ecf0b",
                              + "arn:aws:kms:us-east-1:003384571330:key/6b0f4a0e-1229-4ad6-aa83-ff93ab0cdca6",
                              + "arn:aws:kms:us-east-1:003384571330:key/71ca03b3-d3f2-4b6b-a250-59d5af6804c6",
                              + "arn:aws:kms:us-east-1:003384571330:key/79839ee5-a18c-40c3-9efa-71c488ad4589",
                              + "arn:aws:kms:us-east-1:003384571330:key/7b57229b-8dfc-4121-8cb3-939acf91ac09",
                              + "arn:aws:kms:us-east-1:003384571330:key/80c66571-64f3-426f-9337-9ad597b652f5",
                              + "arn:aws:kms:us-east-1:003384571330:key/82544888-e847-4bfb-907c-0606e99b48bc",
                              + "arn:aws:kms:us-east-1:003384571330:key/895c193a-b42d-4a66-96cd-136f2da62133",
                              + "arn:aws:kms:us-east-1:003384571330:key/9829eec6-dfa8-40b0-97c8-14e491defd7a",
                              + "arn:aws:kms:us-east-1:003384571330:key/a4507982-fe74-4f96-845a-c7552dbf99cb",
                              + "arn:aws:kms:us-east-1:003384571330:key/b0cab95d-2814-456b-b9ba-9324feda9854",
                              + "arn:aws:kms:us-east-1:003384571330:key/b1cd6f54-3bce-4163-ad9a-f1ac8fa4ec95",
                              + "arn:aws:kms:us-east-1:003384571330:key/b2c68437-8399-4aa3-8e01-08ab4f45a558",
                              + "arn:aws:kms:us-east-1:003384571330:key/b58892f6-2b8a-42e5-964e-d948e7b79fd3",
                              + "arn:aws:kms:us-east-1:003384571330:key/b8b337b4-0d91-4e23-86a3-0799b582d276",
                              + "arn:aws:kms:us-east-1:003384571330:key/bc788e72-24df-447d-852c-47f1bb14e4a9",
                              + "arn:aws:kms:us-east-1:003384571330:key/cc26f12b-ae32-4b5f-baca-3c5ddbcc31ca",
                              + "arn:aws:kms:us-east-1:003384571330:key/cc5be3d6-b5d9-4b18-8004-37ac2701fd2c",
                              + "arn:aws:kms:us-east-1:003384571330:key/e8593690-f5bf-44a6-a30b-2cee79307a25",
                              + "arn:aws:kms:us-east-1:003384571330:key/e8f2dbcd-dea7-4e7c-a348-19050cc552cf",
                              + "arn:aws:kms:us-east-1:003384571330:key/e9d6f714-38c9-417d-9f37-ada6843b2df0",
                              + "arn:aws:kms:us-east-1:003384571330:key/eb29db32-6833-4a3c-b067-a55fcf0c48c6",
                              + "arn:aws:kms:us-east-1:003384571330:key/ecc43cde-608b-488b-8295-41a8d9bee42d",
                              + "arn:aws:kms:us-east-1:003384571330:key/ed215ae5-e9a3-4c75-87cf-c44d9ba70ffb",
                              + "arn:aws:kms:us-east-1:003384571330:key/ee54d3ea-7329-40b9-ba61-400a3f1af700",
                              + "arn:aws:kms:us-east-1:003384571330:key/f6aef7a2-9b0f-464d-a63b-aa4ec9172452",
                              + "arn:aws:kms:us-east-1:003384571330:key/f9a12841-1c5a-426b-a68c-93e16f8d3208",
                              + "arn:aws:kms:us-east-1:003384571330:key/ff7fca93-2b54-402a-9734-73d5b8538943",
                            ]
                        )
                        # (3 unchanged attributes hidden)
                    },
                    {
                        Action   = "s3:*"
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::*",
                            "arn:aws:s3:*:*:accesspoint/*",
                            "arn:aws:s3:::*/*",
                            "arn:aws:s3:*:*:job/*",
                        ]
                        Sid      = "VisualEditor2"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # module.conversion-tool.aws_s3_bucket_acl.log_bucket will be created
  + resource "aws_s3_bucket_acl" "log_bucket" {
      + bucket = "qppsf-conversion-tool-logs"
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = "READ_ACP"

              + grantee {
                  + display_name = (known after apply)
                  + type         = "Group"
                  + uri          = "http://acs.amazonaws.com/groups/s3/LogDelivery"
                }
            }
          + grant {
              + permission = "WRITE"

              + grantee {
                  + display_name = (known after apply)
                  + type         = "Group"
                  + uri          = "http://acs.amazonaws.com/groups/s3/LogDelivery"
                }
            }
          + grant {
              + permission = "FULL_CONTROL"

              + grantee {
                  + display_name = (known after apply)
                  + id           = "f66466c4d20e8b146178db86165fb112751b120d41cae93a130ae6d66ec9621a"
                  + type         = "CanonicalUser"
                }
            }
          + owner {
              + display_name = (known after apply)
              + id           = "f66466c4d20e8b146178db86165fb112751b120d41cae93a130ae6d66ec9621a"
            }
        }
    }

  # module.conversion-tool.aws_s3_bucket_lifecycle_configuration.log_bucket will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "log_bucket" {
      + bucket = "qppsf-conversion-tool-logs"
      + id     = (known after apply)

      + rule {
          + id     = "default-lifecycle"
          + status = "Enabled"

          + expiration {
              + days                         = 365
              + expired_object_delete_marker = true
            }

          + filter {
            }

          + transition {
              + days          = 60
              + storage_class = "STANDARD_IA"
            }
          + transition {
              + days          = 90
              + storage_class = "GLACIER"
            }
        }
    }

  # module.conversion-tool.aws_s3_bucket_ownership_controls.log_bucket will be created
  + resource "aws_s3_bucket_ownership_controls" "log_bucket" {
      + bucket = "qppsf-conversion-tool-logs"
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerPreferred"
        }
    }

  # module.conversion-tool.aws_s3_bucket_server_side_encryption_configuration.log_bucket will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
      + bucket = "qppsf-conversion-tool-logs"
      + id     = (known after apply)

      + rule {
          + apply_server_side_encryption_by_default {
              + sse_algorithm = "AES256"
            }
        }
    }

  # module.conversion-tool.aws_s3_bucket_versioning.log_bucket will be created
  + resource "aws_s3_bucket_versioning" "log_bucket" {
      + bucket = "qppsf-conversion-tool-logs"
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

  # module.conversion-tool.aws_security_group_rule.ct-ingress-from-https-elb-to-ui will be created
  + resource "aws_security_group_rule" "ct-ingress-from-https-elb-to-ui" {
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-030ae9a65cdad1954"
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-0377d36214f7db48c"
      + to_port                  = 8443
      + type                     = "ingress"
    }

Plan: 6 to add, 1 to change, 0 to destroy.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
