### PR TITLE
QPPA-10640: Improve maven binary download command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17 AS builder
 ARG MAVEN_VERSION=3.9.6
 ARG USER_HOME_DIR="/root"
 ARG SHA=706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224
-ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && for i in 1 2 3; do \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ ARG SHA=706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b50
 ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && for i in 1 2 3; do \
+      echo "Attempt $i to download Maven..." && \
+      curl -fsSL --connect-timeout 300 --max-time 600 -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz && break || \
+      (echo "Download failed, attempt $i of 3" && sleep 10); \
+     done \
   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \


### PR DESCRIPTION
### Information
- JIRA story https://jira.cms.gov/browse/QPPA-10640

### Changes proposed in this PR:
- improve maven binary download curl command with increased timeout limit and retry logic

### Checklist 
- [x] All JUnit tests pass (`mvn clean verify`).
- [ ] New unit tests written to cover new functionality.
- [ ] Added and updated JavaDocs for non-test classes and methods.
- [ ] No local design debt. Do you feel that something is "ugly" after your changes?
- [ ] Updated documentation (`README.md`, etc.) depending if the changes require it.
