### PR TITLE
QPPSE-314: Added caching for apm entity json files

### DIFF
--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -89,6 +89,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>gov.cms.qpp.conversion</groupId>
 			<artifactId>test-commons</artifactId>
 			<version>${project.version}</version>

--- a/converter/src/test/java/gov/cms/qpp/CacheBuilder.java
+++ b/converter/src/test/java/gov/cms/qpp/CacheBuilder.java
@@ -1,0 +1,35 @@
+package gov.cms.qpp;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import gov.cms.qpp.conversion.model.validation.ApmEntityIds;
+import gov.cms.qpp.model.CacheType;
+
+import java.util.concurrent.TimeUnit;
+
+public class CacheBuilder {
+    private static Cache<CacheType, ApmEntityIds> entityIdsCache;
+
+    CacheBuilder() {}
+
+    public static void buildEntityIdsCache() {
+        entityIdsCache = Caffeine.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .maximumSize(100)
+            .build();
+    }
+
+    public static ApmEntityIds getEntityIds(CacheType value) {
+        if (entityIdsCache == null) buildEntityIdsCache();
+        if (entityIdsCache.getIfPresent(value) == null) {
+            ApmEntityIds entityData = null;
+            switch(value) {
+                case ApmEntityId -> entityData = new ApmEntityIds("test_apm_entity_ids.json");
+                case ApmEntityIds -> entityData = new ApmEntityIds("test_apm_entity_ids.json","test_apm_entity_ids.json");
+                case ApmPcfEntityIds -> entityData = new ApmEntityIds("test_apm_entity_ids.json","test_pcf_apm_entity_ids.json");
+            }
+            entityIdsCache.put(value, entityData);
+        }
+        return entityIdsCache.getIfPresent(value);
+    }
+}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentExtensionTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/ClinicalDocumentExtensionTest.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp.acceptance;
 
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -64,7 +66,7 @@ class ClinicalDocumentExtensionTest {
 	}
 
 	private JsonWrapper convert(Path location) throws IOException {
-		ApmEntityIds apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json", "test_apm_entity_ids.json");
+		ApmEntityIds apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmEntityIds);
 		Converter converter = new Converter(new PathSource(location), new Context(apmEntityIds));
 		return converter.transform();
 	}

--- a/converter/src/test/java/gov/cms/qpp/acceptance/NegativePcfRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/NegativePcfRoundTripTest.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp.acceptance;
 
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +45,7 @@ public class NegativePcfRoundTripTest {
 
 	@BeforeEach
 	void setup() {
-		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json", "test_apm_entity_ids.json");
+		apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmEntityIds);
 	}
 
 	@AfterEach

--- a/converter/src/test/java/gov/cms/qpp/acceptance/Pcf2024AcceptanceTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/Pcf2024AcceptanceTest.java
@@ -19,13 +19,15 @@ import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
 import static gov.cms.qpp.acceptance.Util.getXml;
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 
 public class Pcf2024AcceptanceTest {
     private static final Path BASE = Paths.get("src/test/resources/pcf/acceptance2024");
     private static final Path SUCCESS = BASE.resolve("success");
     private static final Path SUCCESS_WARNING = BASE.resolve("warning");
     private static final Path FAILURE = BASE.resolve("failure");
-    private final ApmEntityIds apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json","test_apm_entity_ids.json");
+    private static final ApmEntityIds apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmEntityIds);
 
     static Stream<Path> successData() {
         return getXml(SUCCESS);

--- a/converter/src/test/java/gov/cms/qpp/acceptance/PcfRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/PcfRoundTripTest.java
@@ -1,6 +1,8 @@
 package gov.cms.qpp.acceptance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -36,7 +38,7 @@ public class PcfRoundTripTest {
 	@SuppressWarnings("unchecked")
 	@BeforeAll
 	static void setup() throws URISyntaxException, IOException {
-		ApmEntityIds apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json", "test_pcf_apm_entity_ids.json");
+		ApmEntityIds apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmPcfEntityIds);
 		URL sample = PcfRoundTripTest.class.getClassLoader()
 			.getResource("pcf/success/PCF_Sample_QRDA-III.xml");
 		Path path = Paths.get(sample.toURI());

--- a/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
+++ b/converter/src/test/java/gov/cms/qpp/acceptance/QualityMeasureIdRoundTripTest.java
@@ -1,6 +1,8 @@
 package gov.cms.qpp.acceptance;
 
 import com.jayway.jsonpath.TypeRef;
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +53,7 @@ class QualityMeasureIdRoundTripTest {
 
 	@BeforeEach
 	void setup() {
-		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json", "test_apm_entity_ids.json");
+		apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmEntityIds);
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.TEST_MEASURE_DATA);
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/conversion/model/validation/ApmEntityIdsTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/model/validation/ApmEntityIdsTest.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp.conversion.model.validation;
 
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,7 @@ class ApmEntityIdsTest {
 
 	@BeforeEach
 	void setUp() {
-		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json");
+		apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmEntityId);
 	}
 
 	@Test

--- a/converter/src/test/java/gov/cms/qpp/conversion/validate/PcfClinicalDocumentValidatorTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/validate/PcfClinicalDocumentValidatorTest.java
@@ -1,5 +1,7 @@
 package gov.cms.qpp.conversion.validate;
 
+import gov.cms.qpp.CacheBuilder;
+import gov.cms.qpp.model.CacheType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +26,7 @@ public class PcfClinicalDocumentValidatorTest {
 
 	@BeforeEach
 	void setUp() {
-		apmEntityIds = new ApmEntityIds("test_apm_entity_ids.json", "test_apm_entity_ids.json");
+		apmEntityIds = CacheBuilder.getEntityIds(CacheType.ApmEntityIds);
 		validator = new PcfClinicalDocumentValidator(new Context(apmEntityIds));
 	}
 

--- a/converter/src/test/java/gov/cms/qpp/model/CacheType.java
+++ b/converter/src/test/java/gov/cms/qpp/model/CacheType.java
@@ -1,0 +1,7 @@
+package gov.cms.qpp.model;
+
+public enum CacheType {
+    ApmEntityId,
+    ApmEntityIds,
+    ApmPcfEntityIds;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,12 @@
 			</dependency>
 
 			<dependency>
+				<groupId>com.github.ben-manes.caffeine</groupId>
+				<artifactId>caffeine</artifactId>
+				<version>3.1.8</version>
+			</dependency>
+
+			<dependency>
 				<groupId>com.google.truth</groupId>
 				<artifactId>truth</artifactId>
 				<version>1.1</version>


### PR DESCRIPTION
### Information
- Added test file caching for apm/pcf entity ids json file.  For the rest of the files, detailed analysis would be needed and a separate ticket will be created.

### Associated JIRA Tickets
- https://jira.cms.gov/browse/QPPSE-314

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
