### PR TITLE
QPPSE-2001: Updated references of UUID table info to reflect 2023 IG

### DIFF
--- a/ERROR_MESSAGES.md
+++ b/ERROR_MESSAGES.md
@@ -8,13 +8,13 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 3 : CT - Unexpected exception occurred during conversion. Please contact the Service Center for assistance via phone at 1-866-288-8292 or TTY: 1-877-715-6222, or by emailing QPP@cms.hhs.gov
 * 4 : CT - Unexpected exception occurred during encoding. Please contact the Service Center for assistance via phone at 1-866-288-8292 or TTY: 1-877-715-6222, or by emailing QPP@cms.hhs.gov
 * 5 : CT - The file is not a QRDA-III XML document. Please ensure that the submission complies with the `(Submission year's)` implementation guide. `(Implementation guide link)`
-* 6 : CT - The measure GUID `(Provided measure id)` is invalid. Please see the Table 14 of the `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
+* 6 : CT - The measure GUID `(Provided measure id)` is invalid. Please see the Table 15 of the `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
 * 7 : CT - The measure reference results must have at least one measure. Please review the measures section of your file as it cannot be empty.
 * 8 : CT - The `(Parent element)` has `(number of aggregate counts)` aggregate count values. A single aggregate count value is required.
 * 9 : CT - Aggregate count value must be an integer
 * 11 : CT - This PI Reference and Results is missing a required Measure Performed child
 * 12 : CT - This PI Measure Performed Reference and Results requires a single Measure ID
-* 13 : CT - Denominator count must be less than or equal to Initial Population count for the measure population `(measure population id)`. Please see the Table 14 of the `(Submission Year)` Implementation guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
+* 13 : CT - Denominator count must be less than or equal to Initial Population count for the measure population `(measure population id)`. Please see the Table 15 of the `(Submission Year)` Implementation guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
 * 14 : CT - The electronic measure id: `(Current eMeasure ID)` requires `(Number of Subpopulations required)` `(Type of Subpopulation required)`(s) but there are `(Number of Subpopulations existing)`
 * 15 : CT - PI Numerator Denominator element should have a PI Section element as a parent
 * 16 : CT - PI Numerator Denominator element does not contain a measure name ID
@@ -46,8 +46,8 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 49 : CT - Amount of stratifications `(Current number of Reporting Stratifiers)` does not meet expectations `(Number of stratifiers required)` for `(Current subpopulation type)` measure `(Current Subpopulation UUID)`. Expected strata: `(Expected strata uuid list)`. Please refer to the Implementation Guide for correct stratification UUID's here: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
 * 50 : CT - An IA performed measure reference and results must have exactly one measure performed child
 * 51 : CT - A single measure performed value is required and must be either a Y or an N.
-* 52 : CT -  The measure data with population id '`(population id)`' must have exactly one Aggregate Count. Please see the Table 14 of `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
-* 53 : CT - Measure data with population id '`(population id)`' must be a whole number greater than or equal to 0. Please see the Table 14 of `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
+* 52 : CT -  The measure data with population id '`(population id)`' must have exactly one Aggregate Count. Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
+* 53 : CT - Measure data with population id '`(population id)`' must be a whole number greater than or equal to 0. Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
 * 55 : CT - A `(Program name)` Performance period start must be 01/01/2023. Please refer to the IG for more information here: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=14
 * 56 : CT - A `(Program name)` Performance period end must be 12/31/2023. Please refer to the IG for more information here: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=14
 * 57 : CT - The measure reference results must have a single measure population
@@ -84,7 +84,7 @@ Any text in the following format `(Example)` are considered variables to be fill
 * 97 : CT - `(Program name)` QRDA-III Submissions require a valid CMS EHR Certification ID (Valid Formats: XX15EXXXXXXXXXX, XX15CXXXXXXXXXX)
 * 98 : CT - The performance rate cannot have a value of 0 and must be of value Null Attribute (NA).
 * 100 : CT - More than one CMS EHR Certification ID was found. Please submit with only one CMS EHR Certification id.
