### PR TITLE
Deploy Release version v2026.03.13.01 to Prod

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 	<artifactId>acceptance-tests</artifactId>
 	<groupId>gov.cms.qpp.conversion</groupId>
-	<version>2026.02.27.01-RELEASE</version>
+	<version>2026.03.13.01-RELEASE</version>
 	<name>conversion-tests</name>
 	<packaging>jar</packaging>
 	<properties>

--- a/commandline/pom.xml
+++ b/commandline/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>gov.cms.qpp.conversion</groupId>
 		<artifactId>qpp-conversion-tool-parent</artifactId>
-		<version>2026.02.27.01-RELEASE</version>
+		<version>2026.03.13.01-RELEASE</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>gov.cms.qpp.conversion</groupId>
 		<artifactId>qpp-conversion-tool-parent</artifactId>
-		<version>2026.02.27.01-RELEASE</version>
+		<version>2026.03.13.01-RELEASE</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>gov.cms.qpp.conversion</groupId>
 		<artifactId>qpp-conversion-tool-parent</artifactId>
-		<version>2026.02.27.01-RELEASE</version>
+		<version>2026.03.13.01-RELEASE</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -185,7 +185,7 @@
 		<dependency>
 			<groupId>gov.cms.qpp.conversion</groupId>
 			<artifactId>commons</artifactId>
-			<version>2026.02.27.01-RELEASE</version>
+			<version>2026.03.13.01-RELEASE</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/generate-race-cpcplus/pom.xml
+++ b/generate-race-cpcplus/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>gov.cms.qpp.conversion</groupId>
 	<artifactId>generateRaceCpcPlus</artifactId>
-	<version>2026.02.27.01-RELEASE</version>
+	<version>2026.03.13.01-RELEASE</version>
 	<name>generate-race-cpcplus</name>
 	<packaging>jar</packaging>
 

--- a/generate/pom.xml
+++ b/generate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>qpp-conversion-tool-parent</artifactId>
 		<groupId>gov.cms.qpp.conversion</groupId>
-		<version>2026.02.27.01-RELEASE</version>
+		<version>2026.03.13.01-RELEASE</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -237,25 +237,25 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.17.3</version>
+				<version>2.18.2</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.17.3</version>
+				<version>2.18.2</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.17.3</version>
+				<version>2.18.2</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.dataformat</groupId>
 				<artifactId>jackson-dataformat-xml</artifactId>
-				<version>2.17.3</version>
+				<version>2.18.2</version>
 			</dependency>
 
 			<dependency>
@@ -515,7 +515,23 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.module</groupId>
 				<artifactId>jackson-module-jaxb-annotations</artifactId>
-				<version>2.17.3</version>
+				<version>2.18.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-core</artifactId>
+				<version>10.1.52</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-el</artifactId>
+				<version>10.1.52</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-websocket</artifactId>
+				<version>10.1.52</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,25 +237,25 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.18.2</version>
+				<version>2.18.6</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.18.2</version>
+				<version>2.18.6</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.18.2</version>
+				<version>2.18.6</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.dataformat</groupId>
 				<artifactId>jackson-dataformat-xml</artifactId>
-				<version>2.18.2</version>
+				<version>2.18.6</version>
 			</dependency>
 
 			<dependency>
@@ -515,7 +515,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.module</groupId>
 				<artifactId>jackson-module-jaxb-annotations</artifactId>
-				<version>2.18.2</version>
+				<version>2.18.6</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>gov.cms.qpp.conversion</groupId>
 	<artifactId>qpp-conversion-tool-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2026.02.27.01-RELEASE</version>
+	<version>2026.03.13.01-RELEASE</version>
 	<name>QPP Conversion Tool</name>
 
 	<properties>

--- a/qrda3-update-measures/pom.xml
+++ b/qrda3-update-measures/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>gov.cms.qpp.conversion</groupId>
 	<artifactId>qpp-update-measures</artifactId>
-	<version>2026.02.27.01-RELEASE</version>
+	<version>2026.03.13.01-RELEASE</version>
 	<name>qrda3-update-measures</name>
 	<packaging>jar</packaging>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- For documentation only; actual coordination is done by the BOMs below -->
         <spring-framework.version>6.2.12</spring-framework.version>
-        <tomcat.version>10.1.45</tomcat.version>
+        <tomcat.version>10.1.52</tomcat.version>
 
         <!-- Test stack kept explicit so CI is deterministic across JDK updates -->
         <junit.jupiter.version>5.10.3</junit.jupiter.version>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>gov.cms.qpp.conversion</groupId>
         <artifactId>qpp-conversion-tool-parent</artifactId>
-        <version>2026.02.27.01-RELEASE</version>
+        <version>2026.03.13.01-RELEASE</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-commons/pom.xml
+++ b/test-commons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>gov.cms.qpp.conversion</groupId>
 		<artifactId>qpp-conversion-tool-parent</artifactId>
-		<version>2026.02.27.01-RELEASE</version>
+		<version>2026.03.13.01-RELEASE</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>gov.cms.qpp.conversion</groupId>
 		<artifactId>qpp-conversion-tool-parent</artifactId>
-		<version>2026.02.27.01-RELEASE</version>
+		<version>2026.03.13.01-RELEASE</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Hi @chetanmunegowda!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/CMSgov/qpp-conversion-tool/actions/runs/23056480831.
The changelog was updated and the version was bumped in the manifest files in this commit: 2ed7d02808aa06eab8e514439d6367366641e7f9.

Merging this PR will create a GitHub release.