### PR TITLE
QPPSE-2783: Added fix for the null TIN root id issue

### DIFF
--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
@@ -80,19 +80,6 @@ public class SpecPiiValidator implements PiiValidator {
 				for(final Map.Entry<String, List<String>> currentEntry: tinNpisMap.entrySet()) {
 					for (final String currentNpi : currentEntry.getValue()) {
 						checkTinNpiCombinations(node, validator, apm, currentEntry, tinNpiCombinations, currentNpi);
-//						boolean combinationExists = false;
-//						for (TinNpiCombination currentCombination : tinNpiCombinations) {	//NOSONAR
-//							if (currentEntry.getKey().equalsIgnoreCase((currentCombination.getTin())) &&	//NOSONAR
-//								currentNpi.equalsIgnoreCase(currentCombination.getNpi())) {
-//								combinationExists = true;
-//								break;
-//							}
-//						}
-//						if (!combinationExists) {	//NOSONAR
-//							LocalizedProblem error = ProblemCode.PCF_MISSING_COMBINATION
-//								.format(currentNpi, getMaskedTin(currentEntry.getKey()), apm);
-//							validator.addWarning(Detail.forProblemAndNode(error, node));
-//						}
 					}
 				}
 			}

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
@@ -79,22 +79,39 @@ public class SpecPiiValidator implements PiiValidator {
 			if (tinNpisMap != null) {
 				for(final Map.Entry<String, List<String>> currentEntry: tinNpisMap.entrySet()) {
 					for (final String currentNpi : currentEntry.getValue()) {
-						boolean combinationExists = false;
-						for (TinNpiCombination currentCombination : tinNpiCombinations) {	//NOSONAR
-							if (currentEntry.getKey().equalsIgnoreCase((currentCombination.getTin())) &&	//NOSONAR
-								currentNpi.equalsIgnoreCase(currentCombination.getNpi())) {
-								combinationExists = true;
-								break;
-							}
-						}
-						if (!combinationExists) {	//NOSONAR
-							LocalizedProblem error = ProblemCode.PCF_MISSING_COMBINATION
-								.format(currentNpi, getMaskedTin(currentEntry.getKey()), apm);
-							validator.addWarning(Detail.forProblemAndNode(error, node));
-						}
+						checkTinNpiCombinations(node, validator, apm, currentEntry, tinNpiCombinations, currentNpi);
+//						boolean combinationExists = false;
+//						for (TinNpiCombination currentCombination : tinNpiCombinations) {	//NOSONAR
+//							if (currentEntry.getKey().equalsIgnoreCase((currentCombination.getTin())) &&	//NOSONAR
+//								currentNpi.equalsIgnoreCase(currentCombination.getNpi())) {
+//								combinationExists = true;
+//								break;
+//							}
+//						}
+//						if (!combinationExists) {	//NOSONAR
+//							LocalizedProblem error = ProblemCode.PCF_MISSING_COMBINATION
+//								.format(currentNpi, getMaskedTin(currentEntry.getKey()), apm);
+//							validator.addWarning(Detail.forProblemAndNode(error, node));
+//						}
 					}
 				}
 			}
+		}
+	}
+
+	private void checkTinNpiCombinations(Node node, NodeValidator validator, String apm, Map.Entry<String, List<String>> currentEntry, List<TinNpiCombination> tinNpiCombinations, String currentNpi) {
+		boolean combinationExists = false;
+		for (TinNpiCombination currentCombination : tinNpiCombinations) {
+			if (currentEntry.getKey().equalsIgnoreCase((currentCombination.getTin())) &&
+					currentNpi.equalsIgnoreCase(currentCombination.getNpi())) {
+				combinationExists = true;
+				break;
+			}
+		}
+		if (!combinationExists) {
+			LocalizedProblem error = ProblemCode.PCF_MISSING_COMBINATION
+					.format(currentNpi, getMaskedTin(currentEntry.getKey()), apm);
+			validator.addWarning(Detail.forProblemAndNode(error, node));
 		}
 	}
 

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
@@ -69,6 +69,8 @@ public class SpecPiiValidator implements PiiValidator {
 
 		List<TinNpiCombination> tinNpiCombinations = createTinNpiMap(tinList, npiList);
 
+		// Adding some sonar exclusions, to avoid cognitive complexity.
+		// The conditions here would probably need to be checked in the specific order
 		Map<String, Map<String, List<String>>> apmToTinNpiMap = file.getApmTinNpiCombinationMap();
 		if (apmToTinNpiMap == null || StringUtils.isEmpty(apm)) {
 			validator.addWarning(Detail.forProblemAndNode(ProblemCode.MISSING_API_TIN_NPI_FILE, node));
@@ -78,14 +80,14 @@ public class SpecPiiValidator implements PiiValidator {
 				for(final Map.Entry<String, List<String>> currentEntry: tinNpisMap.entrySet()) {
 					for (final String currentNpi : currentEntry.getValue()) {
 						boolean combinationExists = false;
-						for (TinNpiCombination currentCombination : tinNpiCombinations) {
-							if (currentEntry.getKey().equalsIgnoreCase((currentCombination.getTin())) &&
+						for (TinNpiCombination currentCombination : tinNpiCombinations) {	//NOSONAR
+							if (currentEntry.getKey().equalsIgnoreCase((currentCombination.getTin())) &&	//NOSONAR
 								currentNpi.equalsIgnoreCase(currentCombination.getNpi())) {
 								combinationExists = true;
 								break;
 							}
 						}
-						if (!combinationExists) {
+						if (!combinationExists) {	//NOSONAR
 							LocalizedProblem error = ProblemCode.PCF_MISSING_COMBINATION
 								.format(currentNpi, getMaskedTin(currentEntry.getKey()), apm);
 							validator.addWarning(Detail.forProblemAndNode(error, node));

--- a/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
+++ b/rest-api/src/main/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidator.java
@@ -28,17 +28,21 @@ public class SpecPiiValidator implements PiiValidator {
 
 	@Override
 	public void validateApmTinNpiCombination(Node node, NodeValidator validator) {
-		validateInvalidApmCombinations(node, validator);
-		validateMissingApmCombinations(node, validator);
+		List<String> npiList = Arrays.asList(
+				node.getValue(NATIONAL_PROVIDER_IDENTIFIER).split(","));
+		List<String> tinList = Arrays.asList(
+				node.getValue(TAX_PAYER_IDENTIFICATION_NUMBER).split(","));
+		if (npiList.size() != tinList.size()) {
+			validator.addError(Detail.forProblemAndNode(ProblemCode.INCORRECT_API_NPI_COMBINATION, node));
+		} else {
+			validateInvalidApmCombinations(node, validator, npiList, tinList);
+			validateMissingApmCombinations(node, validator, npiList, tinList);
+		}
 	}
 
-	private void validateInvalidApmCombinations(Node node, NodeValidator validator) {
+	private void validateInvalidApmCombinations(Node node, NodeValidator validator, List<String> npiList, List<String> tinList) {
 		String program = node.getValue(PROGRAM_NAME);
 		String apm = getApmEntityId(node, program);
-		List<String> npiList = Arrays.asList(
-			node.getValue(NATIONAL_PROVIDER_IDENTIFIER).split(","));
-		List<String> tinList = Arrays.asList(
-			node.getValue(TAX_PAYER_IDENTIFICATION_NUMBER).split(","));
 
 		Map<String, Map<String, List<String>>> apmToTinNpiMap = file.getApmTinNpiCombinationMap();
 		if (apmToTinNpiMap == null || StringUtils.isEmpty(apm)) {
@@ -59,13 +63,9 @@ public class SpecPiiValidator implements PiiValidator {
 		}
 	}
 
-	private void validateMissingApmCombinations(Node node, NodeValidator validator) {
+	private void validateMissingApmCombinations(Node node, NodeValidator validator, List<String> npiList, List<String> tinList) {
 		String program = node.getValue(PROGRAM_NAME);
 		String apm = getApmEntityId(node, program);
-		List<String> npiList = Arrays.asList(
-			node.getValue(NATIONAL_PROVIDER_IDENTIFIER).split(","));
-		List<String> tinList = Arrays.asList(
-			node.getValue(TAX_PAYER_IDENTIFICATION_NUMBER).split(","));
 
 		List<TinNpiCombination> tinNpiCombinations = createTinNpiMap(tinList, npiList);
 

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
@@ -117,7 +117,8 @@ public class SpecPiiValidatorTest {
 		System.out.println(node);
 		NodeValidator nodeValidator = new NodeValidator() {
 			@Override
-			protected void performValidation(Node node) {	//NOSONAR
+			protected void performValidation(Node node) {
+				// Empty Function.  Just adding a comment to avoid sonar flag.
 			}
 		};
 		validator.validateApmTinNpiCombination(node, nodeValidator);

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
@@ -117,7 +117,7 @@ public class SpecPiiValidatorTest {
 		System.out.println(node);
 		NodeValidator nodeValidator = new NodeValidator() {
 			@Override
-			protected void performValidation(Node node) {
+			protected void performValidation(Node node) {	//NOSONAR
 			}
 		};
 		validator.validateApmTinNpiCombination(node, nodeValidator);

--- a/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
+++ b/rest-api/src/test/java/gov/cms/qpp/conversion/api/internal/pii/SpecPiiValidatorTest.java
@@ -110,6 +110,20 @@ public class SpecPiiValidatorTest {
 		Truth.assertThat(nodeValidator.viewWarnings().get(0).getErrorCode()).isEqualTo(108);
 	}
 
+	@Test
+	void testNpiTinSizeMismatch() throws Exception {
+		SpecPiiValidator validator = validator("DogCow_APM", "DogCow_NPI");
+		Node node = node("Invalid_Apm", "DogCow_NPI,DogCow_NPI2", "DogCow", PCF_PROGRAM_NAME);
+		System.out.println(node);
+		NodeValidator nodeValidator = new NodeValidator() {
+			@Override
+			protected void performValidation(Node node) {
+			}
+		};
+		validator.validateApmTinNpiCombination(node, nodeValidator);
+		Truth.assertThat(nodeValidator.viewWarnings().get(0).getErrorCode()).isEqualTo(80);
+	}
+
 	private SpecPiiValidator validator(String apm, String npi) throws Exception {
 		return new SpecPiiValidator(createSpecFile(apm, npi));
 	}


### PR DESCRIPTION
### Information
- When root id for TIN value is null, CT returns unexpected error.  Fixed to return valid error message.

### Checklist 
- [ ] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
