### PR TITLE
QPPSE-2171 DEV Codebuild Cleanup and alignment with resources

### DIFF
--- a/infrastructure/terraform/modules/ecs.tf
+++ b/infrastructure/terraform/modules/ecs.tf
@@ -123,6 +123,12 @@ resource "aws_security_group" "ct_app" {
     protocol        = "tcp"
     security_groups = [aws_security_group.conversion-tool_alb.id]
   }
+  ingress {
+    from_port       = 443
+    to_port         = 8443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.conversion-tool_alb.id]
+  }
   egress {
     from_port   = 0
     to_port     = 0

--- a/infrastructure/terraform/modules/iam.tf
+++ b/infrastructure/terraform/modules/iam.tf
@@ -332,15 +332,27 @@ resource "aws_iam_policy" "conversiontool_svc_policy" {
   policy = jsonencode({
 	"Version": "2012-10-17",
 	"Statement": [
+ 		{
+			"Sid": "CTCodebuildAccess",
+			"Effect": "Allow",
+			"Action": [
+				"codebuild:ListProjects",
+				"codebuild:StartBuild",
+				"codebuild:BatchGetBuilds"
+			],
+			"Resource": [
+				"arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:project/*"
+			]
+		},
     {
-        "Action": [
-            "ecs:DescribeTaskDefinition",
-            "ecs:RegisterTaskDefinition",
-            "ecs:ListTaskDefinitions"
-        ],
-        "Effect": "Allow",
-        "Resource": "*",
-        "Sid": "ECSTaskpermissions"
+      "Action": [
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition",
+          "ecs:ListTaskDefinitions"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "ECSTaskpermissions"
     },
     {
         "Action": [
@@ -409,30 +421,22 @@ resource "aws_iam_policy" "conversiontool_svc_policy" {
 			"Resource": "arn:aws:logs:*:*:*"
 		},
 		{
-			"Sid": "ECRauthorization",
-			"Effect": "Allow",
-			"Action": "ecr:GetAuthorizationToken",
-			"Resource": "*"
-		},
-		{
 			"Sid": "ECRPermissions",
 			"Effect": "Allow",
 			"Action": [
-				"ecr:GetDownloadUrlForLayer",
-				"ecr:BatchGetImage",
-				"ecr:CompleteLayerUpload",
-				"ecr:UploadLayerPart",
-				"ecr:InitiateLayerUpload",
-				"ecr:BatchCheckLayerAvailability",
-				"ecr:PutImage"
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:DescribeRepositories",
+        "ecr:GetRepositoryPolicy",
+        "ecr:ListImages",
+        "ecr:GetAuthorizationToken",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart"
 			],
-			"Resource": [
-				"arn:aws:ecr:us-east-1:${local.account_id}:repository/new-qpp-conversion-tool",
-				"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/dev",
-				"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/devpre",
-				"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/impl",
-				"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/prod"
-			]
+			"Resource": "*"
 		},
 		{
 			"Action": [
@@ -450,6 +454,36 @@ resource "aws_iam_policy" "conversiontool_svc_policy" {
 	]
 })
 }
+		# {
+		# 	"Sid": "ECRauthorization",
+		# 	"Effect": "Allow",
+		# 	"Action": "ecr:GetAuthorizationToken",
+		# 	"Resource": "*"
+		# },
+		# {
+		# 	"Sid": "ECRPermissions",
+		# 	"Effect": "Allow",
+		# 	"Action": [
+    #     "ecr:GetDownloadUrlForLayer",
+    #     "ecr:BatchGetImage",
+    #     "ecr:BatchCheckLayerAvailability",
+    #     "ecr:DescribeRepositories",
+    #     "ecr:GetRepositoryPolicy",
+    #     "ecr:ListImages",
+    #     "ecr:GetAuthorizationToken",
+    #     "ecr:CompleteLayerUpload",
+    #     "ecr:PutImage",
+    #     "ecr:InitiateLayerUpload",
+    #     "ecr:UploadLayerPart"
+		# 	],
+		# 	"Resource": [
+		# 		"arn:aws:ecr:us-east-1:${local.account_id}:repository/new-qpp-conversion-tool",
+		# 		"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/dev",
+		# 		"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/devpre",
+		# 		"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/impl",
+		# 		"arn:aws:ecr:us-east-1:${local.account_id}:repository/qppsf/conversion-tool/prod"
+		# 	]
+		# },
 
 resource "aws_iam_role_policy_attachment" "conversiontool_servicerole_policyattachment" {
   role       = aws_iam_role.conversiontool_codebuild_servicerole.name

--- a/infrastructure/terraform/modules/iam.tf
+++ b/infrastructure/terraform/modules/iam.tf
@@ -353,7 +353,7 @@ resource "aws_iam_policy" "conversiontool_svc_policy" {
           "ecs:ListTaskDefinitions"
       ],
       "Effect": "Allow",
-      "Resource": "*",
+      "Resource": "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task-definition/*",
       "Sid": "ECSTaskpermissions"
     },
     {
@@ -438,7 +438,7 @@ resource "aws_iam_policy" "conversiontool_svc_policy" {
         "ecr:InitiateLayerUpload",
         "ecr:UploadLayerPart"
 			],
-			"Resource": "*"
+			"Resource": "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"
 		},
 		{
 			"Action": [

--- a/infrastructure/terraform/modules/iam.tf
+++ b/infrastructure/terraform/modules/iam.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 locals {
     account_id = data.aws_caller_identity.current.account_id
 }

--- a/infrastructure/terraform/modules/ssm.tf
+++ b/infrastructure/terraform/modules/ssm.tf
@@ -460,7 +460,8 @@ resource "aws_ssm_parameter" "java_opts" {
   name        = "/qppar-sf/${var.environment}/conversion_tool/JAVA_OPTS"
   description = "JAVA_OPTS"
   type        = "SecureString"
-  value       = "-Xms6G -Xmx6G -Xmn5G -XX:+UseStringDeduplication -XX:-AggressiveOpts"
+  ##value       = "-Xms6G -Xmx6G -Xmn5G -XX:+UseStringDeduplication -XX:-AggressiveOpts"
+  value       = "-Xms6G -Xmx6G -Xmn5G -XX:+UseStringDeduplication"
   overwrite   = true
 
   lifecycle {


### PR DESCRIPTION
### Information
- Fixes 
- JIRA story _.

### Changes proposed in this PR:
- Permissions policy alignment in TF Source with deployed DEV resources to allow Codebuild project to run from Github Webhook Event
- SG rule adjustments in TF Source with deployed DEV resources
- the attached plan IS NOT YET APPLIED in DEV (previous work on ECR lifecycle policy implementation, shared account tagging implications).

### Checklist 
- [ ] plan shows only tagging changes and implementation of ECR lifecycle policy
[ct-dev-202404050815.plan.txt](https://github.com/CMSgov/qpp-conversion-tool/files/14884972/ct-dev-202404050815.plan.txt)