-* 101 : CT - Denominator count must be equal to Initial Population count for `(Program name)` measure population `(measure population id)`.Please see the Table 14 of `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
+* 101 : CT - Denominator count must be equal to Initial Population count for `(Program name)` measure population `(measure population id)`.Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: https://ecqi.healthit.gov/sites/default/files/2023-CMS-QRDA-III-Eligible-Clinicians-IG-v1.1-508.pdf#page=43
 * 102 : CT - A PI section cannot contain PI_HIE_5 with PI_HIE_1, PI_LVOTC_1, PI_HIE_4, or PI_LVITC_2
 * 103 : CT - PCF Submissions must have the `(PCF Measure minimum)` following measures: `(Listing of valid measure ids)`
 * 105 : CT - If multiple TINs/NPIs are submitted, each must be reported within a separate performer

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
@@ -116,11 +116,11 @@ public enum ProblemCode implements LocalizedProblem {
 	IA_MEASURE_INVALID_TYPE(51, "A single measure performed value is required and must be either a Y or an N."),
 	MEASURE_PERFORMED_MISSING_AGGREGATE_COUNT(52,
 			" The measure data with population id '`(population id)`' must have exactly one Aggregate Count. "
-			+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+			+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "	//NOSONAR
 			+ DocumentationReference.MEASURE_IDS, true),
 	MEASURE_DATA_VALUE_NOT_INTEGER(53, "Measure data with population id '`(population id)`' "
 			+ "must be a whole number greater than or equal to 0. "
-			+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+			+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "	//NOSONAR
 			+ DocumentationReference.MEASURE_IDS, true),
 	PCF_PERFORMANCE_PERIOD_START(55, "A `(Program name)` Performance period start must be 01/01/2023. "
 			+ "Please refer to the IG for more information here: " + DocumentationReference.PCF_SUBMISSIONS, true),
@@ -191,7 +191,7 @@ public enum ProblemCode implements LocalizedProblem {
 	PCF_ZERO_PERFORMANCE_RATE(98, "The performance rate cannot have a value of 0 and must be of value Null Attribute (NA)."),
 	PCF_DUPLICATE_CEHRT(100, "More than one CMS EHR Certification ID was found. Please submit with only one CMS EHR Certification id."),
 	PCF_DENOMINATOR_COUNT_INVALID(101, "Denominator count must be equal to Initial Population count for `(Program name)` measure population `(measure population id)`."
-		+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+		+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "	//NOSONAR
 		+ DocumentationReference.MEASURE_IDS, true),
 	PI_RESTRICTED_MEASURES(102, "A PI section cannot contain PI_HIE_5 with PI_HIE_1, PI_LVOTC_1, PI_HIE_4, or PI_LVITC_2", false),
 	PCF_TOO_FEW_QUALITY_MEASURE_CATEGORY(103, "PCF Submissions must have the `(PCF Measure minimum)` "

--- a/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
+++ b/commons/src/main/java/gov/cms/qpp/conversion/model/error/ProblemCode.java
@@ -29,7 +29,7 @@ public enum ProblemCode implements LocalizedProblem {
 		+ "Please ensure that the submission complies with the `(Submission year's)` implementation guide. "
 		+ "`(Implementation guide link)`", true),
 	MEASURE_GUID_MISSING(6, "The measure GUID `(Provided measure id)` is invalid. "
-		+ "Please see the Table 14 of the `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+		+ "Please see the Table 15 of the `(Submission year's)` Implementation Guide for valid measure GUIDs: "
 		+ DocumentationReference.MEASURE_IDS, true),
 	CHILD_MEASURE_MISSING(7, "The measure reference results must have at least one measure. "
 			+ "Please review the measures section of your file as it cannot be empty."),
