### PR TITLE
QPPA-11633: Update the Dockerfile and DockerfileTest to use Alpine-based Maven and Eclipse Temurin Java 21 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ RUN mvn -B -ntp \
 # -----------------------------
 # Final runtime stage
 # -----------------------------
-# Uses a smaller Alpine-based Java 21 JRE image for runtime.
-# This helps reduce image size and avoids the Ubuntu OS package vulnerabilities reported by Snyk.
+# Uses a pinned Alpine-based Java 21 JRE image.
+# This avoids the Ubuntu-based OS package vulnerabilities reported by Snyk
+# while keeping the runtime image smaller and more reproducible.
 FROM eclipse-temurin:21.0.10_7-jre-alpine-3.23
 
 # Set the directory where the application will run.
@@ -51,14 +52,23 @@ WORKDIR /usr/src/run/
 # Copy only the runtime artifacts from the builder stage.
 # This keeps Maven, source code, and build dependencies out of the final image.
 COPY --from=builder /usr/src/app/tools/docker/docker-artifacts /usr/src/run/
-COPY --from=builder /usr/src/app/rest-api/target/rest-api.jar /usr/src/run/
+COPY --from=builder /usr/src/app/rest-api/target/rest-api.jar /usr/src/run/rest-api.jar
 
-# Patch Alpine packages and make the startup script executable.
-# Bash is installed only when qppConverter.sh explicitly uses a bash shebang.
-# This keeps the runtime image minimal while still supporting scripts that require /bin/bash.
-RUN apk upgrade --no-cache \
-    && if head -n 1 /usr/src/run/qppConverter.sh | grep -q "bash"; then apk add --no-cache bash; fi \
-    && chmod +x /usr/src/run/qppConverter.sh
+# Prepare the startup script for the Alpine runtime.
+# 1. Remove Windows CRLF line endings if present.
+# 2. Replace a bash shebang with sh because Alpine includes /bin/sh by default,
+#    but does not include /bin/bash unless bash is installed separately.
+# 3. Make the script executable.
+# 4. Validate that the required runtime files exist during image build.
+#
+# We intentionally do not run "apk upgrade" here.
+# The runtime image is pinned, so OS package versions come from the selected base image.
+# This keeps builds more reproducible and avoids transient failures from Alpine package repos.
+RUN sed -i 's/\r$//' /usr/src/run/qppConverter.sh \
+    && sed -i '1s|^#!/bin/bash|#!/bin/sh|' /usr/src/run/qppConverter.sh \
+    && chmod +x /usr/src/run/qppConverter.sh \
+    && test -f /usr/src/run/rest-api.jar \
+    && test -f /usr/src/run/qppConverter.sh
 
 # Application listens on 8443.
 EXPOSE 8443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,20 @@
-FROM eclipse-temurin:21 AS builder
+# -----------------------------
+# Builder stage
+# -----------------------------
+# Uses the official Maven image with Eclipse Temurin Java 21 on Alpine.
+# This stage is only used to compile/package the application.
+# Maven and build tools stay in this stage and are not included in the final runtime image.
+FROM maven:3.9.15-eclipse-temurin-21-alpine AS builder
 
-ARG MAVEN_VERSION=3.9.6
-ARG USER_HOME_DIR="/root"
-ARG SHA=706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224
-ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
+# Set the application source directory inside the container.
+WORKDIR /usr/src/app
 
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && for i in 1 2 3; do \
-      echo "Attempt $i to download Maven..." && \
-      curl -fsSL --connect-timeout 300 --max-time 600 -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz && break || \
-      (echo "Download failed, attempt $i of 3" && sleep 10); \
-     done \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+# Copy custom Maven settings.
+# This is useful if the build depends on internal repositories, mirrors, credentials, or proxy config.
+COPY settings-docker.xml /usr/share/maven/ref/settings-docker.xml
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
-
-# Copy src files needed for build
+# Copy only the source files/modules needed for the Maven build.
+# Keeping this explicit avoids copying unnecessary files into the build context.
 COPY pom.xml /usr/src/app/
 COPY commons/ /usr/src/app/commons/
 COPY test-commons/ /usr/src/app/test-commons/
@@ -32,18 +24,44 @@ COPY rest-api/ /usr/src/app/rest-api/
 COPY generate/ /usr/src/app/generate/
 COPY test-coverage/ /usr/src/app/test-coverage/
 COPY tools/docker/docker-artifacts/ /usr/src/app/tools/docker/docker-artifacts/
