### PR TITLE
QPPSE-1584: Added Parameter Store variable to the buildspec to fix the automation script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # You can also use email addresses if you prefer.
 
 # Default reviewers
-*       @saquino0827 @sivaksb @jpec07
+*       @sivaksb @jpec07

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,6 +7,7 @@ env:
     DOCKERHUB_USERNAME: "/qppar-sf/DOCKERHUB_USERNAME"
     DOCKERHUB_PASS: "/qppar-sf/DOCKERHUB_PASS"
     SLACK_WEBHOOK: "/qppar-sf/dev/conversion_tool/slack_hook_url"
+    PART_FILE: "/qppar-sf/conversion_tool/CPC_PLUS_FILE_NAME"
     PART_FILE_BUCKET: "/qppar-sf/$ENVIRONMENT/conversion_tool/CPC_PLUS_BUCKET_NAME"
     OUTPUT_PART_FILE: "/qppar-sf/$ENVIRONMENT/conversion_tool/CPC_PLUS_VALIDATION_FILE"
 phases:


### PR DESCRIPTION
### Information
- When new participation file is uploaded to S3, the automation script need to get the file from the S3 and process it automatically.  This was not working.  In order to fix that, when we added a SSM variable before, we were getting 403 forbidden error.  So took care of this process manually before.  Now the CT tool is in PROD, checking back on this issue.  We will only be able to see the error in codebuild, when this change is merged to develop.  Once this is merged, I will work with Raj/Tim on this.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