@@ -41,7 +41,7 @@ public enum ProblemCode implements LocalizedProblem {
 	PI_MEASURE_PERFORMED_RNR_MEASURE_ID_NOT_SINGULAR(12, "This PI Measure Performed Reference and Results requires "
 		+ "a single Measure ID"),
 	DENOMINATOR_COUNT_INVALID(13, "Denominator count must be less than or equal to Initial Population count "
-		+ "for the measure population `(measure population id)`. Please see the Table 14 of the `(Submission Year)` Implementation guide for valid measure GUIDs: "
+		+ "for the measure population `(measure population id)`. Please see the Table 15 of the `(Submission Year)` Implementation guide for valid measure GUIDs: "
 		+ DocumentationReference.MEASURE_IDS, true),
 	POPULATION_CRITERIA_COUNT_INCORRECT(14,
 			"The electronic measure id: `(Current eMeasure ID)` requires `(Number of Subpopulations required)` "
@@ -116,11 +116,11 @@ public enum ProblemCode implements LocalizedProblem {
 	IA_MEASURE_INVALID_TYPE(51, "A single measure performed value is required and must be either a Y or an N."),
 	MEASURE_PERFORMED_MISSING_AGGREGATE_COUNT(52,
 			" The measure data with population id '`(population id)`' must have exactly one Aggregate Count. "
-			+ "Please see the Table 14 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+			+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
 			+ DocumentationReference.MEASURE_IDS, true),
 	MEASURE_DATA_VALUE_NOT_INTEGER(53, "Measure data with population id '`(population id)`' "
 			+ "must be a whole number greater than or equal to 0. "
-			+ "Please see the Table 14 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+			+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
 			+ DocumentationReference.MEASURE_IDS, true),
 	PCF_PERFORMANCE_PERIOD_START(55, "A `(Program name)` Performance period start must be 01/01/2023. "
 			+ "Please refer to the IG for more information here: " + DocumentationReference.PCF_SUBMISSIONS, true),
@@ -191,7 +191,7 @@ public enum ProblemCode implements LocalizedProblem {
 	PCF_ZERO_PERFORMANCE_RATE(98, "The performance rate cannot have a value of 0 and must be of value Null Attribute (NA)."),
 	PCF_DUPLICATE_CEHRT(100, "More than one CMS EHR Certification ID was found. Please submit with only one CMS EHR Certification id."),
 	PCF_DENOMINATOR_COUNT_INVALID(101, "Denominator count must be equal to Initial Population count for `(Program name)` measure population `(measure population id)`."
-		+ "Please see the Table 14 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
+		+ "Please see the Table 15 of `(Submission year's)` Implementation Guide for valid measure GUIDs: "
 		+ DocumentationReference.MEASURE_IDS, true),
 	PI_RESTRICTED_MEASURES(102, "A PI section cannot contain PI_HIE_5 with PI_HIE_1, PI_LVOTC_1, PI_HIE_4, or PI_LVITC_2", false),
 	PCF_TOO_FEW_QUALITY_MEASURE_CATEGORY(103, "PCF Submissions must have the `(PCF Measure minimum)` "

--- a/commons/src/main/resources/measures-data.json
+++ b/commons/src/main/resources/measures-data.json
@@ -3540,6 +3540,51 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G2081"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G2090"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G2091"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G9687"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G9988"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "performanceMet",
         "qualityCodes": [
           {
@@ -3583,51 +3628,6 @@
         "qualityCodes": [
           {
             "code": "3052F"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G2081"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G2090"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G2091"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G9687"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G9988"
           }
         ]
       }
@@ -11139,6 +11139,15 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G9688"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "performanceMet",
         "qualityCodes": [
           {
@@ -11159,7 +11168,7 @@
         ]
       },
       {
-        "optionGroup": "00",
+        "optionGroup": "01",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -11185,15 +11194,6 @@
             "modifiers": [
               "8P"
             ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "01",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G9688"
           }
         ]
       }
@@ -14169,6 +14169,15 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G9692"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "performanceMet",
         "qualityCodes": [
           {
@@ -14194,15 +14203,6 @@
             "modifiers": [
               "8P"
             ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G9692"
           }
         ]
       }
@@ -16969,24 +16969,6 @@
       },
       {
         "optionGroup": "00",
-        "optionType": "performanceMet",
-        "qualityCodes": [
-          {
-            "code": "G9991"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "performanceNotMet",
-        "qualityCodes": [
-          {
-            "code": "G9990"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -17380,6 +17362,24 @@
             "code": "30243Y4"
           }
         ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "performanceMet",
+        "qualityCodes": [
+          {
+            "code": "G9991"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "performanceNotMet",
+        "qualityCodes": [
+          {
+            "code": "G9990"
+          }
+        ]
       }
     ]
   },
@@ -17723,27 +17723,6 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
-        "optionType": "performanceMet",
-        "qualityCodes": [
-          {
-            "code": "3017F"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "performanceNotMet",
-        "qualityCodes": [
-          {
-            "code": "3017F",
-            "modifiers": [
-              "8P"
-            ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -17793,6 +17772,27 @@
         "qualityCodes": [
           {
             "code": "G9993"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "performanceMet",
+        "qualityCodes": [
+          {
+            "code": "3017F"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "performanceNotMet",
+        "qualityCodes": [
+          {
+            "code": "3017F",
+            "modifiers": [
+              "8P"
+            ]
           }
         ]
       }
@@ -19785,6 +19785,15 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationException",
+        "qualityCodes": [
+          {
+            "code": "G8433"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -20608,15 +20617,6 @@
         "qualityCodes": [
           {
             "code": "O99.345"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationException",
-        "qualityCodes": [
-          {
-            "code": "G8433"
           }
         ]
       },
@@ -24448,6 +24448,15 @@
       },
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G9720"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "performanceMet",
         "qualityCodes": [
           {
@@ -24464,15 +24473,6 @@
             "modifiers": [
               "8P"
             ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G9720"
           }
         ]
       }
@@ -26926,6 +26926,11 @@
         ]
       },
       {
+        "additionalProcedureCodes": [
+          {
+            "code": "G9902"
+          }
+        ],
         "minAge": 18,
         "optionGroup": "01",
         "procedureCodes": [
@@ -27388,19 +27393,19 @@
       },
       {
         "optionGroup": "02",
-        "optionType": "performanceMet",
+        "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
-            "code": "1036F"
+            "code": "M1159"
           }
         ]
       },
       {
         "optionGroup": "02",
-        "optionType": "eligiblePopulationExclusion",
+        "optionType": "performanceMet",
         "qualityCodes": [
           {
-            "code": "M1159"
+            "code": "1036F"
           }
         ]
       },
@@ -28025,6 +28030,15 @@
       },
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G8797"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "performanceMet",
         "qualityCodes": [
           {
@@ -28041,15 +28055,6 @@
             "modifiers": [
               "8P"
             ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G8797"
           }
         ]
       }
@@ -28130,6 +28135,15 @@
       },
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationExclusion",
+        "qualityCodes": [
+          {
+            "code": "G8798"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "performanceMet",
         "qualityCodes": [
           {
@@ -28146,15 +28160,6 @@
             "modifiers": [
               "8P"
             ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationExclusion",
-        "qualityCodes": [
-          {
-            "code": "G8798"
           }
         ]
       }
@@ -32856,6 +32861,18 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationException",
+        "qualityCodes": [
+          {
+            "code": "G9547"
+          },
+          {
+            "code": "G9549"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -32872,18 +32889,6 @@
           },
           {
             "code": "G9548"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationException",
-        "qualityCodes": [
-          {
-            "code": "G9547"
-          },
-          {
-            "code": "G9549"
           }
         ]
       },
@@ -33245,6 +33250,18 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
+        "optionType": "eligiblePopulationException",
+        "qualityCodes": [
+          {
+            "code": "G9552"
+          },
+          {
+            "code": "G9555"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -33261,18 +33278,6 @@
           },
           {
             "code": "G9554"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "eligiblePopulationException",
-        "qualityCodes": [
-          {
-            "code": "G9552"
-          },
-          {
-            "code": "G9555"
           }
         ]
       },
@@ -40341,27 +40346,6 @@
     "performanceOptions": [
       {
         "optionGroup": "00",
-        "optionType": "performanceMet",
-        "qualityCodes": [
-          {
-            "code": "3095F"
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
-        "optionType": "performanceNotMet",
-        "qualityCodes": [
-          {
-            "code": "3095F",
-            "modifiers": [
-              "8P"
-            ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "00",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -40428,7 +40412,28 @@
         "optionType": "performanceMet",
         "qualityCodes": [
           {
+            "code": "3095F"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "performanceMet",
+        "qualityCodes": [
+          {
             "code": "G8633"
+          }
+        ]
+      },
+      {
+        "optionGroup": "00",
+        "optionType": "performanceNotMet",
+        "qualityCodes": [
+          {
+            "code": "3095F",
+            "modifiers": [
+              "8P"
+            ]
           }
         ]
       },
@@ -40443,27 +40448,6 @@
       },
       {
         "optionGroup": "01",
-        "optionType": "performanceMet",
-        "qualityCodes": [
-          {
-            "code": "3095F"
-          }
-        ]
-      },
-      {
-        "optionGroup": "01",
-        "optionType": "performanceNotMet",
-        "qualityCodes": [
-          {
-            "code": "3095F",
-            "modifiers": [
-              "8P"
-            ]
-          }
-        ]
-      },
-      {
-        "optionGroup": "01",
         "optionType": "eligiblePopulationExclusion",
         "qualityCodes": [
           {
@@ -40530,7 +40514,28 @@
         "optionType": "performanceMet",
         "qualityCodes": [
           {
+            "code": "3095F"
+          }
+        ]
+      },
+      {
+        "optionGroup": "01",
+        "optionType": "performanceMet",
+        "qualityCodes": [
+          {
             "code": "G8633"
+          }
+        ]
+      },
+      {
+        "optionGroup": "01",
+        "optionType": "performanceNotMet",
+        "qualityCodes": [
+          {
+            "code": "3095F",
+            "modifiers": [
+              "8P"
+            ]
           }
         ]
       },
@@ -49580,7 +49585,8 @@
       "5133825",
       "1718371",
       "4757099",
-      "1725296 8483899"
+      "1725296",
+      "8483899"
     ],
     "allowedPrograms": [
       "mips",


### PR DESCRIPTION
### Information
- The UUID information has been moved from Table 14 to Table 15 in 2023 Implementation guide.  All the references to Table 14 needs to be updated to Table 15.

### Associated JIRA Tickets

- https://jira.cms.gov/browse/QPPSE-2001

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