-WORKDIR /usr/src/app/
 
-RUN /usr/local/bin/mvn-entrypoint.sh mvn install -Dmaven.test.skip -Djacoco.skip=true -Dskip.generate=true > /dev/null
+# Build the application.
+# -B runs Maven in batch mode for CI/CD.
+# -ntp disables Maven transfer progress logs.
+# -s uses the custom Maven settings file copied above.
+# Tests, JaCoCo, and generate steps are skipped because this Docker build only packages the runtime artifact.
+RUN mvn -B -ntp \
+    -s /usr/share/maven/ref/settings-docker.xml \
+    clean install \
+    -Dmaven.test.skip=true \
+    -Djacoco.skip=true \
+    -Dskip.generate=true > /dev/null
 
-# Final stage
-FROM eclipse-temurin:21-jre
 
-RUN mkdir -p /usr/src/run/
+# -----------------------------
+# Final runtime stage
+# -----------------------------
+# Uses a smaller Alpine-based Java 21 JRE image for runtime.
+# This helps reduce image size and avoids the Ubuntu OS package vulnerabilities reported by Snyk.
+FROM eclipse-temurin:21.0.10_7-jre-alpine-3.23
+
+# Set the directory where the application will run.
+WORKDIR /usr/src/run/
+
+# Copy only the runtime artifacts from the builder stage.
+# This keeps Maven, source code, and build dependencies out of the final image.
 COPY --from=builder /usr/src/app/tools/docker/docker-artifacts /usr/src/run/
 COPY --from=builder /usr/src/app/rest-api/target/rest-api.jar /usr/src/run/
 
-WORKDIR /usr/src/run/
+# Patch Alpine packages and make the startup script executable.
+# Bash is installed only when qppConverter.sh explicitly uses a bash shebang.
+# This keeps the runtime image minimal while still supporting scripts that require /bin/bash.
+RUN apk upgrade --no-cache \
+    && if head -n 1 /usr/src/run/qppConverter.sh | grep -q "bash"; then apk add --no-cache bash; fi \
+    && chmod +x /usr/src/run/qppConverter.sh
 
+# Application listens on 8443.
 EXPOSE 8443
+
+# Start the application using the existing startup script.
 CMD ["/usr/src/run/qppConverter.sh"]

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -3,7 +3,7 @@
 # -----------------------------
 # Uses Maven with Eclipse Temurin Java 21 on Alpine.
 # This stage builds the application jar only.
-FROM maven:3.9.6-eclipse-temurin-21-alpine AS builder
+FROM maven:3.9.15-eclipse-temurin-21-alpine AS builder
 
 # Copy the full project into the build container.
 COPY ./ /usr/src/app/
@@ -17,7 +17,8 @@ WORKDIR /usr/src/app/
 # Tests and JaCoCo are skipped because this image only needs the built runtime jar.
 RUN mvn -B -ntp install \
     -Dmaven.test.skip=true \
-    -Djacoco.skip=true > /dev/null
+    -Djacoco.skip=true \
+    -Dskip.generate=true > /dev/null
 
 
 # -----------------------------

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -1,21 +1,55 @@
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
+# -----------------------------
+# Builder stage
+# -----------------------------
+# Uses Maven with Eclipse Temurin Java 21 on Alpine.
+# This stage builds the application jar only.
+FROM maven:3.9.6-eclipse-temurin-21-alpine AS builder
 
+# Copy the full project into the build container.
 COPY ./ /usr/src/app/
+
+# Set project directory.
 WORKDIR /usr/src/app/
 
-RUN mvn install -Dmaven.test.skip -Djacoco.skip=true > /dev/null
+# Build the project and create the application jar.
+# -B = batch mode, useful for CI
+# -ntp = no transfer progress, cleaner logs
+# Tests and JaCoCo are skipped because this image only needs the built runtime jar.
+RUN mvn -B -ntp install \
+    -Dmaven.test.skip=true \
+    -Djacoco.skip=true > /dev/null
 
-# Final stage
-FROM eclipse-temurin:21-jre
 
-RUN apt-get update && apt-get install -y dos2unix && rm -rf /var/lib/apt/lists/*
+# -----------------------------
+# Final runtime stage
+# -----------------------------
+# Uses a smaller Alpine-based Eclipse Temurin Java 21 JRE image.
+# This avoids the Ubuntu-based OS package vulnerabilities reported by Snyk.
+FROM eclipse-temurin:21.0.10_7-jre-alpine-3.23
 
-RUN mkdir -p /usr/src/run/
-COPY --from=builder /usr/src/app/rest-api/target/rest-api.jar /usr/src/run/
-COPY --from=builder /usr/src/app/tools/docker/docker-test-artifacts/* /usr/src/run/
-RUN dos2unix /usr/src/run/qppConverterTest.sh
-
+# Set the runtime directory.
 WORKDIR /usr/src/run/
 
+# Copy only the built jar from the builder stage.
+# This keeps Maven, source code, and build dependencies out of the final image.
+COPY --from=builder /usr/src/app/rest-api/target/rest-api.jar /usr/src/run/rest-api.jar
+
+# Copy test runtime artifacts, including qppConverterTest.sh.
+COPY --from=builder /usr/src/app/tools/docker/docker-test-artifacts/ /usr/src/run/
+
+# Fix the startup script for Alpine runtime:
+# 1. Remove Windows CRLF line endings if present.
+# 2. Replace #!/bin/bash with #!/bin/sh because Alpine does not include bash by default.
+# 3. Make the script executable.
+# 4. Validate that the jar and startup script exist during image build.
+RUN sed -i 's/\r$//' /usr/src/run/qppConverterTest.sh \
+    && sed -i '1s|^#!/bin/bash|#!/bin/sh|' /usr/src/run/qppConverterTest.sh \
+    && chmod +x /usr/src/run/qppConverterTest.sh \
+    && test -f /usr/src/run/rest-api.jar \
+    && test -f /usr/src/run/qppConverterTest.sh
+
+# Application test container listens on 8080.
 EXPOSE 8080
+
+# Start the test application using the startup script.
 ENTRYPOINT ["/usr/src/run/qppConverterTest.sh"]

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.2.17</version>
+            <version>6.2.18</version>
         </dependency>
 
         <dependency>

--- a/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
+++ b/converter/src/test/java/gov/cms/qpp/conversion/encode/QualityMeasureIdEncoderTest.java
@@ -3,6 +3,7 @@ package gov.cms.qpp.conversion.encode;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.jayway.jsonpath.TypeRef;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,11 @@ class QualityMeasureIdEncoderTest {
 		wrapper = new JsonWrapper();
 
 		MeasureConfigs.initMeasureConfigs(MeasureConfigs.TEST_MEASURE_DATA);
+	}
+
+	@AfterEach
+	void tearDown() {
+		MeasureConfigs.initMeasureConfigs(MeasureConfigs.DEFAULT_MEASURE_DATA_FILE_NAME);
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -517,19 +517,19 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-webmvc</artifactId>
-				<version>6.2.17</version>
+				<version>6.2.18</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-web</artifactId>
-				<version>6.2.17</version>
+				<version>6.2.18</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-framework-bom</artifactId>
-				<version>6.2.17</version>
+				<version>6.2.18</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -32,7 +32,7 @@
         <requiredCodeCoverage>0.90</requiredCodeCoverage>
 
         <!-- For documentation only; actual coordination is done by the BOMs below -->
-        <spring-framework.version>6.2.17</spring-framework.version>
+        <spring-framework.version>6.2.18</spring-framework.version>
         <!-- tomcat.version is managed by spring-boot-dependencies BOM (3.5.13+) -->
         <tomcat.version>managed-by-boot-bom</tomcat.version>
         <!-- Test stack kept explicit so CI is deterministic across JDK updates -->
@@ -197,19 +197,19 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>6.2.17</version>
+                <version>6.2.18</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-beans</artifactId>
-                <version>6.2.17</version>
+                <version>6.2.18</version>
             </dependency>
 
-            <!-- Framework BOM import: lifts ALL spring-* modules to 6.2.17 (security fix) -->
+            <!-- Framework BOM import: lifts ALL spring-* modules to 6.2.18 (security fix) -->
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>6.2.17</version>
+                <version>6.2.18</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-11633
https://jira.cms.gov/browse/QPPA-11634


---

## Description
- The builder stage uses Maven to compile/package the app.
- The final runtime stage contains only the Java 21 JRE, startup script, and built application jar.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed
